### PR TITLE
fix: CD git pull 재시도 로직 추가 및 충돌 마커 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,11 @@ jobs:
       - name: Pull latest code
         run: |
           cd ~/Backend
-          git pull origin main
+          for i in 1 2 3; do
+            git pull origin main && break
+            echo "git pull failed (attempt $i/3), retrying in 10s..."
+            sleep 10
+          done
 
       - name: Pull and restart containers
         env:
@@ -78,7 +82,6 @@ jobs:
           done
           sudo -E infisical run --env=prod -- docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
-<<<<<<< HEAD
       - name: Ensure MySQL DB users exist
         env:
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}


### PR DESCRIPTION
## Summary
- git pull 실패 시 3회 재시도 (학교 클라우드 DNS 간헐적 실패 대응)
- cd.yml 충돌 마커 제거

## Test plan
- [ ] CI 통과 확인
- [ ] dev → main 머지 후 CD 정상 실행 확인