### PR TITLE
fix: P95/P99 히스토그램 설정 추가 및 Error Rate No Data 개선 (#62)

### DIFF
--- a/grafana/dashboards/http-dashboard.json
+++ b/grafana/dashboards/http-dashboard.json
@@ -108,6 +108,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -134,6 +135,7 @@
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -26,6 +26,10 @@ management:
   endpoint:
     health:
       show-details: always
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
   otlp:
     metrics:
       export:

--- a/service-gateway/src/main/java/com/danburn/gateway/api/TestController.java
+++ b/service-gateway/src/main/java/com/danburn/gateway/api/TestController.java
@@ -1,0 +1,14 @@
+package com.danburn.gateway.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class TestController {
+
+    @GetMapping("/error-test")
+    public Mono<String> errorTest() {
+        throw new RuntimeException("대시보드 테스트용 에러!");
+    }
+}

--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -69,6 +69,10 @@ management:
   endpoint:
     health:
       show-details: always
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
   otlp:
     metrics:
       export:

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -25,6 +25,10 @@ management:
   endpoint:
     health:
       show-details: always
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
   otlp:
     metrics:
       export:

--- a/service-transport/src/main/resources/application.yml
+++ b/service-transport/src/main/resources/application.yml
@@ -21,6 +21,10 @@ management:
   endpoint:
     health:
       show-details: always
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
   otlp:
     metrics:
       export:


### PR DESCRIPTION
## Summary
- 4개 서비스 `application.yml`에 `percentiles-histogram` 활성화 → P95/P99 패널에 `_bucket` 데이터 제공
- HTTP Dashboard의 5xx/4xx Error Rate 패널에 `noValue: "0"` 추가 → No Data 대신 0 표시
- Gateway에 `/error-test` 엔드포인트 추가 → 대시보드 5xx 테스트용

Closes #62

## Test plan
- [ ] 배포 후 Grafana P95/P99 패널에 데이터 표시 확인
- [ ] 5xx/4xx Error Rate 패널이 트래픽 없을 때 `0` 표시 확인
- [ ] `/error-test` 호출 시 5xx Error Rate 패널 반응 확인