### PR TITLE
fix: Gateway forward-headers-strategy 추가로 Swagger 호스트명 수정 (#141)

### DIFF
--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -56,6 +56,7 @@ springdoc:
 
 server:
   port: 8080
+  forward-headers-strategy: native
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- #140 이후에도 Swagger Request URL이 `https://service-congestion`(Docker 내부명)으로 표시되는 문제
- Gateway(WebFlux)에 `server.forward-headers-strategy: native` 추가하여 Nginx의 `X-Forwarded-Host` 헤더를 인식하도록 수정

## Related
- #139, #140, #141

## Test plan
- [ ] 배포 후 Swagger UI에서 Request URL이 `https://api.goseoul.today/api/...`로 표시되는지 확인
- [ ] "Try it out" 실행하여 정상 응답 확인