### PR TITLE
fix: CD 배포 시 MySQL 유저 생성 및 SEOUL_API_KEY infisical 전환 (#123)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,6 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           GF_ADMIN_USER: ${{ secrets.GF_ADMIN_USER }}
           GF_ADMIN_PASSWORD: ${{ secrets.GF_ADMIN_PASSWORD }}
-          SEOUL_API_KEY: ${{ secrets.SEOUL_API_KEY }}
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
         run: |
           cd ~/Backend
@@ -78,6 +77,32 @@ jobs:
             sleep 10
           done
           sudo -E infisical run --env=prod -- docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+
+      - name: Ensure MySQL DB users exist
+        env:
+          INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
+        run: |
+          cd ~/Backend
+          echo "Waiting for MySQL to be healthy..."
+          for i in $(seq 1 30); do
+            if sudo docker exec backend-mysql-1 mysqladmin ping -uroot -proot --silent 2>/dev/null; then
+              echo "MySQL is ready."
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+          sudo -E infisical run --env=prod -- bash -c '
+            docker exec backend-mysql-1 mysql -uroot -proot -e "
+              CREATE USER IF NOT EXISTS \"${CONGESTION_DB_USERNAME}\"@\"%\" IDENTIFIED BY \"${CONGESTION_DB_PASSWORD}\";
+              GRANT ALL PRIVILEGES ON danburn_congestion.* TO \"${CONGESTION_DB_USERNAME}\"@\"%\";
+              CREATE USER IF NOT EXISTS \"${MAP_DB_USERNAME}\"@\"%\" IDENTIFIED BY \"${MAP_DB_PASSWORD}\";
+              GRANT ALL PRIVILEGES ON danburn_map.* TO \"${MAP_DB_USERNAME}\"@\"%\";
+              FLUSH PRIVILEGES;
+            "
+          '
+          echo "DB users ensured. Restarting services..."
+          sudo docker restart backend-service-congestion-1 backend-service-map-1 || true
 
       - name: Start Portainer (if not running)
         run: |


### PR DESCRIPTION
## Summary
- CD deploy 단계에 MySQL healthcheck 후 DB 유저 생성 스텝 추가
- `SEOUL_API_KEY`를 GitHub Secrets에서 제거, infisical에서 통합 주입
- 유저 생성 후 congestion, map 서비스 자동 재시작

## 변경
- `.github/workflows/cd.yml`: "Ensure MySQL DB users exist" 스텝 추가, `SEOUL_API_KEY` secrets 제거

closes #123

## Test plan
- [ ] CD 파이프라인 실행 후 service-congestion, service-map 정상 기동 확인
- [ ] `SELECT user FROM mysql.user` 에서 infisical 유저 존재 확인