### PR TITLE
fix: Gateway CORS 쉼표 구분 origin 파싱 버그 수정

### DIFF
--- a/service-gateway/src/main/java/com/danburn/gateway/GatewayApplication.java
+++ b/service-gateway/src/main/java/com/danburn/gateway/GatewayApplication.java
@@ -2,12 +2,18 @@ package com.danburn.gateway;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import reactor.core.publisher.Mono;
 
 @SpringBootApplication
@@ -25,5 +31,34 @@ public class GatewayApplication {
                         .map(InetAddress::getHostAddress)
                         .orElse("unknown")
         );
+    }
+
+    @Bean
+    public CorsWebFilter corsWebFilter(
+            @Value("${cors.allowed-origins}") String allowedOrigins,
+            @Value("${cors.allowed-methods}") String allowedMethods,
+            @Value("${cors.allowed-headers}") String allowedHeaders) {
+        CorsConfiguration config = new CorsConfiguration();
+
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .toList();
+        config.setAllowedOrigins(origins);
+
+        List<String> methods = Arrays.stream(allowedMethods.split(","))
+                .map(String::trim)
+                .toList();
+        config.setAllowedMethods(methods);
+
+        List<String> headers = Arrays.stream(allowedHeaders.split(","))
+                .map(String::trim)
+                .toList();
+        config.setAllowedHeaders(headers);
+
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsWebFilter(source);
     }
 }

--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -7,13 +7,6 @@ spring:
       port: ${REDIS_PORT:6379}
   cloud:
     gateway:
-      globalcors:
-        cors-configurations:
-          '[/**]':
-            allowedOrigins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
-            allowedMethods: [GET, POST, PUT, DELETE, OPTIONS]
-            allowedHeaders: [Content-Type, Authorization]
-            allowCredentials: true
       default-filters:
         - name: RequestRateLimiter
           args:
@@ -71,6 +64,11 @@ springdoc:
         url: /v3/api-docs/map
       - name: 교통 & 이동수단 서비스
         url: /v3/api-docs/mobility
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+  allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+  allowed-headers: Content-Type,Authorization
 
 server:
   port: 8080


### PR DESCRIPTION
## Summary
- `globalcors` YAML 설정이 환경변수의 쉼표 구분 문자열을 단일 origin으로 인식하는 버그 수정
- `CorsWebFilter` Bean을 직접 등록하여 `split(",")` 처리로 다중 origin 지원
- CORS 관련 설정을 `cors.allowed-origins/methods/headers` 커스텀 프로퍼티로 분리

## Test plan
- [ ] `CORS_ALLOWED_ORIGINS`에 다중 origin 설정 후 각 origin에서 CORS 프리플라이트 요청 확인
- [ ] 단일 origin만 설정했을 때도 정상 동작 확인