### PR TITLE
hotfix: CD deploy docker-compose V1 호환 (#33)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,8 +95,8 @@ jobs:
       - name: Pull and restart containers
         run: |
           cd ~/Backend
-          sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
-          sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+          sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml pull
+          sudo docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
       - name: Clean up old images
         run: sudo docker image prune -f


### PR DESCRIPTION
## Summary
- CD deploy 스텝에서 `docker compose` → `docker-compose`로 변경
- 서버에 Docker Compose V1만 설치되어 있어 `-f` 플래그 인식 실패 수정

## Test plan
- [ ] main 머지 후 CD deploy 스텝 정상 실행 확인

closes #33