### PR TITLE
fix: CD docker pull retry 로직 추가 및 빌드 2개씩 병렬화 (#90)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,28 @@ on:
     branches: [ main ]
 
 jobs:
-  # ── Docker 이미지 순차 빌드 & 푸시 (GitHub-hosted) ────────────────────────
+  # ── Docker 이미지 병렬 빌드 & 푸시 (2개씩, GitHub-hosted) ──────────────────
   build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        include:
+          - service: service-gateway
+            context: .
+            dockerfile: service-gateway/Dockerfile
+          - service: service-map
+            context: .
+            dockerfile: service-map/Dockerfile
+          - service: service-congestion
+            context: .
+            dockerfile: service-congestion/Dockerfile
+          - service: service-transport
+            context: .
+            dockerfile: service-transport/Dockerfile
+          - service: service-ai
+            context: ./service-ai
+            dockerfile: ./service-ai/Dockerfile
 
     steps:
       - uses: actions/checkout@v4
@@ -21,65 +40,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push service-gateway
+      - name: Build and push ${{ matrix.service }}
         uses: docker/build-push-action@v5
         with:
-          context: .
-          file: service-gateway/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-gateway:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-gateway:${{ github.sha }}
-          cache-from: type=gha,scope=service-gateway
-          cache-to: type=gha,scope=service-gateway,mode=max
-
-      - name: Build and push service-map
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: service-map/Dockerfile
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-map:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-map:${{ github.sha }}
-          cache-from: type=gha,scope=service-map
-          cache-to: type=gha,scope=service-map,mode=max
-
-      - name: Build and push service-congestion
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: service-congestion/Dockerfile
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-congestion:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-congestion:${{ github.sha }}
-          cache-from: type=gha,scope=service-congestion
-          cache-to: type=gha,scope=service-congestion,mode=max
-
-      - name: Build and push service-transport
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: service-transport/Dockerfile
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-transport:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-transport:${{ github.sha }}
-          cache-from: type=gha,scope=service-transport
-          cache-to: type=gha,scope=service-transport,mode=max
-
-      - name: Build and push service-ai
-        uses: docker/build-push-action@v5
-        with:
-          context: ./service-ai
-          file: ./service-ai/Dockerfile
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-ai:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-service-ai:${{ github.sha }}
-          cache-from: type=gha,scope=service-ai
-          cache-to: type=gha,scope=service-ai,mode=max
+            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-${{ matrix.service }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/danburn-${{ matrix.service }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
   # ── 서버 배포 (Self-hosted Runner) ─────────────────────────────────────────
   deploy:
@@ -99,7 +70,11 @@ jobs:
           GF_ADMIN_PASSWORD: ${{ secrets.GF_ADMIN_PASSWORD }}
         run: |
           cd ~/Backend
-          sudo -E docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+          for i in 1 2 3; do
+            sudo -E docker compose -f docker-compose.yml -f docker-compose.prod.yml pull && break
+            echo "Pull failed (attempt $i/3), retrying in 10s..."
+            sleep 10
+          done
           sudo -E docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
       - name: Start Portainer (if not running)


### PR DESCRIPTION
## Summary
- docker compose pull 실패 시 최대 3회 자동 재시도 (10초 간격)
- 이미지 빌드를 matrix + max-parallel: 2로 병렬화하여 빌드 시간 단축

## 원인
서버에서 Docker Hub pull 시 간헐적 네트워크 타임아웃으로 CD 배포 반복 실패

Closes #90