### PR TITLE
fix: BaseEntity abstract class 및 LocalDateTime 적용

### DIFF
--- a/service-common/src/main/java/com/danburn/common/domain/BaseEntity.java
+++ b/service-common/src/main/java/com/danburn/common/domain/BaseEntity.java
@@ -1,6 +1,6 @@
 package com.danburn.common.domain;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
@@ -15,16 +15,16 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
-    private Instant createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at")
-    private Instant updatedAt;
+    private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")
-    private Instant deletedAt;
+    private LocalDateTime deletedAt;
 }


### PR DESCRIPTION
## Summary
- BaseEntity를 `abstract class`로 변경 (직접 인스턴스 생성 방지)
- `Instant` → `LocalDateTime` 변경 (시간대 변환 없이 바로 사용 가능)

## 작업 내용
- `public class` → `public abstract class`
- `Instant` → `LocalDateTime` (createdAt, updatedAt, deletedAt)

relates #11