### PR TITLE
fix: Gateway CORS 환경변수 주입 경로 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
     ports:
       - "8080:8080"
     environment:
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
       - CONGESTION_SERVICE_URL=http://service-congestion:8082
       - MAP_SERVICE_URL=http://service-map:8083
       - MOBILITY_SERVICE_URL=http://service-mobility:8084


### PR DESCRIPTION
## Summary
- `docker-compose.yml`에 `CORS_ALLOWED_ORIGINS` 환경변수 주입 경로 추가
- Infisical 등 외부 비밀키 관리 도구에서 주입받을 수 있도록 설정

## Test plan
- [x] Infisical dev 환경에서 주입받아 로컬 테스트 완료
- [x] 허용된 origin (`frontend-mauve-eta-92.vercel.app`) → 200 OK
- [x] 미허용 origin (`goseoul.today`, dev 미등록) → 403 Forbidden
- [x] API 호출 시 CORS 헤더 정상 응답 확인