### PR TITLE
fix: CD 배포 방식 Self-hosted Runner로 변경 (#28)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  # ── 서비스별 Docker 이미지 빌드 & 푸시 ─────────────────────────────────────
+  # ── Docker 이미지 빌드 & 푸시 (GitHub-hosted) ─────────────────────────────
   build-and-push:
     runs-on: ubuntu-latest
 
@@ -52,21 +52,22 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
-  # ── 서버 배포 ──────────────────────────────────────────────────────────────
+  # ── 서버 배포 (Self-hosted Runner) ─────────────────────────────────────────
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build-and-push
 
     steps:
-      - name: Deploy to Server
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: ubuntu
-          key: ${{ secrets.SERVER_SSH_KEY }}
-          script: |
-            cd ~/Backend
-            git pull origin main
-            sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
-            sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
-            sudo docker image prune -f
+      - name: Pull latest code
+        run: |
+          cd ~/Backend
+          git pull origin main
+
+      - name: Pull and restart containers
+        run: |
+          cd ~/Backend
+          sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+          sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+      - name: Clean up old images
+        run: sudo docker image prune -f


### PR DESCRIPTION
## Summary
- CD deploy job을 SSH 방식에서 Self-hosted Runner 방식으로 변경
- `SERVER_HOST`, `SERVER_SSH_KEY` Secrets 불필요

## Test plan
- [ ] Self-hosted Runner 서비스 등록 확인
- [ ] main 머지 시 deploy job이 self-hosted에서 실행되는지 확인

closes #28