### PR TITLE
test: Congestion Service 단위 테스트 작성 (#110)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,4 +33,8 @@ subprojects {
             extendsFrom annotationProcessor
         }
     }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/CongestionApplication.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/CongestionApplication.java
@@ -2,11 +2,9 @@ package com.danburn.congestion;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
 @EnableScheduling
 @EnableAsync
 @SpringBootApplication(scanBasePackages = {"com.danburn.congestion", "com.danburn.common"})

--- a/service-congestion/src/main/java/com/danburn/congestion/config/JpaAuditingConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.danburn.congestion.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/controller/CongestionControllerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/controller/CongestionControllerTest.java
@@ -1,0 +1,99 @@
+package com.danburn.congestion.controller;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.congestion.dto.response.CongestionResponse;
+import com.danburn.congestion.service.CongestionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CongestionController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration.class
+        })
+@ActiveProfiles("test")
+class CongestionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CongestionService congestionService;
+
+    private CongestionResponse createResponse(String areaCode, String level) {
+        return new CongestionResponse(
+                areaCode, level, "테스트 메시지",
+                10000, 12000, "2026-04-01 14:00",
+                List.of(new CongestionResponse.ForecastResponse(
+                        "2026-04-01 15:00", "보통", 8000, 10000
+                ))
+        );
+    }
+
+    @Test
+    @DisplayName("GET /api/congestion → 전체 조회 성공")
+    void findAll_success() throws Exception {
+        given(congestionService.findAll()).willReturn(List.of(
+                createResponse("POI001", "붐빔"),
+                createResponse("POI002", "여유")
+        ));
+
+        mockMvc.perform(get("/api/congestion"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].areaCode").value("POI001"));
+    }
+
+    @Test
+    @DisplayName("GET /api/congestion → 데이터 없음 시 빈 배열")
+    void findAll_empty() throws Exception {
+        given(congestionService.findAll()).willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/congestion"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/congestion/{areaCode} → 단건 조회 성공")
+    void findByAreaCode_success() throws Exception {
+        given(congestionService.findByAreaCode("POI001"))
+                .willReturn(createResponse("POI001", "붐빔"));
+
+        mockMvc.perform(get("/api/congestion/POI001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.areaCode").value("POI001"))
+                .andExpect(jsonPath("$.data.congestionLevel").value("붐빔"))
+                .andExpect(jsonPath("$.data.forecasts").isArray())
+                .andExpect(jsonPath("$.data.forecasts.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/congestion/{areaCode} → 404 에러 응답")
+    void findByAreaCode_notFound() throws Exception {
+        given(congestionService.findByAreaCode("POI999"))
+                .willThrow(new GlobalException(404, "해당 장소의 혼잡도 데이터가 없습니다. areaCode: POI999"));
+
+        mockMvc.perform(get("/api/congestion/POI999"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("해당 장소의 혼잡도 데이터가 없습니다. areaCode: POI999"));
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/domain/CongestionLevelTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/domain/CongestionLevelTest.java
@@ -1,0 +1,44 @@
+package com.danburn.congestion.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CongestionLevelTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "여유, RELAXED",
+            "보통, NORMAL",
+            "약간 붐빔, SLIGHTLY_CROWDED",
+            "붐빔, BUSY"
+    })
+    @DisplayName("fromDescription: 유효한 설명 → 올바른 enum 반환")
+    void fromDescription_validDescription(String description, CongestionLevel expected) {
+        assertThat(CongestionLevel.fromDescription(description)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("fromDescription: 앞뒤 공백이 있어도 정상 변환")
+    void fromDescription_trimmedDescription() {
+        assertThat(CongestionLevel.fromDescription("  여유  ")).isEqualTo(CongestionLevel.RELAXED);
+    }
+
+    @Test
+    @DisplayName("fromDescription: 알 수 없는 설명 → IllegalArgumentException")
+    void fromDescription_invalidDescription() {
+        assertThatThrownBy(() -> CongestionLevel.fromDescription("알 수 없음"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("알 수 없는 혼잡도 레벨");
+    }
+
+    @Test
+    @DisplayName("getDescription: enum → 한글 설명 반환")
+    void getDescription() {
+        assertThat(CongestionLevel.BUSY.getDescription()).isEqualTo("붐빔");
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/scheduler/CongestionSchedulerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/scheduler/CongestionSchedulerTest.java
@@ -1,0 +1,95 @@
+package com.danburn.congestion.scheduler;
+
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.dto.response.CongestionApiResponse;
+import com.danburn.congestion.infra.SeoulApiClient;
+import com.danburn.congestion.service.CongestionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionSchedulerTest {
+
+    @Mock
+    private SeoulApiClient seoulApiClient;
+
+    @Mock
+    private CongestionService congestionService;
+
+    @InjectMocks
+    private CongestionScheduler congestionScheduler;
+
+    private CongestionApiResponse createApiResponse(String areaCode, String level) {
+        return new CongestionApiResponse(
+                "테스트장소", areaCode, level,
+                "혼잡도 메시지", 10000, 12000,
+                "2026-04-01 14:00",
+                List.of(new CongestionApiResponse.ForecastResponse(
+                        "2026-04-01 15:00", "보통", 8000, 10000
+                ))
+        );
+    }
+
+    @Test
+    @DisplayName("API 응답 정상 → Redis + DB 저장 호출")
+    void fetchAndSave_success() {
+        given(seoulApiClient.fetchAll()).willReturn(List.of(
+                createApiResponse("POI001", "붐빔"),
+                createApiResponse("POI002", "여유")
+        ));
+
+        congestionScheduler.fetchAndSave();
+
+        then(congestionService).should().saveAllToRedis(anyList());
+        then(congestionService).should().saveAllToDb(anyList());
+    }
+
+    @Test
+    @DisplayName("API 응답이 빈 리스트 → 저장 호출 안 함")
+    void fetchAndSave_emptyResponse() {
+        given(seoulApiClient.fetchAll()).willReturn(Collections.emptyList());
+
+        congestionScheduler.fetchAndSave();
+
+        then(congestionService).should(never()).saveAllToRedis(anyList());
+        then(congestionService).should(never()).saveAllToDb(anyList());
+    }
+
+    @Test
+    @DisplayName("API 호출 예외 발생 → 저장 호출 안 함 (예외 전파 없음)")
+    void fetchAndSave_apiException() {
+        given(seoulApiClient.fetchAll()).willThrow(new RuntimeException("API 서버 장애"));
+
+        congestionScheduler.fetchAndSave();
+
+        then(congestionService).should(never()).saveAllToRedis(anyList());
+        then(congestionService).should(never()).saveAllToDb(anyList());
+    }
+
+    @Test
+    @DisplayName("forecast가 null인 응답 → 빈 리스트로 변환되어 저장")
+    void fetchAndSave_nullForecasts() {
+        CongestionApiResponse responseWithNullForecasts = new CongestionApiResponse(
+                "테스트장소", "POI001", "보통",
+                "메시지", 5000, 6000,
+                "2026-04-01 14:00", null
+        );
+        given(seoulApiClient.fetchAll()).willReturn(List.of(responseWithNullForecasts));
+
+        congestionScheduler.fetchAndSave();
+
+        then(congestionService).should().saveAllToRedis(anyList());
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/scheduler/DataCleanupSchedulerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/scheduler/DataCleanupSchedulerTest.java
@@ -1,0 +1,49 @@
+package com.danburn.congestion.scheduler;
+
+import com.danburn.congestion.service.CongestionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class DataCleanupSchedulerTest {
+
+    @Mock
+    private CongestionService congestionService;
+
+    @InjectMocks
+    private DataCleanupScheduler dataCleanupScheduler;
+
+    @Test
+    @DisplayName("cleanupOldData: retentionDays 기준으로 deleteOlderThan 호출")
+    void cleanupOldData_success() {
+        ReflectionTestUtils.setField(dataCleanupScheduler, "retentionDays", 7);
+        given(congestionService.deleteOlderThan(any(Instant.class))).willReturn(10);
+
+        dataCleanupScheduler.cleanupOldData();
+
+        then(congestionService).should().deleteOlderThan(any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("cleanupOldData: deleteOlderThan 예외 발생 → 예외 전파 없음")
+    void cleanupOldData_exception() {
+        ReflectionTestUtils.setField(dataCleanupScheduler, "retentionDays", 7);
+        given(congestionService.deleteOlderThan(any(Instant.class)))
+                .willThrow(new RuntimeException("DB 연결 실패"));
+
+        dataCleanupScheduler.cleanupOldData();
+
+        then(congestionService).should().deleteOlderThan(any(Instant.class));
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/CongestionServiceTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/CongestionServiceTest.java
@@ -1,0 +1,207 @@
+package com.danburn.congestion.service;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.congestion.domain.Congestion;
+import com.danburn.congestion.domain.CongestionLevel;
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.dto.response.CongestionResponse;
+import com.danburn.congestion.repository.CongestionJpaRepository;
+import com.danburn.congestion.repository.CongestionRedisRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionServiceTest {
+
+    @Mock
+    private CongestionRedisRepository congestionRedisRepository;
+
+    @Mock
+    private CongestionJpaRepository congestionJpaRepository;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private CongestionService congestionService;
+
+    private CongestionRedisDto createRedisDto(String areaCode, String level) {
+        return new CongestionRedisDto(
+                areaCode, level, "테스트 메시지",
+                10000, 12000, "2026-04-01 14:00",
+                List.of(new CongestionRedisDto.ForecastDto(
+                        "2026-04-01 15:00", "보통", 8000, 10000
+                ))
+        );
+    }
+
+    private Congestion createEntity(String areaCode, CongestionLevel level) {
+        return Congestion.builder()
+                .areaCode(areaCode)
+                .congestionLevel(level)
+                .congestionMessage("테스트 메시지")
+                .minPeopleCount(10000)
+                .maxPeopleCount(12000)
+                .populationTime(LocalDateTime.of(2026, 4, 1, 14, 0))
+                .forecast("[]")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("findByAreaCode")
+    class FindByAreaCode {
+
+        @Test
+        @DisplayName("Redis 캐시 히트 → Redis 데이터 반환")
+        void redisHit() {
+            CongestionRedisDto dto = createRedisDto("POI001", "붐빔");
+            given(congestionRedisRepository.findByAreaCode("POI001"))
+                    .willReturn(Optional.of(dto));
+
+            CongestionResponse result = congestionService.findByAreaCode("POI001");
+
+            assertThat(result.areaCode()).isEqualTo("POI001");
+            assertThat(result.congestionLevel()).isEqualTo("붐빔");
+            assertThat(result.forecasts()).hasSize(1);
+            then(congestionJpaRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("Redis 미스 + DB 히트 → DB 데이터 반환")
+        void redisMissDbHit() {
+            given(congestionRedisRepository.findByAreaCode("POI001"))
+                    .willReturn(Optional.empty());
+            given(congestionJpaRepository.findTopByAreaCodeOrderByCreatedAtDesc("POI001"))
+                    .willReturn(Optional.of(createEntity("POI001", CongestionLevel.BUSY)));
+
+            CongestionResponse result = congestionService.findByAreaCode("POI001");
+
+            assertThat(result.areaCode()).isEqualTo("POI001");
+            assertThat(result.congestionLevel()).isEqualTo("붐빔");
+        }
+
+        @Test
+        @DisplayName("Redis 미스 + DB 미스 → GlobalException(404)")
+        void redisMissDbMiss() {
+            given(congestionRedisRepository.findByAreaCode("POI999"))
+                    .willReturn(Optional.empty());
+            given(congestionJpaRepository.findTopByAreaCodeOrderByCreatedAtDesc("POI999"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> congestionService.findByAreaCode("POI999"))
+                    .isInstanceOf(GlobalException.class)
+                    .satisfies(ex -> assertThat(((GlobalException) ex).getStatus()).isEqualTo(404));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAll")
+    class FindAll {
+
+        @Test
+        @DisplayName("Redis에 데이터 있음 → Redis 데이터 반환")
+        void redisHasData() {
+            List<CongestionRedisDto> dtos = List.of(
+                    createRedisDto("POI001", "붐빔"),
+                    createRedisDto("POI002", "여유")
+            );
+            given(congestionRedisRepository.findAll()).willReturn(dtos);
+
+            List<CongestionResponse> result = congestionService.findAll();
+
+            assertThat(result).hasSize(2);
+            then(congestionJpaRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("Redis 비어있음 → DB 폴백 조회")
+        void redisMissFallbackToDb() {
+            given(congestionRedisRepository.findAll()).willReturn(Collections.emptyList());
+            given(congestionJpaRepository.findLatestPerLocation())
+                    .willReturn(List.of(createEntity("POI001", CongestionLevel.NORMAL)));
+
+            List<CongestionResponse> result = congestionService.findAll();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).congestionLevel()).isEqualTo("보통");
+        }
+    }
+
+    @Nested
+    @DisplayName("saveAllToRedis")
+    class SaveAllToRedis {
+
+        @Test
+        @DisplayName("Redis 배치 저장 호출")
+        void saveAll() {
+            List<CongestionRedisDto> dtos = List.of(createRedisDto("POI001", "붐빔"));
+
+            congestionService.saveAllToRedis(dtos);
+
+            then(congestionRedisRepository).should().saveAll(dtos);
+        }
+    }
+
+    @Nested
+    @DisplayName("saveAllToDb")
+    class SaveAllToDb {
+
+        @Test
+        @DisplayName("DTO → Entity 변환 후 DB 배치 저장")
+        void saveAll() {
+            List<CongestionRedisDto> dtos = List.of(createRedisDto("POI001", "붐빔"));
+
+            congestionService.saveAllToDb(dtos);
+
+            then(congestionJpaRepository).should().saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("populationTime이 null이어도 저장 성공")
+        void saveAllWithNullPopulationTime() {
+            CongestionRedisDto dto = new CongestionRedisDto(
+                    "POI001", "여유", "메시지", 1000, 2000, null, Collections.emptyList()
+            );
+
+            congestionService.saveAllToDb(List.of(dto));
+
+            then(congestionJpaRepository).should().saveAll(anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteOlderThan")
+    class DeleteOlderThan {
+
+        @Test
+        @DisplayName("cutoff 이전 데이터 삭제 → 삭제 건수 반환")
+        void deleteOldData() {
+            Instant cutoff = Instant.now();
+            given(congestionJpaRepository.deleteByCreatedAtBefore(cutoff)).willReturn(5);
+
+            int deleted = congestionService.deleteOlderThan(cutoff);
+
+            assertThat(deleted).isEqualTo(5);
+        }
+    }
+}

--- a/service-congestion/src/test/resources/application-test.yml
+++ b/service-congestion/src/test/resources/application-test.yml
@@ -1,0 +1,21 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+management:
+  otlp:
+    metrics:
+      export:
+        enabled: false
+
+congestion:
+  scheduler:
+    interval: 300000
+    initial-delay: 10000
+  cleanup:
+    cron: "0 0 3 * * *"
+    retention-days: 7

--- a/service-congestion/src/test/resources/logback-test.xml
+++ b/service-congestion/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- Congestion Service 핵심 로직에 대한 단위 테스트 26건 작성
- `@EnableJpaAuditing`을 별도 `JpaAuditingConfig`로 분리하여 `@WebMvcTest` 호환성 확보
- 루트 `build.gradle`에 `useJUnitPlatform()` 추가

## 테스트 목록

| 클래스 | 건수 | 검증 대상 |
|--------|------|-----------|
| `CongestionLevelTest` | 7 | enum fromDescription 정상/예외/공백 |
| `CongestionServiceTest` | 9 | Redis/DB 폴백 조회, 저장, 삭제 |
| `CongestionSchedulerTest` | 4 | 스케줄러 수집 흐름 정상/빈응답/예외/null forecast |
| `DataCleanupSchedulerTest` | 2 | 데이터 정리 정상/예외 |
| `CongestionControllerTest` | 4 | API 응답 형식, 404 에러 |

## Test plan
- [x] `./gradlew :service-congestion:test` — 26건 전체 PASS 확인
- [x] CI 빌드 통과 확인

closes #110