### PR TITLE
feat: 전체 서비스 Swagger UI 통합 설정

### DIFF
--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
 
     compileOnly 'org.projectlombok:lombok'

--- a/service-gateway/build.gradle
+++ b/service-gateway/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
 

--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
         - id: map-route
           uri: ${MAP_SERVICE_URL:http://localhost:8083}
           predicates:
-            - Path=/api/map/**,/swagger-ui/**,/v3/api-docs/**
+            - Path=/api/map/**
         # 교통 & 버스 서비스
         - id: transport-route
           uri: ${TRANSPORT_SERVICE_URL:http://localhost:8084}
@@ -28,6 +28,35 @@ spring:
           uri: ${AI_SERVICE_URL:http://localhost:8085}
           predicates:
             - Path=/api/ai/**
+        # Swagger API Docs 라우트
+        - id: congestion-api-docs
+          uri: ${CONGESTION_SERVICE_URL:http://localhost:8082}
+          predicates:
+            - Path=/v3/api-docs/congestion
+          filters:
+            - RewritePath=/v3/api-docs/congestion, /v3/api-docs
+        - id: map-api-docs
+          uri: ${MAP_SERVICE_URL:http://localhost:8083}
+          predicates:
+            - Path=/v3/api-docs/map
+          filters:
+            - RewritePath=/v3/api-docs/map, /v3/api-docs
+        - id: transport-api-docs
+          uri: ${TRANSPORT_SERVICE_URL:http://localhost:8084}
+          predicates:
+            - Path=/v3/api-docs/transport
+          filters:
+            - RewritePath=/v3/api-docs/transport, /v3/api-docs
+
+springdoc:
+  swagger-ui:
+    urls:
+      - name: 혼잡도 분석 서비스
+        url: /v3/api-docs/congestion
+      - name: 지도 & 대체지 추천 서비스
+        url: /v3/api-docs/map
+      - name: 교통 & 버스 서비스
+        url: /v3/api-docs/transport
 
 server:
   port: 8080

--- a/service-map/build.gradle
+++ b/service-map/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/service-transport/build.gradle
+++ b/service-transport/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
 
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
- service-map, service-congestion, service-transport에 `springdoc-openapi-starter-webmvc-ui` 의존성 추가
- service-gateway에 `springdoc-openapi-starter-webflux-ui` 추가 및 각 서비스 API docs 라우트 설정
- 게이트웨이 Swagger UI(`http://<IP>:8080/swagger-ui.html`)에서 드롭다운으로 전체 서비스 API 문서 확인 가능

## Test plan
- [ ] 게이트웨이 빌드 후 `http://<IP>:8080/swagger-ui.html` 접속 확인
- [ ] 드롭다운에서 혼잡도/지도/교통 서비스 선택 시 각 API docs 정상 로딩 확인
- [ ] 각 서비스 직접 접속(`:<port>/swagger-ui/index.html`)도 정상 동작 확인

closes #26