### PR TITLE
revert: CD 변경 감지 방식 롤백 — 전체 서비스 빌드로 복원

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,102 +5,28 @@ on:
     branches: [ main ]
 
 jobs:
-  # ── 변경된 서비스 감지 ─────────────────────────────────────────────────────
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.build-matrix.outputs.matrix }}
-      has_changes: ${{ steps.build-matrix.outputs.has_changes }}
-      services: ${{ steps.build-matrix.outputs.services }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Detect changed paths
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            common:
-              - 'service-common/**'
-            gateway:
-              - 'service-gateway/**'
-            map:
-              - 'service-map/**'
-            congestion:
-              - 'service-congestion/**'
-            mobility:
-              - 'service-mobility/**'
-            ai:
-              - 'service-ai/**'
-            infra:
-              - 'docker-compose.yml'
-              - 'docker-compose.prod.yml'
-
-      - name: Build matrix from changes
-        id: build-matrix
-        run: |
-          MATRIX="[]"
-
-          # service-common 변경 시 Java 서비스 전체 빌드
-          COMMON="${{ steps.filter.outputs.common }}"
-
-          add_service() {
-            local svc="$1" ctx="$2" dockerfile="$3"
-            MATRIX=$(echo "$MATRIX" | jq -c --arg s "$svc" --arg c "$ctx" --arg d "$dockerfile" \
-              '. + [{"service": $s, "context": $c, "dockerfile": $d}]')
-          }
-
-          if [[ "$COMMON" == "true" || "${{ steps.filter.outputs.gateway }}" == "true" ]]; then
-            add_service "service-gateway" "." "service-gateway/Dockerfile"
-          fi
-          if [[ "$COMMON" == "true" || "${{ steps.filter.outputs.map }}" == "true" ]]; then
-            add_service "service-map" "." "service-map/Dockerfile"
-          fi
-          if [[ "$COMMON" == "true" || "${{ steps.filter.outputs.congestion }}" == "true" ]]; then
-            add_service "service-congestion" "." "service-congestion/Dockerfile"
-          fi
-          if [[ "$COMMON" == "true" || "${{ steps.filter.outputs.mobility }}" == "true" ]]; then
-            add_service "service-mobility" "." "service-mobility/Dockerfile"
-          fi
-          if [[ "${{ steps.filter.outputs.ai }}" == "true" ]]; then
-            add_service "service-ai" "./service-ai" "./service-ai/Dockerfile"
-          fi
-
-          # infra 파일(docker-compose) 변경 시 전체 빌드 (add_service + unique_by로 중복 안전)
-          if [[ "${{ steps.filter.outputs.infra }}" == "true" ]]; then
-            add_service "service-gateway" "." "service-gateway/Dockerfile"
-            add_service "service-map" "." "service-map/Dockerfile"
-            add_service "service-congestion" "." "service-congestion/Dockerfile"
-            add_service "service-mobility" "." "service-mobility/Dockerfile"
-            add_service "service-ai" "./service-ai" "./service-ai/Dockerfile"
-          fi
-
-          # 중복 제거
-          MATRIX=$(echo "$MATRIX" | jq -c 'unique_by(.service)')
-
-          # 변경된 서비스 이름 목록 (deploy에서 사용)
-          SERVICES=$(echo "$MATRIX" | jq -r '.[].service' | tr '\n' ' ')
-
-          if [ "$(echo "$MATRIX" | jq 'length')" -gt 0 ]; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "matrix={\"include\":$MATRIX}" >> "$GITHUB_OUTPUT"
-          echo "services=$SERVICES" >> "$GITHUB_OUTPUT"
-          echo "🔍 Changed services: $SERVICES"
-
-  # ── 변경된 서비스만 빌드 & 푸시 ────────────────────────────────────────────
+  # ── Docker 이미지 병렬 빌드 & 푸시 (2개씩, GitHub-hosted) ──────────────────
   build-and-push:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.has_changes == 'true'
     strategy:
       max-parallel: 2
-      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+      matrix:
+        include:
+          - service: service-gateway
+            context: .
+            dockerfile: service-gateway/Dockerfile
+          - service: service-map
+            context: .
+            dockerfile: service-map/Dockerfile
+          - service: service-congestion
+            context: .
+            dockerfile: service-congestion/Dockerfile
+          - service: service-mobility
+            context: .
+            dockerfile: service-mobility/Dockerfile
+          - service: service-ai
+            context: ./service-ai
+            dockerfile: ./service-ai/Dockerfile
 
     steps:
       - uses: actions/checkout@v4
@@ -126,13 +52,10 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
-  # ── 서버 배포 (변경된 컨테이너만 재시작) ───────────────────────────────────
+  # ── 서버 배포 (Self-hosted Runner) ─────────────────────────────────────────
   deploy:
     runs-on: self-hosted
-    needs: [ detect-changes, build-and-push ]
-    
-    if: needs.detect-changes.outputs.has_changes == 'true'
-
+    needs: build-and-push
 
     steps:
       - name: Pull latest code
@@ -149,27 +72,18 @@ jobs:
             exit 1
           fi
 
-      - name: Pull changed images and restart
+      - name: Pull and restart containers
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           GF_ADMIN_USER: ${{ secrets.GF_ADMIN_USER }}
           GF_ADMIN_PASSWORD: ${{ secrets.GF_ADMIN_PASSWORD }}
           INFISICAL_TOKEN: ${{ secrets.INFISICAL_TOKEN }}
-          CHANGED_SERVICES: ${{ needs.detect-changes.outputs.services }}
         run: |
           cd ~/Backend
-
-          if [ -z "$CHANGED_SERVICES" ]; then
-            echo "No services to deploy, skipping."
-            exit 0
-          fi
-
-          # 변경된 서비스만 pull
           success=false
           for i in 1 2 3; do
             sudo -E infisical run --env=prod -- \
-              docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-              pull $CHANGED_SERVICES && success=true && break
+              docker compose -f docker-compose.yml -f docker-compose.prod.yml pull && success=true && break
             echo "Pull failed (attempt $i/3), retrying in 10s..."
             sleep 10
           done
@@ -177,13 +91,8 @@ jobs:
             echo "::error::docker pull failed after 3 attempts"
             exit 1
           fi
-
-          # 변경된 서비스만 재생성 (--no-deps: 의존 컨테이너 재시작 방지)
           sudo -E infisical run --env=prod -- \
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-            up -d --no-deps $CHANGED_SERVICES
-
-          echo "✅ Restarted: $CHANGED_SERVICES"
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
       - name: Ensure MySQL DB users exist
         env:


### PR DESCRIPTION
## Summary
- `dorny/paths-filter` 기반 변경 감지 CD를 제거하고 **전체 5개 서비스 빌드**로 롤백
- merge commit에서 변경 감지가 정상 동작하지 않아 일부 서비스만 빌드되는 문제 해결

## Test plan
- [ ] main push 시 5개 서비스 전부 빌드되는지 확인