### PR TITLE
hotfix: 대시보드 메트릭 이름 OTLP 형식으로 수정 (#49)

### DIFF
--- a/grafana/dashboards/http-dashboard.json
+++ b/grafana/dashboards/http-dashboard.json
@@ -19,7 +19,7 @@
       },
       "targets": [
         {
-          "expr": "sum by(job) (rate(http_server_requests_seconds_count{job=~\"$service\"}[1m]))",
+          "expr": "sum by(job) (rate(http_server_requests_milliseconds_count{job=~\"$service\"}[1m]))",
           "legendFormat": "{{job}}"
         }
       ]
@@ -38,7 +38,7 @@
       },
       "targets": [
         {
-          "expr": "sum by(uri, method) (rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))",
+          "expr": "sum by(uri, method) (rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]))",
           "legendFormat": "{{method}} {{uri}}"
         }
       ]
@@ -50,14 +50,14 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "custom": { "fillOpacity": 10 }
         },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "rate(http_server_requests_seconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) / rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m])",
+          "expr": "rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) / rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m])",
           "legendFormat": "{{job}} - {{method}} {{uri}}"
         }
       ]
@@ -69,14 +69,14 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "custom": { "fillOpacity": 10 }
         },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by(le, job) (rate(http_server_requests_seconds_bucket{job=~\"$service\", uri!~\"/actuator.*\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le, job) (rate(http_server_requests_milliseconds_bucket{job=~\"$service\", uri!~\"/actuator.*\"}[5m])))",
           "legendFormat": "{{job}} P95"
         }
       ]
@@ -88,14 +88,14 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "custom": { "fillOpacity": 10 }
         },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum by(le, job) (rate(http_server_requests_seconds_bucket{job=~\"$service\", uri!~\"/actuator.*\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by(le, job) (rate(http_server_requests_milliseconds_bucket{job=~\"$service\", uri!~\"/actuator.*\"}[5m])))",
           "legendFormat": "{{job}} P99"
         }
       ]
@@ -121,7 +121,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m]))",
           "legendFormat": "5xx Error Rate"
         }
       ]
@@ -147,7 +147,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{job=~\"$service\", status=~\"4..\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"4..\"}[5m])) / sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m]))",
           "legendFormat": "4xx Rate"
         }
       ]
@@ -160,7 +160,7 @@
       "fieldConfig": { "defaults": {}, "overrides": [] },
       "targets": [
         {
-          "expr": "sum by(status) (increase(http_server_requests_seconds_count{job=~\"$service\"}[1h]))",
+          "expr": "sum by(status) (increase(http_server_requests_milliseconds_count{job=~\"$service\"}[1h]))",
           "legendFormat": "{{status}}"
         }
       ]
@@ -171,12 +171,12 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": { "unit": "s" },
+        "defaults": { "unit": "ms" },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "topk(10, rate(http_server_requests_seconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) / rate(http_server_requests_seconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))",
+          "expr": "topk(10, rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) / rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))",
           "legendFormat": "{{job}} {{method}} {{uri}}",
           "format": "table",
           "instant": true
@@ -191,7 +191,7 @@
         "name": "service",
         "type": "query",
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "definition": "label_values(http_server_requests_seconds_count, job)",
+        "definition": "label_values(http_server_requests_milliseconds_count, job)",
         "regex": "service-.*",
         "multi": true,
         "includeAll": true,

--- a/grafana/dashboards/jvm-dashboard.json
+++ b/grafana/dashboards/jvm-dashboard.json
@@ -86,7 +86,7 @@
       },
       "targets": [
         {
-          "expr": "rate(jvm_gc_pause_seconds_count{job=~\"$service\"}[1m])",
+          "expr": "rate(jvm_gc_pause_milliseconds_count{job=~\"$service\"}[1m])",
           "legendFormat": "{{job}} - {{cause}}"
         }
       ]
@@ -98,14 +98,14 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "ms",
           "custom": { "fillOpacity": 10 }
         },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "rate(jvm_gc_pause_seconds_sum{job=~\"$service\"}[1m])",
+          "expr": "rate(jvm_gc_pause_milliseconds_sum{job=~\"$service\"}[1m])",
           "legendFormat": "{{job}} - {{cause}}"
         }
       ]
@@ -124,15 +124,15 @@
       },
       "targets": [
         {
-          "expr": "jvm_threads_live_threads{job=~\"$service\"}",
+          "expr": "jvm_threads_live{job=~\"$service\"}",
           "legendFormat": "{{job}} - Live"
         },
         {
-          "expr": "jvm_threads_daemon_threads{job=~\"$service\"}",
+          "expr": "jvm_threads_daemon{job=~\"$service\"}",
           "legendFormat": "{{job}} - Daemon"
         },
         {
-          "expr": "jvm_threads_peak_threads{job=~\"$service\"}",
+          "expr": "jvm_threads_peak{job=~\"$service\"}",
           "legendFormat": "{{job}} - Peak"
         }
       ]


### PR DESCRIPTION
## Summary
- Micrometer → OTLP 전송 시 메트릭 이름이 변환되어 대시보드에서 No data 발생
- 실제 Prometheus에 수집된 메트릭 이름에 맞게 대시보드 수정

## 변경 내용
### JVM 대시보드
| 기존 | 수정 |
|---|---|
| `jvm_gc_pause_seconds_*` | `jvm_gc_pause_milliseconds_*` |
| `jvm_threads_live_threads` | `jvm_threads_live` |
| `jvm_threads_daemon_threads` | `jvm_threads_daemon` |
| `jvm_threads_peak_threads` | `jvm_threads_peak` |

### HTTP 대시보드
| 기존 | 수정 |
|---|---|
| `http_server_requests_seconds_*` | `http_server_requests_milliseconds_*` |

단위도 `s` → `ms`로 변경

## Test plan
- [ ] 배포 후 JVM 대시보드에서 데이터 표시 확인
- [ ] HTTP 대시보드에서 데이터 표시 확인

closes #49