### PR TITLE
refactor: CORS 설정을 @ConfigurationProperties로 개선

### DIFF
--- a/service-gateway/src/main/java/com/danburn/gateway/GatewayApplication.java
+++ b/service-gateway/src/main/java/com/danburn/gateway/GatewayApplication.java
@@ -2,13 +2,11 @@ package com.danburn.gateway;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.cors.CorsConfiguration;
@@ -16,7 +14,10 @@ import org.springframework.web.cors.reactive.CorsWebFilter;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import reactor.core.publisher.Mono;
 
+import com.danburn.gateway.config.CorsProperties;
+
 @SpringBootApplication
+@EnableConfigurationProperties(CorsProperties.class)
 public class GatewayApplication {
 
     public static void main(String[] args) {
@@ -34,27 +35,11 @@ public class GatewayApplication {
     }
 
     @Bean
-    public CorsWebFilter corsWebFilter(
-            @Value("${cors.allowed-origins}") String allowedOrigins,
-            @Value("${cors.allowed-methods}") String allowedMethods,
-            @Value("${cors.allowed-headers}") String allowedHeaders) {
+    public CorsWebFilter corsWebFilter(CorsProperties corsProperties) {
         CorsConfiguration config = new CorsConfiguration();
-
-        List<String> origins = Arrays.stream(allowedOrigins.split(","))
-                .map(String::trim)
-                .toList();
-        config.setAllowedOrigins(origins);
-
-        List<String> methods = Arrays.stream(allowedMethods.split(","))
-                .map(String::trim)
-                .toList();
-        config.setAllowedMethods(methods);
-
-        List<String> headers = Arrays.stream(allowedHeaders.split(","))
-                .map(String::trim)
-                .toList();
-        config.setAllowedHeaders(headers);
-
+        config.setAllowedOrigins(corsProperties.getAllowedOrigins());
+        config.setAllowedMethods(corsProperties.getAllowedMethods());
+        config.setAllowedHeaders(corsProperties.getAllowedHeaders());
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/service-gateway/src/main/java/com/danburn/gateway/config/CorsProperties.java
+++ b/service-gateway/src/main/java/com/danburn/gateway/config/CorsProperties.java
@@ -1,0 +1,37 @@
+package com.danburn.gateway.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins;
+    private List<String> allowedMethods;
+    private List<String> allowedHeaders;
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    public List<String> getAllowedMethods() {
+        return allowedMethods;
+    }
+
+    public void setAllowedMethods(List<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+}


### PR DESCRIPTION
## Summary
- `@Value` + 수동 `split(",")` 방식을 `@ConfigurationProperties`로 교체
- Spring Boot 자동 바인딩으로 쉼표 구분 환경변수를 `List<String>`으로 변환
- `CorsProperties` 설정 클래스 분리

## Test plan
- [ ] 다중 origin 환경변수 설정 후 CORS 프리플라이트 요청 확인
- [ ] 단일 origin 설정 시 정상 동작 확인