### PR TITLE
fix: MySQL DB 생성을 init 스크립트로 통합 (#93)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     image: mysql:8.0
     environment:
       MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: danburn_map
     ports:
       - "3306:3306"
     volumes:

--- a/mysql/init/01-create-databases.sql
+++ b/mysql/init/01-create-databases.sql
@@ -1,4 +1,3 @@
--- MYSQL_DATABASE=danburn_map 은 Docker가 자동 생성
--- 나머지 DB를 여기서 추가 생성
+-- 모든 DB를 init 스크립트에서 생성
+CREATE DATABASE IF NOT EXISTS danburn_map;
 CREATE DATABASE IF NOT EXISTS danburn_congestion;
-CREATE DATABASE IF NOT EXISTS danburn_mobility;


### PR DESCRIPTION
## Summary
- `MYSQL_DATABASE` 환경변수 제거, init 스크립트에서 모든 DB 생성
- `danburn_map`, `danburn_congestion` 2개 DB를 `01-create-databases.sql`에서 통합 관리

## 원인
기존에 `MYSQL_DATABASE=danburn_map`만 설정되어 있어 `danburn_congestion` DB가 누락, congestion 서비스 기동 실패

Closes #93