### PR TITLE
dev → main 통합 (v3)

### DIFF
--- a/grafana/dashboards/log-dashboard.json
+++ b/grafana/dashboards/log-dashboard.json
@@ -6,7 +6,7 @@
   "links": [],
   "panels": [
     {
-      "title": "ERROR Log Count (Last 1h)",
+      "title": "ERROR Log Count",
       "type": "stat",
       "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
       "datasource": { "type": "loki", "uid": "loki" },
@@ -36,14 +36,14 @@
       },
       "targets": [
         {
-          "expr": "sum(count_over_time({app=~\"$service\", level=\"ERROR\"} |~ \"$search\" [1h]))",
+          "expr": "sum(count_over_time({app=~\"$service\", level=\"ERROR\"} |~ \"$search\" [$__range]))",
           "legendFormat": "ERROR count",
           "refId": "A"
         }
       ]
     },
     {
-      "title": "WARN Log Count (Last 1h)",
+      "title": "WARN Log Count",
       "type": "stat",
       "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
       "datasource": { "type": "loki", "uid": "loki" },
@@ -73,7 +73,7 @@
       },
       "targets": [
         {
-          "expr": "sum(count_over_time({app=~\"$service\", level=\"WARN\"} |~ \"$search\" [1h]))",
+          "expr": "sum(count_over_time({app=~\"$service\", level=\"WARN\"} |~ \"$search\" [$__range]))",
           "legendFormat": "WARN count",
           "refId": "A"
         }
@@ -154,7 +154,8 @@
         "label": "Service",
         "type": "query",
         "datasource": { "type": "loki", "uid": "loki" },
-        "definition": "label_values(app)",
+        "definition": "label_values({app=~\".+\"}, app)",
+        "query": "label_values({app=~\".+\"}, app)",
         "regex": "",
         "multi": true,
         "includeAll": true,
@@ -168,7 +169,8 @@
         "label": "Log Level",
         "type": "query",
         "datasource": { "type": "loki", "uid": "loki" },
-        "definition": "label_values(level)",
+        "definition": "label_values({app=~\".+\"}, level)",
+        "query": "label_values({app=~\".+\"}, level)",
         "regex": "",
         "multi": true,
         "includeAll": true,

--- a/service-ai/app/observability.py
+++ b/service-ai/app/observability.py
@@ -55,7 +55,13 @@ def setup_observability(app) -> None:
     formatter = _TraceLogFormatter(fmt)
 
     # Loki 핸들러를 QueueHandler로 감싸서 이벤트 루프 차단 방지
-    loki_handler = logging_loki.LokiHandler(
+    class _LevelLokiHandler(logging_loki.LokiHandler):
+        """로그 레벨을 Loki label에 포함시키는 핸들러."""
+        def emit(self, record):
+            self.emitter.tags["level"] = record.levelname
+            super().emit(record)
+
+    loki_handler = _LevelLokiHandler(
         url=settings.loki_url,
         tags={"app": "service-ai"},
         version="1",

--- a/service-common/src/main/resources/logback-common.xml
+++ b/service-common/src/main/resources/logback-common.xml
@@ -19,7 +19,7 @@
                 <pattern>app=${APP_NAME},host=${HOSTNAME},level=%level</pattern>
             </label>
             <message>
-                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [${APP_NAME},%X{traceId:-},%X{spanId:-}] --- [%15.15t] %-40.40logger{39} : %m%n</pattern>
             </message>
             <sortByTime>true</sortByTime>
         </format>


### PR DESCRIPTION
## Summary
- 로그 대시보드 필터 쿼리 수정 (Service/Level 드롭다운 정상 동작)
- ERROR/WARN Count 패널 동적 시간 범위 적용 (`[$__range]`)
- Spring 로그에 traceId/spanId 포함 (Loki → Tempo 연동)
- AI Service LokiHandler level label 추가 (레벨 필터링 지원)

## Test plan
- [ ] CD 파이프라인 배포 성공 확인
- [ ] Grafana Log Dashboard 필터 정상 동작 확인
- [ ] 로그에서 TraceID 클릭 → Tempo 트레이스 이동 확인