### PR TITLE
feat: GitHub Actions CD 파이프라인 구축 (#28)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,72 @@
+name: CD - Deploy to Server
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  # ── 서비스별 Docker 이미지 빌드 & 푸시 ─────────────────────────────────────
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - service: service-gateway
+            context: .
+            dockerfile: service-gateway/Dockerfile
+          - service: service-map
+            context: .
+            dockerfile: service-map/Dockerfile
+          - service: service-congestion
+            context: .
+            dockerfile: service-congestion/Dockerfile
+          - service: service-transport
+            context: .
+            dockerfile: service-transport/Dockerfile
+          - service: service-ai
+            context: ./service-ai
+            dockerfile: ./service-ai/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-${{ matrix.service }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
+
+  # ── 서버 배포 ──────────────────────────────────────────────────────────────
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Deploy to Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ubuntu
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            cd ~/Backend
+            git pull origin main
+            sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+            sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+            sudo docker image prune -f

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,20 @@
+# docker-compose.yml 위에 덮어쓰는 프로덕션 오버라이드
+# 사용법: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# DOCKERHUB_USERNAME 환경변수 필요 (서버 ~/.bashrc 등에 export)
+
+services:
+  service-congestion:
+    image: ${DOCKERHUB_USERNAME}/danburn-service-congestion:latest
+
+  service-map:
+    image: ${DOCKERHUB_USERNAME}/danburn-service-map:latest
+
+  service-transport:
+    image: ${DOCKERHUB_USERNAME}/danburn-service-transport:latest
+
+  service-ai:
+    image: ${DOCKERHUB_USERNAME}/danburn-service-ai:latest
+
+  service-gateway:
+    image: ${DOCKERHUB_USERNAME}/danburn-service-gateway:latest


### PR DESCRIPTION
## Summary
- main 브랜치 푸시 시 자동 배포되는 CD 워크플로우 추가
- 서비스별 Docker 이미지 빌드 → Docker Hub 푸시 → SSH 서버 배포
- 프로덕션용 `docker-compose.prod.yml` 오버라이드 파일 추가

## 필요 사전 설정
- GitHub Secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `SERVER_HOST`, `SERVER_SSH_KEY`
- 서버 환경변수: `export DOCKERHUB_USERNAME=<아이디>`

## Test plan
- [ ] GitHub Secrets 등록 후 main 머지 시 Actions 정상 실행 확인
- [ ] Docker Hub에 이미지 푸시 확인
- [ ] 서버에서 이미지 pull 및 컨테이너 재시작 확인

closes #28