### PR TITLE
feat: RabbitMQ 서비스 추가 (Congestion → AI 비동기 통신) (#93)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,22 @@ services:
     networks:
       - backend-net
 
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend-net
+
   # ── Observability (Prometheus + Loki + Grafana) ─────────────────────────────
 
   observability:
@@ -70,10 +86,16 @@ services:
       - CONGESTION_SCHEDULER_INTERVAL=${CONGESTION_SCHEDULER_INTERVAL:-300000}
       - CONGESTION_CLEANUP_CRON=${CONGESTION_CLEANUP_CRON:-0 0 3 * * *}
       - CONGESTION_CLEANUP_RETENTION_DAYS=${CONGESTION_CLEANUP_RETENTION_DAYS:-7}
+      - SPRING_RABBITMQ_HOST=rabbitmq
+      - SPRING_RABBITMQ_PORT=5672
+      - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USER:-guest}
+      - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASS:-guest}
     depends_on:
       redis:
         condition: service_healthy
       mysql:
+        condition: service_healthy
+      rabbitmq:
         condition: service_healthy
     networks:
       - backend-net
@@ -121,6 +143,18 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8085:8085"
+    environment:
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_PORT=5672
+      - RABBITMQ_USER=${RABBITMQ_USER:-guest}
+      - RABBITMQ_PASS=${RABBITMQ_PASS:-guest}
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - backend-net
 


### PR DESCRIPTION
## Summary
- RabbitMQ 서비스 추가 (`rabbitmq:3-management-alpine`)
- congestion 서비스에 RabbitMQ 연결 환경변수 및 depends_on 추가
- ai 서비스에 RabbitMQ, Redis 연결 환경변수 및 depends_on 추가
- 환경변수로 RabbitMQ 계정 오버라이드 가능 (`RABBITMQ_USER`, `RABBITMQ_PASS`)

Closes #93