### PR TITLE
fix: Grafana 대시보드 No Data 수정 (#53)

### DIFF
--- a/grafana/dashboards/http-dashboard.json
+++ b/grafana/dashboards/http-dashboard.json
@@ -57,7 +57,7 @@
       },
       "targets": [
         {
-          "expr": "rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) / rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m])",
+          "expr": "rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) / (rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) > 0)",
           "legendFormat": "{{job}} - {{method}} {{uri}}"
         }
       ]
@@ -176,7 +176,7 @@
       },
       "targets": [
         {
-          "expr": "topk(10, rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) / rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))",
+          "expr": "topk(10, rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) / (rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) > 0))",
           "legendFormat": "{{job}} {{method}} {{uri}}",
           "format": "table",
           "instant": true

--- a/grafana/dashboards/jvm-dashboard.json
+++ b/grafana/dashboards/jvm-dashboard.json
@@ -73,7 +73,7 @@
       ]
     },
     {
-      "title": "GC Pause Count (per min)",
+      "title": "GC Pause Rate (/s)",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "title": "GC Pause Duration (per min)",
+      "title": "GC Pause Duration Rate (ms/s)",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },


### PR DESCRIPTION
## Summary
- `$service` 템플릿 변수에 `allValue: "service-.*"` 추가하여 All 선택 시 No Data 문제 해결
- OTLP 변환된 메트릭 이름으로 통일 (`_seconds` → `_milliseconds`, 스레드명 등)
- 단위(unit)도 `s` → `ms`로 맞춤

## Test plan
- [ ] Grafana JVM Dashboard에서 All 선택 시 데이터 표시 확인
- [ ] Grafana HTTP Dashboard에서 All 선택 시 데이터 표시 확인
- [ ] 개별 서비스 선택 시에도 정상 동작 확인

Closes #53