### PR TITLE
dev → main 통합: Observability, EDA, AI Service, 버그 수정

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
@@ -99,19 +99,17 @@ public class RealSeoulApiClient implements SeoulApiClient {
         try {
             JsonNode root = objectMapper.readTree(json);
 
-            String resultCode = root.path("RESULT.CODE").asText();
-            if (!"INFO-000".equals(resultCode)) {
+            JsonNode dataArray = root.path("SeoulRtd.citydata_ppltn");
+            if (dataArray.isMissingNode() || !dataArray.isArray() || dataArray.isEmpty()) {
+                String resultCode = root.path("RESULT").path("CODE").asText();
+                String resultMessage = root.path("RESULT").path("MESSAGE").asText();
                 log.warn("[SeoulApiClient] API 오류 응답 - area={}({}), code={}, message={}, raw={}",
-                        area.getName(), area.getCode(), resultCode, root.path("RESULT.MESSAGE").asText(),
+                        area.getName(), area.getCode(), resultCode, resultMessage,
                         json.length() > 200 ? json.substring(0, 200) + "..." : json);
                 return null;
             }
 
-            JsonNode data = root.path("SeoulRtd.citydata_ppltn").get(0);
-            if (data == null) {
-                log.warn("[SeoulApiClient] 응답 데이터 없음 - area={}({})", area.getName(), area.getCode());
-                return null;
-            }
+            JsonNode data = dataArray.get(0);
 
             List<CongestionApiResponse.ForecastResponse> forecasts = new ArrayList<>();
             JsonNode fcstNode = data.path("FCST_PPLTN");


### PR DESCRIPTION
## Summary
- **Observability**: 분산 트레이싱(Micrometer → OTel → Tempo), Grafana 로그 대시보드(Loki), AI Service 로깅/트레이싱
- **EDA 고도화**: RabbitMQ 양방향 EDA 전환, Exactly-Once 멱등성 구현, Shared DB 제거
- **AI Service**: Cerebras Cloud API 연동, Function Calling, 배치 처리, 혼잡 원인 분석
- **CD 파이프라인**: 변경 서비스만 빌드/배포, git pull 재시도, 롤백
- **버그 수정**: Swagger forwarded headers, Docker MTU, JPA 중복 키, 서울 API 파싱, 로그 대시보드 쿼리 등

## Changes (49 files, +1352 / -306)
- Grafana 대시보드/데이터소스 프로비저닝 추가
- service-ai: FastAPI 기반 AI 분석 서비스 구현 (RabbitMQ consumer/publisher, observability)
- service-congestion: RabbitMQ 연동, CongestionStateTracker, AiReport 도메인, API 파싱 수정
- service-gateway/map/mobility: forward-headers, tracing 설정
- CD 워크플로우 개선

## Test plan
- [ ] Docker Compose 환경에서 전체 서비스 정상 기동 확인
- [ ] 혼잡도 수집 스케줄러 동작 및 데이터 저장 확인
- [ ] RabbitMQ 이벤트 발행/소비 정상 동작 확인
- [ ] Grafana 대시보드에서 로그/메트릭/트레이스 확인