### PR TITLE
fix: 로그 대시보드 Loki 쿼리 수정 + CD git pull 충돌 방지

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Pull latest code
         run: |
           cd ~/Backend
+          git checkout -- .
+          git clean -fd
           success=false
           for i in 1 2 3; do
             git pull origin main && success=true && break

--- a/grafana/dashboards/log-dashboard.json
+++ b/grafana/dashboards/log-dashboard.json
@@ -158,7 +158,7 @@
         "regex": "",
         "multi": true,
         "includeAll": true,
-        "allValue": ".*",
+        "allValue": ".+",
         "current": { "selected": true, "text": "All", "value": "$__all" },
         "refresh": 2,
         "sort": 1
@@ -172,7 +172,7 @@
         "regex": "",
         "multi": true,
         "includeAll": true,
-        "allValue": ".*",
+        "allValue": ".+",
         "current": { "selected": true, "text": "All", "value": "$__all" },
         "refresh": 2,
         "sort": 0


### PR DESCRIPTION
## Summary
- 로그 대시보드 `allValue`를 `.*` → `.+`로 수정 (Loki 빈 값 매칭 불허 대응)
- CD 워크플로우에 `git checkout -- . && git clean -fd` 추가하여 로컬 변경 파일로 인한 배포 실패 방지

## Test plan
- [ ] Grafana Log Dashboard에서 "All" 선택 시 parse error 없이 로그 조회 확인
- [ ] CD 파이프라인 배포 성공 확인