### PR TITLE
fix: Swagger UI Failed to fetch 오류 수정

### DIFF
--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
 
 server:
   port: 8082
+  forward-headers-strategy: framework
 
 management:
   endpoints:

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
 
 server:
   port: 8083
+  forward-headers-strategy: framework
 
 management:
   endpoints:

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
 
 server:
   port: 8084
+  forward-headers-strategy: framework
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- Gateway 경유 Swagger UI에서 "Try it out" 실행 시 `Failed to fetch` 오류 발생
- 원인: downstream 서비스가 Docker 내부 호스트명(`service-congestion:8082`)을 OpenAPI 서버 URL로 반환 → 브라우저에서 해석 불가
- `server.forward-headers-strategy: framework` 설정을 3개 서비스(congestion, map, mobility)에 추가하여 Gateway의 `X-Forwarded-*` 헤더를 신뢰하도록 변경

## Test plan
- [ ] 배포 후 `https://api.goseoul.today/swagger-ui/index.html`에서 혼잡도 API "Try it out" 실행하여 정상 응답 확인
- [ ] map, mobility 서비스 Swagger도 동일하게 동작 확인