### PR TITLE
fix: CD 워크플로우 머지 충돌 마커 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,7 +78,6 @@ jobs:
           done
           sudo -E infisical run --env=prod -- docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
-<<<<<<< HEAD
       - name: Ensure MySQL DB users exist
         env:
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}


### PR DESCRIPTION
## Summary
- cd.yml에 남아있던 `<<<<<<< HEAD` 머지 충돌 마커 제거
- 이로 인해 CD 워크플로우가 파싱 실패하여 배포가 안 되고 있었음

## Test plan
- [ ] CI 통과 확인
- [ ] dev → main 머지 후 CD 정상 실행 확인