### PR TITLE
fix: Gateway forward-headers-strategy 추가로 Swagger 호스트명 수정

### DIFF
--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -56,6 +56,7 @@ springdoc:
 
 server:
   port: 8080
+  forward-headers-strategy: native
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- #139 이후에도 Swagger UI Request URL이 `https://service-congestion`으로 표시되는 문제
- 원인: Gateway(WebFlux)가 Nginx의 `X-Forwarded-Host`를 인식하지 못해 downstream에 Docker 내부 호스트명 전달
- Gateway에 `server.forward-headers-strategy: native` 추가 (WebFlux는 `native`, MVC는 `framework`)

## Related
- #139, #140

## Test plan
- [ ] 배포 후 Swagger UI에서 Request URL이 `https://api.goseoul.today/api/congestion/...`로 표시되는지 확인
- [ ] "Try it out" 실행하여 정상 응답 확인