### PR TITLE
feat: Cerebras Cloud API 연동 및 areaName 파이프라인 전파

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,10 @@ services:
       - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
       - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       - MYSQL_URL=mysql+aiomysql://${CONGESTION_DB_USERNAME:-root}:${CONGESTION_DB_PASSWORD:-root}@mysql:3306/danburn_congestion
+      - AI_PROVIDER=${AI_PROVIDER:-openai}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.cerebras.ai/v1}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL:-qwen-3-235b-a22b-instruct-2507}
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/service-ai/app/ai/openai_client.py
+++ b/service-ai/app/ai/openai_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 import httpx
 
@@ -11,9 +12,10 @@ logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = (
     "당신은 서울시 실시간 혼잡도 데이터를 분석하는 전문가입니다. "
-    "각 지역의 혼잡 원인을 간결하게 분석하세요. "
+    "각 지역의 혼잡 원인을 지역 특성(상권, 교통, 관광지 등)과 "
+    "시간대 맥락(출근길, 점심시간, 퇴근길, 저녁 약속, 심야 등)을 고려하여 간결하게 분석하세요. "
     '응답은 반드시 {"results": [...]} 형태의 JSON 객체로, '
-    "각 항목에 area_code와 analysis_message 필드를 포함하세요."
+    "각 항목에 area_code, area_name, analysis_message 필드를 포함하세요."
 )
 
 
@@ -47,7 +49,15 @@ class OpenAIAnalyzer(AIAnalyzer):
 
         try:
             content = response.json()["choices"][0]["message"]["content"]
-            parsed = json.loads(content)
+            # 마크다운 코드블록 제거 방어
+            match = re.search(r'```(?:json)?\s*(.*?)```', content, re.DOTALL)
+            if match:
+                content = match.group(1)
+            parsed = json.loads(content.strip())
+            if isinstance(parsed, list):
+                parsed = {"results": parsed}
+            elif not isinstance(parsed, dict):
+                parsed = {"results": []}
         except (KeyError, IndexError, json.JSONDecodeError) as e:
             logger.error("[OpenAI] 응답 파싱 실패 - %s", e)
             raise
@@ -66,6 +76,7 @@ class OpenAIAnalyzer(AIAnalyzer):
                 continue
             results.append(
                 AnalysisResult(
+                    area_name=event.area_name,
                     area_code=area_code,
                     congestion_level=event.congestion_level,
                     analysis_message=analysis_message,

--- a/service-ai/app/ai/stub.py
+++ b/service-ai/app/ai/stub.py
@@ -8,9 +8,10 @@ class StubAnalyzer(AIAnalyzer):
     async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
         return [
             AnalysisResult(
+                area_name=e.area_name,
                 area_code=e.area_code,
                 congestion_level=e.congestion_level,
-                analysis_message=f"[Stub] {e.area_code} 지역이 {e.congestion_level} 상태입니다. "
+                analysis_message=f"[Stub] {e.area_name}({e.area_code}) 지역이 {e.congestion_level} 상태입니다. "
                                  f"인근 행사 및 출퇴근 시간대 영향으로 추정됩니다.",
                 population_time=e.population_time,
             )

--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -4,9 +4,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     # AI API
     ai_provider: str = "stub"  # "stub" | "openai"
-    openai_base_url: str = "https://api.openai.com/v1"  # 오라클 자체 호스팅 시 Cloudflare Tunnel URL로 변경 (Infisical)
-    openai_api_key: str = ""  # 오라클 AI 서버 접근 시 해당 서버의 API Key 필요 (Infisical)
-    openai_model: str = "gpt-4o-mini"
+    openai_base_url: str = "https://api.cerebras.ai/v1"
+    openai_api_key: str = ""
+    openai_model: str = "qwen-3-235b-a22b-instruct-2507"
 
     # RabbitMQ
     rabbitmq_url: str  # amqp://{user}:{pass}@{host}:{port}/

--- a/service-ai/app/models/schemas.py
+++ b/service-ai/app/models/schemas.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 
 class CongestionEvent(BaseModel):
+    area_name: str
     area_code: str
     congestion_level: str
     max_people_count: int
@@ -9,6 +10,7 @@ class CongestionEvent(BaseModel):
 
 
 class AnalysisResult(BaseModel):
+    area_name: str
     area_code: str
     congestion_level: str
     analysis_message: str

--- a/service-ai/app/rabbitmq/consumer.py
+++ b/service-ai/app/rabbitmq/consumer.py
@@ -59,6 +59,7 @@ class RabbitMQConsumer:
         try:
             body = json.loads(message.body.decode())
             event = CongestionEvent(
+                area_name=body["areaName"],
                 area_code=body["areaCode"],
                 congestion_level=body["congestionLevel"],
                 max_people_count=body["maxPeopleCount"],

--- a/service-ai/app/store/mysql_store.py
+++ b/service-ai/app/store/mysql_store.py
@@ -19,6 +19,7 @@ class AiReport(Base):
     __tablename__ = "ai_report"
 
     id = Column("ai_report_id", Integer, primary_key=True, autoincrement=True)
+    area_name = Column(String(100), nullable=False)
     area_code = Column(String(50), nullable=False, index=True)
     congestion_level = Column(String(20), nullable=False)
     analysis_message = Column(Text, nullable=False)
@@ -46,6 +47,7 @@ class MySQLStore:
                 for r in results:
                     session.add(
                         AiReport(
+                            area_name=r.area_name,
                             area_code=r.area_code,
                             congestion_level=r.congestion_level,
                             analysis_message=r.analysis_message,

--- a/service-ai/main.py
+++ b/service-ai/main.py
@@ -69,3 +69,16 @@ async def test_publish(area_code: str = "POI001", congestion_level: str = "붐�
         )
         await channel.default_exchange.publish(message, routing_key=settings.rabbitmq_queue)
     return {"status": "published", "area_code": area_code, "congestion_level": congestion_level}
+
+
+@app.post("/test/analyze")
+async def test_analyze():
+    """Cerebras API 직접 호출 테스트. 더미 이벤트 2건으로 분석 결과를 반환한다."""
+    from app.models.schemas import CongestionEvent
+
+    dummy_events = [
+        CongestionEvent(area_name="강남역", area_code="POI001", congestion_level="BUSY", max_people_count=50000, population_time="2026-04-04T14:30:00"),
+        CongestionEvent(area_name="홍대입구역", area_code="POI002", congestion_level="BUSY", max_people_count=32000, population_time="2026-04-04T14:30:00"),
+    ]
+    results = await analyzer.analyze(dummy_events)
+    return {"results": [r.model_dump() for r in results]}

--- a/service-congestion/src/main/java/com/danburn/congestion/domain/AiReport.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/domain/AiReport.java
@@ -20,6 +20,9 @@ public class AiReport extends BaseEntity {
     @Column(name = "ai_report_id")
     private Long id;
 
+    @Column(name = "area_name", nullable = false, length = 100)
+    private String areaName;
+
     @Column(name = "area_code", nullable = false, length = 50)
     private String areaCode;
 
@@ -33,7 +36,8 @@ public class AiReport extends BaseEntity {
     private String populationTime;
 
     @Builder
-    private AiReport(String areaCode, String congestionLevel, String analysisMessage, String populationTime) {
+    private AiReport(String areaName, String areaCode, String congestionLevel, String analysisMessage, String populationTime) {
+        this.areaName = areaName;
         this.areaCode = areaCode;
         this.congestionLevel = congestionLevel;
         this.analysisMessage = analysisMessage;

--- a/service-congestion/src/main/java/com/danburn/congestion/dto/CongestionRedisDto.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/dto/CongestionRedisDto.java
@@ -6,6 +6,7 @@ import java.util.List;
  * Redis에 저장되는 혼잡도 데이터 DTO
  */
 public record CongestionRedisDto(
+        String areaName,
         String areaCode,
         String congestionLevel,
         String congestionMessage,

--- a/service-congestion/src/main/java/com/danburn/congestion/event/CongestionBusyEvent.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/event/CongestionBusyEvent.java
@@ -4,6 +4,7 @@ package com.danburn.congestion.event;
  * BUSY 상승 엣지 감지 시 RabbitMQ로 발행되는 이벤트
  */
 public record CongestionBusyEvent(
+        String areaName,
         String areaCode,
         String congestionLevel,
         Integer maxPeopleCount,

--- a/service-congestion/src/main/java/com/danburn/congestion/scheduler/CongestionScheduler.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/scheduler/CongestionScheduler.java
@@ -49,6 +49,7 @@ public class CongestionScheduler {
                             : Collections.emptyList();
 
                     CongestionRedisDto dto = new CongestionRedisDto(
+                            apiResponse.areaName(),
                             apiResponse.areaCode(),
                             apiResponse.congestionLevel(),
                             apiResponse.congestionMessage(),
@@ -86,6 +87,7 @@ public class CongestionScheduler {
             try {
                 CongestionRedisDto dto = dtoMap.get(areaCode);
                 eventPublisher.publishBusyEvent(new CongestionBusyEvent(
+                        dto.areaName(),
                         dto.areaCode(),
                         dto.congestionLevel(),
                         dto.maxPeopleCount(),

--- a/service-congestion/src/test/java/com/danburn/congestion/service/CongestionServiceTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/CongestionServiceTest.java
@@ -47,7 +47,7 @@ class CongestionServiceTest {
 
     private CongestionRedisDto createRedisDto(String areaCode, String level) {
         return new CongestionRedisDto(
-                areaCode, level, "테스트 메시지",
+                "테스트장소", areaCode, level, "테스트 메시지",
                 10000, 12000, "2026-04-01 14:00",
                 List.of(new CongestionRedisDto.ForecastDto(
                         "2026-04-01 15:00", "보통", 8000, 10000
@@ -180,7 +180,7 @@ class CongestionServiceTest {
         @DisplayName("populationTime이 null이어도 저장 성공")
         void saveAllWithNullPopulationTime() {
             CongestionRedisDto dto = new CongestionRedisDto(
-                    "POI001", "여유", "메시지", 1000, 2000, null, Collections.emptyList()
+                    "테스트장소", "POI001", "여유", "메시지", 1000, 2000, null, Collections.emptyList()
             );
 
             congestionService.saveAllToDb(List.of(dto));


### PR DESCRIPTION
## Summary
- AI 서비스 외부 API를 Oracle 자체 호스팅에서 **Cerebras Cloud (`qwen-3-235b-a22b-instruct-2507`)**로 전환
- 혼잡 이벤트 파이프라인 전체에 **areaName 필드** 추가 (Java → RabbitMQ → Python → Redis/MySQL)
- AI 프롬프트에 **지역 특성 + 시간대 맥락** 분석 지시 추가
- JSON 응답 **방어 파싱** 추가
<img width="1411" height="615" alt="image" src="https://github.com/user-attachments/assets/1c8b696e-92c5-47ce-a104-cc068aa90c00" />

## Test plan
- [x] Cerebras API curl 직접 호출 테스트
- [x] Docker 환경 RabbitMQ → AI Service 배치 처리 테스트
- [x] Redis/MySQL 저장 확인 (area_name 포함)
- [x] `/test/analyze` 엔드포인트 정상 응답
- [x] Java `service-congestion:test` 통과