### PR TITLE
fix: protobuf-java 의존성 누락으로 서비스 기동 실패 수정 (#87)

### DIFF
--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
+    implementation 'com.google.protobuf:protobuf-java:3.25.5'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/service-map/build.gradle
+++ b/service-map/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
+    implementation 'com.google.protobuf:protobuf-java:3.25.5'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/service-transport/build.gradle
+++ b/service-transport/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
+    implementation 'com.google.protobuf:protobuf-java:3.25.5'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
- `service-congestion`, `service-map`, `service-transport`에 `protobuf-java:3.25.5` 의존성 추가
- `OtlpMeterRegistry`가 protobuf를 필요로 하나 누락되어 `ClassNotFoundException` 발생

## 원인
`service-gateway`에만 `protobuf-java`가 있고 나머지 3개 모듈에 빠져있었음

Closes #87