### PR TITLE
fix: 배포 서버 혼잡도 API 연결 실패 수정

### DIFF
--- a/service-congestion/Dockerfile
+++ b/service-congestion/Dockerfile
@@ -25,4 +25,4 @@ WORKDIR /app
 COPY --from=builder /app/service-congestion/build/libs/*.jar app.jar
 
 EXPOSE 8082
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Djava.net.preferIPv4Stack=true", "-jar", "app.jar"]

--- a/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
@@ -10,8 +10,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.DefaultUriBuilderFactory;
 
+
+import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +32,6 @@ public class RealSeoulApiClient implements SeoulApiClient {
     private final String apiKey;
     private final ExecutorService executor;
 
-    private static final String URL_TEMPLATE =
-            "http://openapi.seoul.go.kr:8088/{apiKey}/json/citydata_ppltn/1/5/{areaName}";
     public RealSeoulApiClient(
             RestTemplateBuilder restTemplateBuilder,
             ObjectMapper objectMapper,
@@ -41,10 +40,7 @@ public class RealSeoulApiClient implements SeoulApiClient {
         if (apiKey == null || apiKey.isBlank()) {
             throw new IllegalArgumentException("seoul.api.key must be configured");
         }
-        DefaultUriBuilderFactory uriFactory = new DefaultUriBuilderFactory();
-        uriFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
         this.restTemplate = restTemplateBuilder
-                .uriTemplateHandler(uriFactory)
                 .connectTimeout(Duration.ofSeconds(5))
                 .readTimeout(Duration.ofSeconds(10))
                 .build();
@@ -87,12 +83,14 @@ public class RealSeoulApiClient implements SeoulApiClient {
 
     private CongestionApiResponse fetchOne(SeoulArea area) {
         try {
-            String response = restTemplate.getForObject(
-                    URL_TEMPLATE, String.class, apiKey, area.getName());
+            String encodedName = area.getName().replace(" ", "%20");
+            String url = "http://openapi.seoul.go.kr:8088/" + apiKey
+                    + "/json/citydata_ppltn/1/5/" + encodedName;
+            String response = restTemplate.getForObject(URI.create(url), String.class);
             return parseResponse(response, area);
         } catch (Exception e) {
-            log.warn("[SeoulApiClient] API 호출 실패 - area={}, error={}",
-                    area.getName(), e.getClass().getSimpleName());
+            log.warn("[SeoulApiClient] API 호출 실패 - area={}, error={}, message={}",
+                    area.getName(), e.getClass().getSimpleName(), e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- Alpine JRE에서 IPv6 우선 시도로 인한 서울 API 연결 타임아웃 수정 (`-Djava.net.preferIPv4Stack=true`)
- 공백 포함 장소명(잠실롯데타워 일대 등) `IllegalArgumentException` 수정 — `URI.create()`로 직접 URL 생성
- 에러 로그에 `message` 필드 추가하여 디버깅 개선
### 원인
  1. Docker 이미지가 Alpine 기반인데, Alpine의 JVM은 외부 서버 연결 시 IPv6를 먼저 시도함
  2. 서울 API 서버(openapi.seoul.go.kr:8088)는 IPv6를 지원 안 함
  3. IPv6 연결 시도 → 타임아웃(10초) → 실패 → 모든 요청 실패

## Test plan
- [ ] 배포 후 `docker logs backend-service-congestion-1 --tail 20` 으로 수집 성공 확인
- [ ] DB에 데이터 적재 확인: `SELECT COUNT(*) FROM congestion;`