### PR TITLE
fix: Grafana 대시보드 No Data 수정 및 PromQL 개선 (#53)

### DIFF
--- a/grafana/dashboards/http-dashboard.json
+++ b/grafana/dashboards/http-dashboard.json
@@ -57,7 +57,7 @@
       },
       "targets": [
         {
-          "expr": "rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) / rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m])",
+          "expr": "rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) / (rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[1m]) > 0)",
           "legendFormat": "{{job}} - {{method}} {{uri}}"
         }
       ]
@@ -121,7 +121,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"5..\"}[5m])) / (sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m])) > 0)",
           "legendFormat": "5xx Error Rate"
         }
       ]
@@ -147,7 +147,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"4..\"}[5m])) / sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m]))",
+          "expr": "sum(rate(http_server_requests_milliseconds_count{job=~\"$service\", status=~\"4..\"}[5m])) / (sum(rate(http_server_requests_milliseconds_count{job=~\"$service\"}[5m])) > 0)",
           "legendFormat": "4xx Rate"
         }
       ]
@@ -176,7 +176,7 @@
       },
       "targets": [
         {
-          "expr": "topk(10, rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) / rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]))",
+          "expr": "topk(10, rate(http_server_requests_milliseconds_sum{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) / (rate(http_server_requests_milliseconds_count{job=~\"$service\", uri!~\"/actuator.*\"}[5m]) > 0))",
           "legendFormat": "{{job}} {{method}} {{uri}}",
           "format": "table",
           "instant": true
@@ -195,6 +195,7 @@
         "regex": "service-.*",
         "multi": true,
         "includeAll": true,
+        "allValue": "service-.*",
         "current": { "selected": true, "text": "All", "value": "$__all" }
       }
     ]

--- a/grafana/dashboards/jvm-dashboard.json
+++ b/grafana/dashboards/jvm-dashboard.json
@@ -73,7 +73,7 @@
       ]
     },
     {
-      "title": "GC Pause Count (per min)",
+      "title": "GC Pause Rate (/s)",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "title": "GC Pause Duration (per min)",
+      "title": "GC Pause Duration Rate (ms/s)",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -149,6 +149,7 @@
         "regex": "service-.*",
         "multi": true,
         "includeAll": true,
+        "allValue": "service-.*",
         "current": { "selected": true, "text": "All", "value": "$__all" }
       }
     ]


### PR DESCRIPTION
## Summary
- `$service` 템플릿 변수에 `allValue: "service-.*"` 추가하여 All 선택 시 No Data 해결
- 모든 나눗셈 패널(Avg, Top10, 5xx, 4xx)에 division-by-zero 가드 추가
- GC 패널 제목을 rate() 결과에 맞게 수정

## Test plan
- [ ] Grafana JVM/HTTP Dashboard에서 All 선택 시 데이터 표시 확인
- [ ] 트래픽 없는 서비스에서 NaN 스파이크 없는지 확인

Closes #53