### PR TITLE
fix: 5xx/4xx Error Rate 패널 division-by-zero 가드 추가 (#53)

### DIFF
--- a/grafana/dashboards/http-dashboard.json
+++ b/grafana/dashboards/http-dashboard.json
@@ -121,7 +121,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"5..\"}[5m])) / (sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m])) > 0)",
           "legendFormat": "5xx Error Rate"
         }
       ]
@@ -147,7 +147,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"4..\"}[5m])) / sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"4..\"}[5m])) / (sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m])) > 0)",
           "legendFormat": "4xx Rate"
         }
       ]


### PR DESCRIPTION
## Summary
- 5xx Error Rate, 4xx Rate 패널에 `> 0` 가드 추가하여 트래픽 없을 때 NaN 방지
- Gemini 코드 리뷰 반영

## Test plan
- [ ] 트래픽 없는 상태에서 5xx/4xx 패널에 NaN 스파이크 없는지 확인

Closes #53