### PR TITLE
fix: Cerebras API 429 에러 해결 — Rate Limiter + 로깅 (#218)

### DIFF
--- a/service-ai/app/ai/openai_client.py
+++ b/service-ai/app/ai/openai_client.py
@@ -5,6 +5,7 @@ import re
 import httpx
 
 from app.ai.interface import AIAnalyzer
+from app.ai.rate_limiter import RateLimiter
 from app.config import settings
 from app.models.schemas import AnalysisResult, CongestionEvent
 
@@ -28,12 +29,17 @@ class OpenAIAnalyzer(AIAnalyzer):
             headers={"Authorization": f"Bearer {settings.openai_api_key}"},
             timeout=httpx.Timeout(60.0, read=300.0),
         )
+        self._rate_limiter = RateLimiter(
+            max_requests=settings.rate_limit_rpm,
+            period_seconds=60.0,
+        )
 
     async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
         user_content = json.dumps(
             [e.model_dump() for e in events], ensure_ascii=False
         )
 
+        await self._rate_limiter.acquire()
         response = await self._client.post(
             "/chat/completions",
             json={

--- a/service-ai/app/ai/openai_client.py
+++ b/service-ai/app/ai/openai_client.py
@@ -51,6 +51,9 @@ class OpenAIAnalyzer(AIAnalyzer):
                 # Ollama/Qwen 호환: response_format은 OpenAI 전용이므로 프롬프트로 JSON 출력 유도
             },
         )
+        if response.status_code == 429:
+            headers = {k: v for k, v in response.headers.items() if "rate" in k.lower() or "retry" in k.lower()}
+            logger.error("[OpenAI] 429 Too Many Requests - headers=%s, body=%s", headers, response.text)
         response.raise_for_status()
 
         try:

--- a/service-ai/app/ai/rate_limiter.py
+++ b/service-ai/app/ai/rate_limiter.py
@@ -1,0 +1,42 @@
+import asyncio
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RateLimiter:
+    """토큰 버킷 기반 Rate Limiter.
+
+    Cerebras Free Tier: qwen-3-235b → 30 RPM
+    안전 마진을 두고 기본값 25 RPM 으로 설정.
+    """
+
+    def __init__(self, max_requests: int = 25, period_seconds: float = 60.0) -> None:
+        self._max_tokens = max_requests
+        self._period = period_seconds
+        self._tokens = float(max_requests)
+        self._last_refill = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """토큰을 1개 소비한다. 부족하면 충전될 때까지 대기."""
+        while True:
+            async with self._lock:
+                self._refill()
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+                wait = (1.0 - self._tokens) / (self._max_tokens / self._period)
+
+            logger.info("[RateLimiter] 속도 제한 대기 %.1f초", wait)
+            await asyncio.sleep(wait)
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        self._tokens = min(
+            self._max_tokens,
+            self._tokens + elapsed * (self._max_tokens / self._period),
+        )
+        self._last_refill = now

--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -8,6 +8,9 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     openai_model: str = "qwen-3-235b-a22b-instruct-2507"
 
+    # Rate Limit (Cerebras Free Tier: 30 RPM, 안전 마진 적용)
+    rate_limit_rpm: int = 25
+
     # RabbitMQ
     rabbitmq_url: str  # amqp://{user}:{pass}@{host}:{port}/
     rabbitmq_queue: str = "ai.congestion.analysis"

--- a/service-ai/app/rabbitmq/batch.py
+++ b/service-ai/app/rabbitmq/batch.py
@@ -9,6 +9,7 @@ from app.rabbitmq.publisher import RabbitMQPublisher
 logger = logging.getLogger(__name__)
 
 MAX_BATCH_RETRY = 2
+RETRY_BASE_DELAY = 5.0  # 초기 대기 시간 (초)
 
 
 class BatchProcessor:
@@ -76,8 +77,10 @@ class BatchProcessor:
         except Exception as e:
             self._retry_count += 1
             if self._retry_count <= MAX_BATCH_RETRY:
-                logger.warning("[BatchProcessor] AI 분석 실패 (%d/%d) - %s, %d건 재삽입",
-                               self._retry_count, MAX_BATCH_RETRY, e, len(events))
+                delay = RETRY_BASE_DELAY * (2 ** (self._retry_count - 1))
+                logger.warning("[BatchProcessor] AI 분석 실패 (%d/%d) - %s, %.0f초 후 %d건 재시도",
+                               self._retry_count, MAX_BATCH_RETRY, e, delay, len(events))
+                await asyncio.sleep(delay)
                 async with self._lock:
                     self._buffer.extend(events)
             else:

--- a/service-ai/app/rabbitmq/consumer.py
+++ b/service-ai/app/rabbitmq/consumer.py
@@ -41,7 +41,7 @@ class RabbitMQConsumer:
             try:
                 self._connection = await aio_pika.connect_robust(settings.rabbitmq_url)
                 self._channel = await self._connection.channel()
-                await self._channel.set_qos(prefetch_count=10)
+                await self._channel.set_qos(prefetch_count=1)
 
                 queue = await self._channel.declare_queue(
                     settings.rabbitmq_queue, durable=True

--- a/service-ai/app/rabbitmq/consumer.py
+++ b/service-ai/app/rabbitmq/consumer.py
@@ -41,7 +41,7 @@ class RabbitMQConsumer:
             try:
                 self._connection = await aio_pika.connect_robust(settings.rabbitmq_url)
                 self._channel = await self._connection.channel()
-                await self._channel.set_qos(prefetch_count=1)
+                await self._channel.set_qos(prefetch_count=5)
 
                 queue = await self._channel.declare_queue(
                     settings.rabbitmq_queue, durable=True


### PR DESCRIPTION
## Summary
- 토큰 버킷 기반 Rate Limiter 추가 (25 RPM, Cerebras Free Tier 30 RPM 대비 안전 마진)
- 배치 재시도에 지수 백오프 적용 (5초 → 10초, 즉시 재삽입 방지)
- 429 응답 시 rate 관련 헤더 + 본문 로깅 추가 (원인 특정용)
- RabbitMQ prefetchCount: 10 → 5 조정

## 배경
- Cerebras API에서 429 Too Many Requests 에러가 반복 발생
- 현재 분당 ~0.6회 호출로 RPM 초과는 아닌 것으로 추정
- 정확한 원인 특정을 위해 429 응답 로깅 추가

## Test plan
- [ ] 배포 후 429 에러 로그에 헤더/본문 정보가 정상 출력되는지 확인
- [ ] Rate Limiter 동작으로 429 발생 빈도 감소 확인
- [ ] 기존 AI 분석 플로우 정상 작동 확인

closes #218