### PR TITLE
hotfix: Grafana 익명 접근 Viewer로 변경 - 정적 파일 로딩 실패 해결 (#47)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       - "4317:4317"   # OTel Collector gRPC
       - "4318:4318"   # OTel Collector HTTP
     environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
       - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:?GF_ADMIN_USER is not set}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD is not set}
       - GF_SERVER_ROOT_URL=https://grafana.goseoul.today/


### PR DESCRIPTION
## Summary
- Grafana 12.x에서 `GF_AUTH_ANONYMOUS_ENABLED=false` 시 정적 파일(JS/CSS)까지 로그인 리다이렉트되어 로그인 페이지 렌더링 불가
- 익명 접근을 `Viewer` 권한으로 허용하여 정적 파일 로드 및 대시보드 조회 가능하게 변경
- 대시보드 편집/삭제는 admin 로그인 필요

## 변경 내용
```diff
- GF_AUTH_ANONYMOUS_ENABLED=false
+ GF_AUTH_ANONYMOUS_ENABLED=true
+ GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
```

## Test plan
- [ ] 배포 후 `grafana.goseoul.today` 로그인 페이지 정상 렌더링 확인
- [ ] 대시보드 조회 가능 확인
- [ ] admin 로그인 시 편집 가능 확인

closes #47