### PR TITLE
fix: CD 파이프라인 변경된 서비스만 빌드/배포 (#146)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,15 +68,13 @@ jobs:
             add_service "service-ai" "./service-ai" "./service-ai/Dockerfile"
           fi
 
-          # infra 파일(docker-compose) 변경 시 전체 빌드
+          # infra 파일(docker-compose) 변경 시 전체 빌드 (add_service + unique_by로 중복 안전)
           if [[ "${{ steps.filter.outputs.infra }}" == "true" ]]; then
-            MATRIX='[
-              {"service":"service-gateway","context":".","dockerfile":"service-gateway/Dockerfile"},
-              {"service":"service-map","context":".","dockerfile":"service-map/Dockerfile"},
-              {"service":"service-congestion","context":".","dockerfile":"service-congestion/Dockerfile"},
-              {"service":"service-mobility","context":".","dockerfile":"service-mobility/Dockerfile"},
-              {"service":"service-ai","context":"./service-ai","dockerfile":"./service-ai/Dockerfile"}
-            ]'
+            add_service "service-gateway" "." "service-gateway/Dockerfile"
+            add_service "service-map" "." "service-map/Dockerfile"
+            add_service "service-congestion" "." "service-congestion/Dockerfile"
+            add_service "service-mobility" "." "service-mobility/Dockerfile"
+            add_service "service-ai" "./service-ai" "./service-ai/Dockerfile"
           fi
 
           # 중복 제거
@@ -137,11 +135,16 @@ jobs:
       - name: Pull latest code
         run: |
           cd ~/Backend
+          success=false
           for i in 1 2 3; do
-            git pull origin main && break
+            git pull origin main && success=true && break
             echo "git pull failed (attempt $i/3), retrying in 10s..."
             sleep 10
           done
+          if [ "$success" = false ]; then
+            echo "::error::git pull failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Pull changed images and restart
         env:
@@ -153,14 +156,24 @@ jobs:
         run: |
           cd ~/Backend
 
+          if [ -z "$CHANGED_SERVICES" ]; then
+            echo "No services to deploy, skipping."
+            exit 0
+          fi
+
           # 변경된 서비스만 pull
+          success=false
           for i in 1 2 3; do
             sudo -E infisical run --env=prod -- \
               docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-              pull $CHANGED_SERVICES && break
+              pull $CHANGED_SERVICES && success=true && break
             echo "Pull failed (attempt $i/3), retrying in 10s..."
             sleep 10
           done
+          if [ "$success" = false ]; then
+            echo "::error::docker pull failed after 3 attempts"
+            exit 1
+          fi
 
           # 변경된 서비스만 재생성 (--no-deps: 의존 컨테이너 재시작 방지)
           sudo -E infisical run --env=prod -- \


### PR DESCRIPTION
## Summary
- `dorny/paths-filter`로 변경된 모듈만 감지하여 동적 matrix 생성
- `service-common` 변경 시 Java 서비스 전체 빌드, `docker-compose` 변경 시 전체 빌드
- deploy에서 변경된 컨테이너만 pull/restart (`--no-deps`)
- 재시도 3회 실패 시 파이프라인 중단, 빈 서비스 목록 방어 코드 추가

## Test plan
- [ ] service-ai만 변경된 커밋으로 push → ai만 빌드되는지 확인
- [ ] service-common 변경 시 Java 4개 서비스 전체 빌드 확인
- [ ] docker-compose 변경 시 5개 전체 빌드 확인
- [ ] 서비스 코드 변경 없는 커밋(docs 등) → 빌드 스킵 확인