### PR TITLE
chore: resolve dev→main conflict 및 dev 변경사항 main 반영

### DIFF
--- a/service-map/src/main/java/com/danburn/map/dto/response/EventResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/EventResponse.java
@@ -1,0 +1,4 @@
+package com.danburn.map.dto.response;
+
+public class EventResponse {
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/EventResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/EventResponse.java
@@ -1,4 +1,0 @@
-package com.danburn.map.dto.response;
-
-public class EventResponse {
-}

--- a/service-map/src/main/java/com/danburn/map/repository/EventJpaRepository.java
+++ b/service-map/src/main/java/com/danburn/map/repository/EventJpaRepository.java
@@ -4,6 +4,7 @@ import com.danburn.map.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,6 +21,7 @@ public interface EventJpaRepository extends JpaRepository<Event, Long> {
     @Param("longitude") Double longitude,
     @Param("radiusMeter") Double radiusMeter);
 
+  @Transactional
   void deleteByEndDateBefore(LocalDate today);
 
   Optional<Event> findByEventTitleAndPlaceAndStartDate(String eventTitle, String place, LocalDate startDate);

--- a/service-map/src/main/java/com/danburn/map/service/EventService.java
+++ b/service-map/src/main/java/com/danburn/map/service/EventService.java
@@ -1,7 +1,6 @@
 package com.danburn.map.service;
 
 import com.danburn.map.domain.Event;
-import com.danburn.map.service.EventUpsertService;
 import com.danburn.map.dto.request.SeoulCultureInfoApiRequest;
 import com.danburn.map.dto.response.SeoulCultureInfoApiResponse;
 import com.danburn.map.infra.SeoulCultureInfoApiClient;
@@ -13,7 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -31,7 +32,14 @@ public class EventService {
         LocalDate today = LocalDate.now();
 
         log.info("서울시 문화행사 API 동기화 시작");
-        
+
+        List<Event> allEvents = eventJpaRepository.findAll();
+        Map<String, Event> existingEventMap = new HashMap<>();
+        for (Event e : allEvents) {
+            String key = e.getEventTitle() + "|" + e.getPlace() + "|" + e.getStartDate();
+            existingEventMap.putIfAbsent(key, e);
+        }
+
         for (int i = 0; i < maxBatches; i++) {
             int startIndex = i * batchSize + 1;
             int endIndex = (i + 1) * batchSize;
@@ -50,7 +58,7 @@ public class EventService {
                         maxBatches = (int)Math.ceil((double)listTotalCount / batchSize);
                     }
                     List<SeoulCultureInfoApiResponse.Row> rows = response.culturalEventInfo().row();
-                    eventUpsertService.upsertEventBatch(rows, today);
+                    eventUpsertService.upsertEventBatch(rows, today, existingEventMap);
 
                     if (rows.size() < batchSize) break;
                 } else {

--- a/service-map/src/main/java/com/danburn/map/service/EventUpsertService.java
+++ b/service-map/src/main/java/com/danburn/map/service/EventUpsertService.java
@@ -12,8 +12,6 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -22,16 +20,9 @@ public class EventUpsertService {
   private final EventJpaRepository eventJpaRepository;
 
   @Transactional
-  public void upsertEventBatch(List<SeoulCultureInfoApiResponse.Row> rows, LocalDate today) {
+  public void upsertEventBatch(List<SeoulCultureInfoApiResponse.Row> rows, LocalDate today, Map<String, Event> existingEventMap) {
     int insertCount = 0;
     int updateCount = 0;
-
-    Map<String, Event> existingEventMap = new java.util.HashMap<>();
-    List<Event> allEvents = eventJpaRepository.findAll();
-    for (Event e : allEvents) {
-      String key = e.getEventTitle() + "|" + e.getPlace() + "|" + e.getStartDate();
-      existingEventMap.putIfAbsent(key, e);
-    }
 
     for (SeoulCultureInfoApiResponse.Row row : rows) {
       try {
@@ -49,6 +40,7 @@ public class EventUpsertService {
             row.inquiry(), row.orgLink(), row.mainImg(),
             row.latitude(), row.longitude()
           );
+          eventJpaRepository.save(event);
           updateCount++;
         } else {
           Event newEvent = Event.builder()

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## Summary

dev → main 머지 시 발생하는 컨플릭트를 해결한 브랜치입니다. 이 브랜치는 main을 ancestor로 가지므로 fast-forward 머지 가능합니다.

### 포함 커밋
- `745b150` Revert: 기한 지난 문화행사 삭제 메소드 @Transactional 추가 및 upsertEventBatch에서 findAll 중복 호출 제거 (#226)
- `e740ddd` chore: resolve dev conflict 문제 해결 (#231)

### 변경 파일 (4개, +16/-14)
- service-map/.../repository/EventJpaRepository.java
- service-map/.../service/EventService.java
- service-map/.../service/EventUpsertService.java
- service-map/src/main/resources/application.yml

### 검증
- 트리 hash가 origin/dev와 100% 동일 (`88062a20...`) — dev에서 검증된 코드와 비트 단위로 같음
- main이 ancestor이므로 fast-forward 가능, 컨플릭트 0

### 머지 후 작업
- dev를 새 main HEAD로 force-push하여 history 정렬 예정