### PR TITLE
hotfix: CD deploy DOCKERHUB_USERNAME 환경변수 전달 (#35)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,10 +93,12 @@ jobs:
           git pull origin main
 
       - name: Pull and restart containers
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
           cd ~/Backend
-          sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
-          sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+          sudo -E docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+          sudo -E docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
       - name: Clean up old images
         run: sudo docker image prune -f


### PR DESCRIPTION
## Summary
- deploy 스텝에 `DOCKERHUB_USERNAME` 환경변수를 GitHub Secrets에서 전달
- `sudo -E`로 환경변수를 sudo 하위 프로세스에 유지

## Test plan
- [ ] main 머지 후 CD deploy 스텝에서 이미지 pull 정상 확인

closes #35