### PR TITLE
fix: 서울 API 응답 파싱 로직 수정

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
@@ -99,19 +99,17 @@ public class RealSeoulApiClient implements SeoulApiClient {
         try {
             JsonNode root = objectMapper.readTree(json);
 
-            String resultCode = root.path("RESULT.CODE").asText();
-            if (!"INFO-000".equals(resultCode)) {
+            JsonNode dataArray = root.path("SeoulRtd.citydata_ppltn");
+            if (dataArray.isMissingNode() || !dataArray.isArray() || dataArray.isEmpty()) {
+                String resultCode = root.path("RESULT").path("CODE").asText();
+                String resultMessage = root.path("RESULT").path("MESSAGE").asText();
                 log.warn("[SeoulApiClient] API 오류 응답 - area={}({}), code={}, message={}, raw={}",
-                        area.getName(), area.getCode(), resultCode, root.path("RESULT.MESSAGE").asText(),
+                        area.getName(), area.getCode(), resultCode, resultMessage,
                         json.length() > 200 ? json.substring(0, 200) + "..." : json);
                 return null;
             }
 
-            JsonNode data = root.path("SeoulRtd.citydata_ppltn").get(0);
-            if (data == null) {
-                log.warn("[SeoulApiClient] 응답 데이터 없음 - area={}({})", area.getName(), area.getCode());
-                return null;
-            }
+            JsonNode data = dataArray.get(0);
 
             List<CongestionApiResponse.ForecastResponse> forecasts = new ArrayList<>();
             JsonNode fcstNode = data.path("FCST_PPLTN");


### PR DESCRIPTION
## Summary
- 서울 API 성공 응답에 `RESULT.CODE` 필드가 없어 정상 데이터가 오류로 판정되던 버그 수정
- `SeoulRtd.citydata_ppltn` 데이터 배열 존재 여부를 먼저 확인하고, 없을 때만 에러 코드 체크하도록 변경
- 에러 응답의 `RESULT.CODE` 접근도 중첩 구조(`RESULT` → `CODE`)로 수정

## Test plan
- [x] Docker 환경에서 혼잡도 스케줄러 실행 후 수집 건수 0이 아닌지 확인
- [x] 잘못된 지역명으로 호출 시 에러 로그가 정상 출력되는지 확인