### PR TITLE
hotfix: Grafana root_url 설정 추가 (Cloudflare Tunnel 프록시 대응) (#43)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=false
       - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:?GF_ADMIN_USER is not set}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD is not set}
+      - GF_SERVER_ROOT_URL=https://grafana.goseoul.today/
     volumes:
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
       - ./grafana/dashboards:/var/lib/grafana/dashboards


### PR DESCRIPTION
## Summary
- Cloudflare Tunnel 리버스 프록시 환경에서 Grafana 로딩 실패 해결
- `GF_SERVER_ROOT_URL=https://grafana.goseoul.today/` 환경변수 추가

## 원인
Grafana가 자신의 외부 URL을 모르면 정적 파일(JS/CSS) 경로가 맞지 않아 "failed to load its application files" 에러 발생

## Test plan
- [ ] 배포 후 `grafana.goseoul.today` 접속하여 로그인 페이지 정상 렌더링 확인

closes #43