### PR TITLE
fix: Gateway CORS 환경변수 주입 경로 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
     ports:
       - "8080:8080"
     environment:
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
       - CONGESTION_SERVICE_URL=http://service-congestion:8082
       - MAP_SERVICE_URL=http://service-map:8083
       - MOBILITY_SERVICE_URL=http://service-mobility:8084


### PR DESCRIPTION
## Summary
- `docker-compose.yml`에 `CORS_ALLOWED_ORIGINS` 환경변수가 누락되어 컨테이너에 전달되지 않던 문제 수정
- `.env` 파일에서 주입받고, 미설정 시 `http://localhost:3000` 기본값 사용

## Test plan
- [ ] 서버 `.env`에 `CORS_ALLOWED_ORIGINS` 설정 후 `docker compose up -d --build service-gateway`
- [ ] `curl -i -X OPTIONS` 프리플라이트 요청으로 CORS 헤더 확인