### PR TITLE
fix: Grafana 마운트 경로 otel-lgtm 이미지에 맞게 동기화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD:?GF_ADMIN_PASSWORD is not set}
       - GF_SERVER_ROOT_URL=https://grafana.goseoul.today/
     volumes:
-      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
-      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning/dashboards/dashboard.yml:/otel-lgtm/grafana/conf/provisioning/dashboards/danburn.yaml
+      - ./grafana/dashboards:/otel-lgtm/danburn-dashboards
     networks:
       - backend-net
 

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -8,5 +8,5 @@ providers:
     disableDeletion: false
     editable: true
     options:
-      path: /var/lib/grafana/dashboards
+      path: /otel-lgtm/danburn-dashboards
       foldersFromFilesStructure: false


### PR DESCRIPTION
## Summary
- docker-compose.yml 볼륨 마운트 경로를 otel-lgtm 이미지 경로로 수정
- dashboard.yml 프로비저닝 경로 동기화
- main과 dev 간 설정 불일치 해소