### PR TITLE
hotfix: Grafana 프로비저닝 마운트 경로 수정 (#51)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD is not set}
       - GF_SERVER_ROOT_URL=https://grafana.goseoul.today/
     volumes:
-      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
-      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning/dashboards/dashboard.yml:/otel-lgtm/grafana/conf/provisioning/dashboards/danburn.yaml
+      - ./grafana/dashboards:/otel-lgtm/danburn-dashboards
     networks:
       - backend-net
 

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -8,5 +8,5 @@ providers:
     disableDeletion: false
     editable: true
     options:
-      path: /var/lib/grafana/dashboards
+      path: /otel-lgtm/danburn-dashboards
       foldersFromFilesStructure: false


### PR DESCRIPTION
## Summary
- grafana/otel-lgtm 이미지의 실제 프로비저닝 경로에 맞게 볼륨 마운트 수정
- 기존: `/etc/grafana/provisioning/dashboards` (일반 Grafana 경로)
- 수정: `/otel-lgtm/grafana/conf/provisioning/dashboards/` (otel-lgtm 실제 경로)

## 변경
```diff
- ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
- ./grafana/dashboards:/var/lib/grafana/dashboards
+ ./grafana/provisioning/dashboards/dashboard.yml:/otel-lgtm/grafana/conf/provisioning/dashboards/danburn.yaml
+ ./grafana/dashboards:/otel-lgtm/danburn-dashboards
```

## Test plan
- [ ] 배포 후 Dan-burn 폴더에 JVM/HTTP 대시보드 자동 생성 확인
- [ ] 대시보드에 메트릭 데이터 표시 확인

closes #51