### PR TITLE
fix: ERROR/WARN Count stat 패널 instant query로 변경

### DIFF
--- a/grafana/dashboards/log-dashboard.json
+++ b/grafana/dashboards/log-dashboard.json
@@ -38,7 +38,8 @@
         {
           "expr": "sum(count_over_time({app=~\"$service\", level=\"ERROR\"} |~ \"$search\" [$__range]))",
           "legendFormat": "ERROR count",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ]
     },
@@ -75,7 +76,8 @@
         {
           "expr": "sum(count_over_time({app=~\"$service\", level=\"WARN\"} |~ \"$search\" [$__range]))",
           "legendFormat": "WARN count",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ]
     },


### PR DESCRIPTION
## Summary
- ERROR/WARN Count stat 패널을 range query → instant query로 변경
- 시간 범위 변경 시 카운트가 왜곡되던 문제 해결 (step별 중복 카운트 방지)

## Test plan
- [ ] 1h/3h/6h/12h/24h 시간 범위 변경 시 카운트가 단조 증가하는지 확인