### PR TITLE
fix: RestTemplate 한글 URL 인코딩 방지

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
@@ -11,6 +11,8 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +42,10 @@ public class RealSeoulApiClient implements SeoulApiClient {
         if (apiKey == null || apiKey.isBlank()) {
             throw new IllegalArgumentException("seoul.api.key must be configured");
         }
+        DefaultUriBuilderFactory uriFactory = new DefaultUriBuilderFactory();
+        uriFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
         this.restTemplate = restTemplateBuilder
+                .uriTemplateHandler(uriFactory)
                 .connectTimeout(Duration.ofSeconds(5))
                 .readTimeout(Duration.ofSeconds(10))
                 .build();


### PR DESCRIPTION
## Summary
- RestTemplate이 URI 변수를 자동 퍼센트 인코딩하여 서울 공공데이터 API 호출 실패 (400)
- `DefaultUriBuilderFactory.EncodingMode.NONE` 설정으로 한글이 인코딩 없이 전송되도록 수정
- 운영 서버 congestion 테이블 0건 문제 해결

## 원인
`강남역` → `%EA%B0%95%EB%82%A8%EC%97%AD`으로 인코딩되어 서울 API가 거부

## 변경 파일
- `RealSeoulApiClient.java`: RestTemplate 생성 시 `EncodingMode.NONE` 적용 (2줄 추가)

closes #117

## Test plan
- [x] `./gradlew :service-congestion:build` 통과
- [x] `./gradlew :service-congestion:test` 통과
- [ ] 운영 서버 배포 후 `SELECT COUNT(*) FROM congestion` 으로 데이터 수집 확인