### PR TITLE
fix: AI 분석 429 재발 차단 및 DLQ 기반 최종 일관성 확보 (#228)

### DIFF
--- a/service-ai/app/ai/errors.py
+++ b/service-ai/app/ai/errors.py
@@ -1,0 +1,46 @@
+"""AI 호출 실패 분류용 예외 계층.
+
+- Cerebras 429 응답: body.error.code + x-should-retry 헤더로 재시도 판정
+- NonRetriableError: 재시도 금지 → 즉시 DLQ 라우팅
+  · queue_exceeded
+  · x-should-retry: false
+- RetriableError: retry_after 초 후 재시도 가능
+  · token_quota_exceeded
+"""
+
+from __future__ import annotations
+
+
+class AIServiceError(Exception):
+    """service-ai AI 호출 오류 베이스 클래스."""
+
+    def __init__(self, error_code: str, message: str) -> None:
+        super().__init__(f"[{error_code}] {message}")
+        self.error_code = error_code
+        self.message = message
+
+
+class NonRetriableError(AIServiceError):
+    """재시도 금지 오류 → 즉시 DLQ.
+
+    대표 케이스
+    - Cerebras queue_exceeded: Free tier 큐 포화 (재시도 시 즉시 재실패)
+    - x-should-retry: false 헤더: 서버가 명시적 재시도 금지
+    """
+
+
+class RetriableError(AIServiceError):
+    """retry_after 초 후 재시도 가능 오류.
+
+    대표 케이스
+    - Cerebras token_quota_exceeded: TPM/TPD 초과 (리셋 시간까지 대기)
+    """
+
+    def __init__(
+        self,
+        error_code: str,
+        message: str,
+        retry_after: float,
+    ) -> None:
+        super().__init__(error_code, message)
+        self.retry_after = retry_after

--- a/service-ai/app/ai/openai_client.py
+++ b/service-ai/app/ai/openai_client.py
@@ -4,8 +4,9 @@ import re
 
 import httpx
 
+from app.ai.errors import NonRetriableError, RetriableError
 from app.ai.interface import AIAnalyzer
-from app.ai.rate_limiter import RateLimiter
+from app.ai.rate_limiter import RateLimiter, estimate_prompt_tokens
 from app.config import settings
 from app.models.schemas import AnalysisResult, CongestionEvent
 
@@ -19,9 +20,98 @@ SYSTEM_PROMPT = (
     "각 항목에 area_code, area_name, analysis_message 필드를 포함하세요."
 )
 
+# retry-after 헤더 누락 시 기본 대기 시간(초)
+DEFAULT_RETRY_AFTER = 60.0
+
+
+def _parse_retry_after(headers: httpx.Headers) -> float:
+    """retry-after / x-ratelimit-reset-* 헤더에서 대기 시간(초) 파싱.
+
+    지원 형식:
+    - 정수/소수 초:   ``"60"``, ``"0.12"``
+    - ``s`` 접미사:   ``"0.12s"``
+    - ``ms`` 접미사:  ``"17ms"`` (밀리초 → 초 변환)
+
+    파싱 실패(HTTP-Date, ``"1m30s"`` 등 알 수 없는 형식) → 해당 헤더 스킵 후
+    다음 폴백 헤더로 이동. 모든 헤더 실패 시 :data:`DEFAULT_RETRY_AFTER` 반환.
+
+    HTTP-Date(RFC 7231)는 의도적으로 지원하지 않습니다 — 잘못 파싱하여 수십억
+    초 대기를 유발하느니 default 60초로 fall-back 하는 편이 안전합니다.
+    """
+    for key in ("retry-after", "x-ratelimit-reset-tokens", "x-ratelimit-reset-requests"):
+        raw = headers.get(key)
+        if not raw:
+            continue
+        raw = raw.strip()
+        try:
+            if raw.endswith("ms"):
+                return max(1.0, float(raw[:-2]) / 1000.0)
+            if raw.endswith("s"):
+                return max(1.0, float(raw[:-1]))
+            return max(1.0, float(raw))
+        except ValueError:
+            # HTTP-Date 등 알 수 없는 형식 → 다음 헤더로 fall-through
+            continue
+    return DEFAULT_RETRY_AFTER
+
+
+def _extract_error_code(body_text: str) -> str:
+    """429 응답 본문에서 error.code 추출. 실패 시 빈 문자열."""
+    try:
+        body = json.loads(body_text)
+    except (json.JSONDecodeError, ValueError):
+        return ""
+    err = body.get("error") if isinstance(body, dict) else None
+    if not isinstance(err, dict):
+        return ""
+    code = err.get("code") or err.get("type") or ""
+    return str(code)
+
+
+def _classify_429(response: httpx.Response) -> Exception:
+    """429 응답 → RetriableError / NonRetriableError 분류."""
+    headers = response.headers
+    body_text = response.text or ""
+    error_code = _extract_error_code(body_text)
+    should_retry_raw = (headers.get("x-should-retry") or "").strip().lower()
+    should_retry = should_retry_raw != "false"
+
+    # 디버깅용 - 핵심 헤더 + 본문 로깅
+    rl_headers = {
+        k: v for k, v in headers.items()
+        if "rate" in k.lower() or "retry" in k.lower()
+    }
+    logger.error(
+        "[OpenAI] 429 Too Many Requests - code=%s, should_retry=%s, headers=%s, body=%s",
+        error_code or "(unknown)",
+        should_retry,
+        rl_headers,
+        body_text,
+    )
+
+    if error_code == "queue_exceeded" or not should_retry:
+        return NonRetriableError(
+            error_code=error_code or "non_retriable_429",
+            message=body_text or "429 Too Many Requests (non-retriable)",
+        )
+
+    if error_code == "token_quota_exceeded":
+        return RetriableError(
+            error_code=error_code,
+            message=body_text or "429 Too Many Requests (token quota)",
+            retry_after=_parse_retry_after(headers),
+        )
+
+    # 알 수 없는 429 → 재시도 가능으로 간주 (기본 대기)
+    return RetriableError(
+        error_code=error_code or "unknown_429",
+        message=body_text or "429 Too Many Requests",
+        retry_after=_parse_retry_after(headers),
+    )
+
 
 class OpenAIAnalyzer(AIAnalyzer):
-    """OpenAI API를 호출하여 혼잡 원인을 분석한다."""
+    """OpenAI (Cerebras) API 호출로 혼잡 원인 분석."""
 
     def __init__(self) -> None:
         self._client = httpx.AsyncClient(
@@ -30,34 +120,53 @@ class OpenAIAnalyzer(AIAnalyzer):
             timeout=httpx.Timeout(60.0, read=300.0),
         )
         self._rate_limiter = RateLimiter(
-            max_requests=settings.rate_limit_rpm,
-            period_seconds=60.0,
+            tpm_limit=settings.tpm_limit,
+            tpd_limit=settings.tpd_limit,
         )
 
     async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
         user_content = json.dumps(
             [e.model_dump() for e in events], ensure_ascii=False
         )
+        user_message = f"{user_content}\n\n결과는 Markdown 없이 순수 JSON 객체로만 응답하세요."
 
-        await self._rate_limiter.acquire()
+        # 프롬프트 토큰 사전 추정
+        # - 시스템 + 유저 메시지 + 응답 예산 경험치(배치당 약 400)
+        estimated = (
+            estimate_prompt_tokens(SYSTEM_PROMPT)
+            + estimate_prompt_tokens(user_message)
+            + 400
+        )
+
+        await self._rate_limiter.acquire(estimated)
         response = await self._client.post(
             "/chat/completions",
             json={
                 "model": settings.openai_model,
                 "messages": [
                     {"role": "system", "content": SYSTEM_PROMPT},
-                    {"role": "user", "content": f"{user_content}\n\n결과는 Markdown 없이 순수 JSON 객체로만 응답하세요."},
+                    {"role": "user", "content": user_message},
                 ],
-                # Ollama/Qwen 호환: response_format은 OpenAI 전용이므로 프롬프트로 JSON 출력 유도
+                # Ollama/Qwen 호환: response_format 미지원 → 프롬프트로 JSON 출력 유도
             },
         )
+
         if response.status_code == 429:
-            headers = {k: v for k, v in response.headers.items() if "rate" in k.lower() or "retry" in k.lower()}
-            logger.error("[OpenAI] 429 Too Many Requests - headers=%s, body=%s", headers, response.text)
+            # 실패 요청은 토큰 미소비 → 추정치 전액 환불
+            self._rate_limiter.record_actual(0, estimated)
+            raise _classify_429(response)
+
         response.raise_for_status()
 
+        payload = response.json()
+
+        # 응답 수신 후 실제 사용량으로 보정
+        usage = payload.get("usage") or {}
+        actual_total = int(usage.get("total_tokens", estimated))
+        self._rate_limiter.record_actual(actual_total, estimated)
+
         try:
-            content = response.json()["choices"][0]["message"]["content"]
+            content = payload["choices"][0]["message"]["content"]
             # 마크다운 코드블록 제거 방어
             match = re.search(r'```(?:json)?\s*(.*?)```', content, re.DOTALL)
             if match:

--- a/service-ai/app/ai/rate_limiter.py
+++ b/service-ai/app/ai/rate_limiter.py
@@ -1,42 +1,168 @@
+"""토큰 예산 기반 Rate Limiter.
+
+- Cerebras Free Tier (qwen-3-235b-a22b-instruct-2507, 2026-04 확인)
+  · TPM 60,000 / TPH 1,000,000 / TPD 1,000,000
+  · RPM 30 / RPH 900 / RPD 14,400
+- 기존 RPM 기반 구현 한계: 배치 크기 증가 시 TPM 쉽게 초과 (구조적 결함)
+- 개선: TPM + TPD 이중 leaky bucket 으로 토큰 단위 강제
+
+API
+- await limiter.acquire(estimated_tokens): 두 버킷 여유 확보까지 대기
+- limiter.record_actual(actual, estimated): 응답 수신 후 실제 사용량 보정
+"""
+
+from __future__ import annotations
+
 import asyncio
-import time
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
 
-class RateLimiter:
-    """토큰 버킷 기반 Rate Limiter.
+class _TokenBucket:
+    """단순 leaky bucket.
 
-    Cerebras Free Tier: qwen-3-235b → 30 RPM
-    안전 마진을 두고 기본값 25 RPM 으로 설정.
+    - capacity: 윈도우 내 최대 토큰 수
+    - window_seconds: 완전 충전 소요 시간(초)
+    - 누출 속도 = capacity / window_seconds (tokens/sec)
     """
 
-    def __init__(self, max_requests: int = 25, period_seconds: float = 60.0) -> None:
-        self._max_tokens = max_requests
-        self._period = period_seconds
-        self._tokens = float(max_requests)
+    def __init__(self, capacity: int, window_seconds: float, name: str) -> None:
+        self._capacity = float(capacity)
+        self._window = float(window_seconds)
+        self._available = float(capacity)
         self._last_refill = time.monotonic()
-        self._lock = asyncio.Lock()
+        self._name = name
 
-    async def acquire(self) -> None:
-        """토큰을 1개 소비한다. 부족하면 충전될 때까지 대기."""
-        while True:
-            async with self._lock:
-                self._refill()
-                if self._tokens >= 1.0:
-                    self._tokens -= 1.0
-                    return
-                wait = (1.0 - self._tokens) / (self._max_tokens / self._period)
-
-            logger.info("[RateLimiter] 속도 제한 대기 %.1f초", wait)
-            await asyncio.sleep(wait)
+    @property
+    def capacity(self) -> float:
+        return self._capacity
 
     def _refill(self) -> None:
         now = time.monotonic()
         elapsed = now - self._last_refill
-        self._tokens = min(
-            self._max_tokens,
-            self._tokens + elapsed * (self._max_tokens / self._period),
-        )
+        if elapsed <= 0:
+            return
+        refill_rate = self._capacity / self._window
+        self._available = min(self._capacity, self._available + elapsed * refill_rate)
         self._last_refill = now
+
+    def wait_time(self, tokens: float) -> float:
+        """tokens 사용 가능 시점까지 대기 시간(초). 여유 있으면 0."""
+        self._refill()
+        if self._available >= tokens:
+            return 0.0
+        deficit = tokens - self._available
+        refill_rate = self._capacity / self._window
+        return deficit / refill_rate
+
+    def consume(self, tokens: float) -> None:
+        """tokens 차감 (보정용 음수 허용)."""
+        self._refill()
+        self._available -= tokens
+        if self._available < 0:
+            logger.debug(
+                "[RateLimiter] %s 버킷 음수 진입 - available=%.0f",
+                self._name,
+                self._available,
+            )
+
+    def refund(self, tokens: float) -> None:
+        """tokens 환불 (capacity 상한 준수)."""
+        self._refill()
+        self._available = min(self._capacity, self._available + tokens)
+
+
+class RateLimiter:
+    """TPM + TPD 이중 버킷 Rate Limiter."""
+
+    def __init__(self, tpm_limit: int, tpd_limit: int) -> None:
+        self._tpm = _TokenBucket(tpm_limit, 60.0, "TPM")
+        self._tpd = _TokenBucket(tpd_limit, 24 * 60 * 60.0, "TPD")
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, estimated_tokens: int) -> None:
+        """두 버킷 모두 estimated_tokens 여유 확보까지 대기."""
+        if estimated_tokens <= 0:
+            return
+        while True:
+            async with self._lock:
+                wait_tpm = self._tpm.wait_time(estimated_tokens)
+                wait_tpd = self._tpd.wait_time(estimated_tokens)
+                wait = max(wait_tpm, wait_tpd)
+                if wait <= 0:
+                    self._tpm.consume(estimated_tokens)
+                    self._tpd.consume(estimated_tokens)
+                    return
+            logger.info(
+                "[RateLimiter] 토큰 예산 대기 %.1f초 (est=%d, tpm_wait=%.1f, tpd_wait=%.1f)",
+                wait,
+                estimated_tokens,
+                wait_tpm,
+                wait_tpd,
+            )
+            await asyncio.sleep(wait)
+
+    def record_actual(self, actual_tokens: int, estimated_tokens: int) -> None:
+        """실제 사용량과 추정치 차이 보정.
+
+        - delta > 0: 추가 차감
+        - delta < 0: 일부 환불
+        """
+        delta = actual_tokens - estimated_tokens
+        if delta == 0:
+            return
+        if delta > 0:
+            self._tpm.consume(delta)
+            self._tpd.consume(delta)
+        else:
+            self._tpm.refund(-delta)
+            self._tpd.refund(-delta)
+
+
+_TIKTOKEN_ENCODER = None
+_TIKTOKEN_FAILED = False
+
+
+def _get_tiktoken_encoder():
+    """tiktoken 인코더 지연 로드.
+
+    - TIKTOKEN_DISABLE=1: 오프라인 테스트용 강제 비활성화
+    - 정상: cl100k_base 1회 로드 후 캐시
+    - 실패: None 반환 → 폴백 경로 유도
+    """
+    global _TIKTOKEN_ENCODER, _TIKTOKEN_FAILED
+    if _TIKTOKEN_FAILED:
+        return None
+    if _TIKTOKEN_ENCODER is not None:
+        return _TIKTOKEN_ENCODER
+    import os
+
+    if os.environ.get("TIKTOKEN_DISABLE") == "1":
+        _TIKTOKEN_FAILED = True
+        return None
+    try:
+        import tiktoken
+
+        _TIKTOKEN_ENCODER = tiktoken.get_encoding("cl100k_base")
+        return _TIKTOKEN_ENCODER
+    except Exception as e:  # pragma: no cover
+        logger.warning("[RateLimiter] tiktoken 로드 실패, 휴리스틱 폴백 사용: %s", e)
+        _TIKTOKEN_FAILED = True
+        return None
+
+
+def estimate_prompt_tokens(text: str) -> int:
+    """tiktoken 기반 프롬프트 토큰 사전 추정.
+
+    - Qwen 토크나이저와 cl100k_base 불일치 무시 (record_actual 로 보정)
+    - 로드 실패 / TIKTOKEN_DISABLE=1: len(text)//4 휴리스틱 폴백
+    """
+    enc = _get_tiktoken_encoder()
+    if enc is None:
+        return max(1, len(text) // 4)
+    try:
+        return len(enc.encode(text))
+    except Exception:  # pragma: no cover
+        return max(1, len(text) // 4)

--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -2,24 +2,40 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    # AI API
+    # ── AI API ──
     ai_provider: str = "stub"  # "stub" | "openai"
     openai_base_url: str = "https://api.cerebras.ai/v1"
     openai_api_key: str = ""
     openai_model: str = "qwen-3-235b-a22b-instruct-2507"
 
-    # Rate Limit (Cerebras Free Tier: 30 RPM, 안전 마진 적용)
+    # ── Rate Limit (토큰 예산 기반) ──
+    # - Cerebras Free Tier: TPM 60,000 / TPD 1,000,000
+    # - 운영 여유 마진 적용
+    tpm_limit: int = 50_000
+    tpd_limit: int = 900_000
+    # 레거시 호환용 (구 RPM 기반 설정)
     rate_limit_rpm: int = 25
 
-    # RabbitMQ
+    # ── RabbitMQ ──
     rabbitmq_url: str  # amqp://{user}:{pass}@{host}:{port}/
     rabbitmq_queue: str = "ai.congestion.analysis"
 
-    # Batch
-    batch_window_seconds: float = 2.0
-    batch_max_size: int = 10
+    # ── RabbitMQ DLX / DLQ ──
+    # - DLX: direct, durable
+    # - DLQ: TTL 24h, max-length 10,000
+    # - 재처리 워커: 10분 주기, 사이클당 최대 50건
+    dlq_dlx_name: str = "ai.congestion.dlx"
+    rabbitmq_dlq_name: str = "ai.congestion.dlq"
+    dlq_message_ttl_ms: int = 86_400_000  # 24h
+    dlq_max_length: int = 10_000
+    dlq_reprocess_interval_seconds: int = 600  # 10분
+    dlq_reprocess_batch_max: int = 50
 
-    # Observability
+    # ── Batch ──
+    batch_window_seconds: float = 5.0
+    batch_max_size: int = 3
+
+    # ── Observability ──
     otlp_traces_url: str = "http://localhost:4318/v1/traces"
     loki_url: str = "http://localhost:3100/loki/api/v1/push"
 

--- a/service-ai/app/rabbitmq/batch.py
+++ b/service-ai/app/rabbitmq/batch.py
@@ -1,6 +1,9 @@
 import asyncio
 import logging
 
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.ai.errors import NonRetriableError, RetriableError
 from app.ai.interface import AIAnalyzer
 from app.config import settings
 from app.models.schemas import CongestionEvent
@@ -9,11 +12,19 @@ from app.rabbitmq.publisher import RabbitMQPublisher
 logger = logging.getLogger(__name__)
 
 MAX_BATCH_RETRY = 2
-RETRY_BASE_DELAY = 5.0  # 초기 대기 시간 (초)
+RETRY_BASE_DELAY = 5.0  # 초기 대기 시간(초)
+
+# 배치 버퍼 항목 타입
+BatchItem = tuple[CongestionEvent, AbstractIncomingMessage]
 
 
 class BatchProcessor:
-    """메시지를 버퍼에 모아 배치로 AI 분석 → 결과 저장한다."""
+    """메시지 버퍼 → 배치 AI 분석 → 결과 발행.
+
+    - 버퍼 항목: (event, IncomingMessage) 쌍
+    - 처리 결과에 따라 ack / nack(requeue=False) 라우팅
+    - nack(requeue=False): DLX 경유 DLQ 이동
+    """
 
     def __init__(
         self,
@@ -22,7 +33,7 @@ class BatchProcessor:
     ) -> None:
         self._analyzer = analyzer
         self._publisher = publisher
-        self._buffer: list[CongestionEvent] = []
+        self._buffer: list[BatchItem] = []
         self._retry_count: int = 0
         self._lock = asyncio.Lock()
         self._timer_task: asyncio.Task | None = None
@@ -31,8 +42,11 @@ class BatchProcessor:
     async def start(self) -> None:
         self._running = True
         self._timer_task = asyncio.create_task(self._timer_loop())
-        logger.info("[BatchProcessor] 시작 (window=%ss, max_size=%d)",
-                    settings.batch_window_seconds, settings.batch_max_size)
+        logger.info(
+            "[BatchProcessor] 시작 (window=%ss, max_size=%d)",
+            settings.batch_window_seconds,
+            settings.batch_max_size,
+        )
 
     async def stop(self) -> None:
         self._running = False
@@ -45,16 +59,15 @@ class BatchProcessor:
         # 남은 버퍼 처리
         await self._flush()
 
-    async def add(self, event: CongestionEvent) -> None:
-        should_flush = False
+    async def add(self, event: CongestionEvent, message: AbstractIncomingMessage) -> None:
+        items: list[BatchItem] | None = None
         async with self._lock:
-            self._buffer.append(event)
+            self._buffer.append((event, message))
             if len(self._buffer) >= settings.batch_max_size:
-                events = self._buffer.copy()
+                items = self._buffer.copy()
                 self._buffer.clear()
-                should_flush = True
-        if should_flush:
-            await self._process(events)
+        if items is not None:
+            await self._process(items)
 
     async def _timer_loop(self) -> None:
         while self._running:
@@ -65,30 +78,92 @@ class BatchProcessor:
         async with self._lock:
             if not self._buffer:
                 return
-            events = self._buffer.copy()
+            items = self._buffer.copy()
             self._buffer.clear()
-        await self._process(events)
+        await self._process(items)
 
-    async def _process(self, events: list[CongestionEvent]) -> None:
+    async def _ack_all(self, items: list[BatchItem]) -> None:
+        for _event, message in items:
+            try:
+                await message.ack()
+            except Exception as e:  # pragma: no cover - 방어적 로깅
+                logger.error("[BatchProcessor] ack 실패 - %s", e)
+
+    async def _dlq_all(self, items: list[BatchItem], reason: str) -> None:
+        """nack(requeue=False) → DLX 경유 DLQ 라우팅."""
+        logger.error(
+            "[BatchProcessor] %d건 DLQ 라우팅 - %s",
+            len(items),
+            reason,
+        )
+        for _event, message in items:
+            try:
+                await message.nack(requeue=False)
+            except Exception as e:  # pragma: no cover - 방어적 로깅
+                logger.error("[BatchProcessor] nack 실패 - %s", e)
+
+    async def _rebuffer(self, items: list[BatchItem]) -> None:
+        async with self._lock:
+            self._buffer.extend(items)
+
+    async def _process(self, items: list[BatchItem]) -> None:
+        if not items:
+            return
+        events = [event for event, _ in items]
         logger.info("[BatchProcessor] 배치 처리 시작 - %d건", len(events))
+
         try:
             results = await self._analyzer.analyze(events)
             self._retry_count = 0
+        except NonRetriableError as e:
+            # 재시도 금지 → 즉시 DLQ
+            await self._dlq_all(items, f"NonRetriableError: {e}")
+            self._retry_count = 0
+            return
+        except RetriableError as e:
+            # retry_after 대기 후 재버퍼링
+            logger.warning(
+                "[BatchProcessor] RetriableError - %.1f초 후 %d건 재시도 (%s)",
+                e.retry_after,
+                len(items),
+                e,
+            )
+            await asyncio.sleep(e.retry_after)
+            await self._rebuffer(items)
+            return
         except Exception as e:
             self._retry_count += 1
             if self._retry_count <= MAX_BATCH_RETRY:
                 delay = RETRY_BASE_DELAY * (2 ** (self._retry_count - 1))
-                logger.warning("[BatchProcessor] AI 분석 실패 (%d/%d) - %s, %.0f초 후 %d건 재시도",
-                               self._retry_count, MAX_BATCH_RETRY, e, delay, len(events))
+                logger.warning(
+                    "[BatchProcessor] AI 분석 실패 (%d/%d) - %s, %.0f초 후 %d건 재시도",
+                    self._retry_count,
+                    MAX_BATCH_RETRY,
+                    e,
+                    delay,
+                    len(items),
+                )
                 await asyncio.sleep(delay)
-                async with self._lock:
-                    self._buffer.extend(events)
+                await self._rebuffer(items)
             else:
-                logger.error("[BatchProcessor] AI 분석 최종 실패 - %s, %d건 폐기", e, len(events))
+                await self._dlq_all(
+                    items,
+                    f"최대 재시도 초과 ({MAX_BATCH_RETRY}회): {e}",
+                )
                 self._retry_count = 0
             return
+
+        # 분석 성공 → publish 시도
         try:
             await self._publisher.publish_all(results)
         except Exception as e:
-            logger.error("[BatchProcessor] RabbitMQ 발행 실패 - %s", e)
-        logger.info("[BatchProcessor] 배치 처리 완료 - %d건", len(results))
+            # publish 실패 → DLQ 로 라우팅 (재처리 루프에 위임)
+            await self._dlq_all(items, f"Publisher 실패: {e}")
+            return
+
+        await self._ack_all(items)
+        logger.info(
+            "[BatchProcessor] 배치 처리 완료 - 분석=%d건, 입력=%d건",
+            len(results),
+            len(items),
+        )

--- a/service-ai/app/rabbitmq/consumer.py
+++ b/service-ai/app/rabbitmq/consumer.py
@@ -4,10 +4,11 @@ import logging
 
 import aio_pika
 from aio_pika.abc import AbstractIncomingMessage
+from aio_pika.exceptions import ChannelPreconditionFailed
 
-from app.rabbitmq.batch import BatchProcessor
 from app.config import settings
 from app.models.schemas import CongestionEvent
+from app.rabbitmq.batch import BatchProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,12 @@ MAX_RECONNECT_DELAY = 30
 
 
 class RabbitMQConsumer:
-    """RabbitMQ에서 혼잡도 이벤트를 수신하여 BatchProcessor에 전달한다."""
+    """RabbitMQ 혼잡도 이벤트 수신 → BatchProcessor 전달.
+
+    - DLX/DLQ 토폴로지 선언
+    - 메인 큐: x-dead-letter-exchange 인자 포함
+    - ack/nack: BatchProcessor 담당 (여기서는 파싱 실패만 즉시 DLQ)
+    """
 
     def __init__(self, batch_processor: BatchProcessor) -> None:
         self._batch = batch_processor
@@ -35,6 +41,64 @@ class RabbitMQConsumer:
             await self._connection.close()
         logger.info("[Consumer] 종료 완료")
 
+    async def _declare_topology(self, channel: aio_pika.abc.AbstractChannel) -> aio_pika.abc.AbstractQueue:
+        """DLX, DLQ, 메인 큐 선언.
+
+        - 1) DLX (direct, durable)
+        - 2) DLQ (TTL + max-length) → DLX 에 바인딩
+        - 3) 메인 큐 (x-dead-letter-exchange 인자 포함)
+        - 기존 메인 큐가 DLX 인자 없이 존재 → PRECONDITION_FAILED 발생
+          · 대응: 경고 로그 + passive 재선언 (마이그레이션 안내)
+          · 마이그레이션: 관리 UI 에서 큐 삭제 또는 재선언 스크립트 필요
+        """
+        # 1. DLX 선언
+        dlx = await channel.declare_exchange(
+            settings.dlq_dlx_name,
+            aio_pika.ExchangeType.DIRECT,
+            durable=True,
+        )
+
+        # 2. DLQ 선언 (TTL + max-length)
+        dlq = await channel.declare_queue(
+            settings.rabbitmq_dlq_name,
+            durable=True,
+            arguments={
+                "x-message-ttl": settings.dlq_message_ttl_ms,
+                "x-max-length": settings.dlq_max_length,
+            },
+        )
+        await dlq.bind(dlx, routing_key=settings.rabbitmq_queue)
+
+        # 3. 메인 큐 선언 (DLX 인자 포함)
+        main_args = {
+            "x-dead-letter-exchange": settings.dlq_dlx_name,
+            "x-dead-letter-routing-key": settings.rabbitmq_queue,
+        }
+        try:
+            queue = await channel.declare_queue(
+                settings.rabbitmq_queue,
+                durable=True,
+                arguments=main_args,
+            )
+        except ChannelPreconditionFailed as e:
+            logger.warning(
+                "[Consumer] 메인 큐 '%s' 가 DLX 인자 없이 이미 존재합니다. "
+                "DLQ 라우팅 활성화 → RabbitMQ Management UI 에서 큐 삭제 후 재시작 필요. 원인: %s",
+                settings.rabbitmq_queue,
+                e,
+            )
+            # PRECONDITION_FAILED → 채널 닫힘 가능성 → 새 채널 확보
+            try:
+                self._channel = await self._connection.channel()  # type: ignore[union-attr]
+                await self._channel.set_qos(prefetch_count=5)
+                queue = await self._channel.declare_queue(
+                    settings.rabbitmq_queue,
+                    durable=True,
+                )
+            except Exception:
+                raise
+        return queue
+
     async def _connect(self) -> None:
         delay = 1
         while self._running:
@@ -43,12 +107,15 @@ class RabbitMQConsumer:
                 self._channel = await self._connection.channel()
                 await self._channel.set_qos(prefetch_count=5)
 
-                queue = await self._channel.declare_queue(
-                    settings.rabbitmq_queue, durable=True
-                )
+                queue = await self._declare_topology(self._channel)
                 await queue.consume(self._on_message)
 
-                logger.info("[Consumer] RabbitMQ 연결 완료 - queue=%s", settings.rabbitmq_queue)
+                logger.info(
+                    "[Consumer] RabbitMQ 연결 완료 - queue=%s, dlq=%s, dlx=%s",
+                    settings.rabbitmq_queue,
+                    settings.rabbitmq_dlq_name,
+                    settings.dlq_dlx_name,
+                )
                 return
             except Exception as e:
                 logger.warning("[Consumer] 연결 실패, %d초 후 재시도 - %s", delay, e)
@@ -56,6 +123,11 @@ class RabbitMQConsumer:
                 delay = min(delay * 2, MAX_RECONNECT_DELAY)
 
     async def _on_message(self, message: AbstractIncomingMessage) -> None:
+        """메시지 파싱 → BatchProcessor 전달.
+
+        - ack/nack 은 BatchProcessor 담당 (여기서 호출 금지)
+        - 파싱 실패만 즉시 nack(requeue=False) → DLQ
+        """
         try:
             body = json.loads(message.body.decode())
             event = CongestionEvent(
@@ -65,8 +137,12 @@ class RabbitMQConsumer:
                 max_people_count=body["maxPeopleCount"],
                 population_time=body["populationTime"],
             )
-            await self._batch.add(event)
-            await message.ack()
         except Exception as e:
-            logger.error("[Consumer] 메시지 처리 실패, 폐기 - %s", e)
-            await message.nack(requeue=False)
+            logger.error("[Consumer] 메시지 파싱 실패, DLQ 라우팅 - %s", e)
+            try:
+                await message.nack(requeue=False)
+            except Exception as nack_err:  # pragma: no cover - 방어적 로깅
+                logger.error("[Consumer] nack 실패 - %s", nack_err)
+            return
+
+        await self._batch.add(event, message)

--- a/service-ai/app/rabbitmq/dlq_worker.py
+++ b/service-ai/app/rabbitmq/dlq_worker.py
@@ -1,0 +1,132 @@
+"""DLQ 재처리 워커.
+
+- 목적: Cerebras 여유 시간대(새벽 등)에 DLQ 자동 소화 → 최종 일관성 보장
+- 동작: 일정 주기로 DLQ 메시지를 꺼내 메인 큐로 재발행
+- 실패 처리: 재발행 실패 시 DLQ 반환 (requeue=True) → 다음 주기 재시도
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import aio_pika
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class DLQWorker:
+    """DLQ → 메인 큐 재처리 워커.
+
+    - 주기: settings.dlq_reprocess_interval_seconds
+    - 사이클당 최대: settings.dlq_reprocess_batch_max 건
+    - 소비 방식: basic_get (polling)
+    - 성공: ack / 실패: nack(requeue=True)
+    """
+
+    def __init__(self) -> None:
+        self._task: asyncio.Task | None = None
+        self._running = False
+        self._connection: aio_pika.abc.AbstractRobustConnection | None = None
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info(
+            "[DLQWorker] 시작 (interval=%ds, batch_max=%d, source=%s, target=%s)",
+            settings.dlq_reprocess_interval_seconds,
+            settings.dlq_reprocess_batch_max,
+            settings.rabbitmq_dlq_name,
+            settings.rabbitmq_queue,
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._connection and not self._connection.is_closed:
+            await self._connection.close()
+            self._connection = None
+        logger.info("[DLQWorker] 종료 완료")
+
+    async def _run_loop(self) -> None:
+        try:
+            while self._running:
+                try:
+                    await asyncio.sleep(settings.dlq_reprocess_interval_seconds)
+                    if not self._running:
+                        break
+                    reprocessed = await self._reprocess_cycle()
+                    if reprocessed > 0:
+                        logger.info("[DLQWorker] 재처리 완료 - %d건", reprocessed)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.error("[DLQWorker] 사이클 실패 - %s", e)
+        except asyncio.CancelledError:
+            logger.info("[DLQWorker] 취소 신호 수신")
+            raise
+
+    async def _ensure_connection(self) -> aio_pika.abc.AbstractRobustConnection:
+        if self._connection is None or self._connection.is_closed:
+            self._connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+        return self._connection
+
+    async def _reprocess_cycle(self) -> int:
+        """한 사이클 재처리. 성공 건수 반환."""
+        connection = await self._ensure_connection()
+        channel = await connection.channel()
+        try:
+            await channel.set_qos(prefetch_count=settings.dlq_reprocess_batch_max)
+            dlq = await channel.get_queue(settings.rabbitmq_dlq_name, ensure=True)
+
+            success_count = 0
+            for _ in range(settings.dlq_reprocess_batch_max):
+                message: AbstractIncomingMessage | None = await dlq.get(
+                    timeout=5.0, fail=False
+                )
+                if message is None:
+                    break
+                if await self._try_republish(channel, message):
+                    success_count += 1
+            return success_count
+        finally:
+            if not channel.is_closed:
+                await channel.close()
+
+    async def _try_republish(
+        self,
+        channel: aio_pika.abc.AbstractChannel,
+        message: AbstractIncomingMessage,
+    ) -> bool:
+        """메인 큐로 재발행 + 성공 여부 반환."""
+        try:
+            new_message = aio_pika.Message(
+                body=message.body,
+                content_type=message.content_type or "application/json",
+                delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                headers=dict(message.headers or {}),
+            )
+            await channel.default_exchange.publish(
+                new_message,
+                routing_key=settings.rabbitmq_queue,
+            )
+            await message.ack()
+            return True
+        except Exception as e:
+            logger.error("[DLQWorker] 재발행 실패, DLQ 로 반환 - %s", e)
+            try:
+                await message.nack(requeue=True)
+            except Exception as nack_err:  # pragma: no cover - 방어적 로깅
+                logger.error("[DLQWorker] nack 실패 - %s", nack_err)
+            return False

--- a/service-ai/main.py
+++ b/service-ai/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 from contextlib import asynccontextmanager
@@ -11,6 +10,7 @@ from app.config import settings
 from app.observability import setup_observability, shutdown_observability
 from app.rabbitmq.batch import BatchProcessor
 from app.rabbitmq.consumer import RabbitMQConsumer
+from app.rabbitmq.dlq_worker import DLQWorker
 from app.rabbitmq.publisher import RabbitMQPublisher
 
 logger = logging.getLogger(__name__)
@@ -19,6 +19,7 @@ analyzer = create_analyzer()
 publisher = RabbitMQPublisher()
 batch_processor = BatchProcessor(analyzer, publisher)
 consumer = RabbitMQConsumer(batch_processor)
+dlq_worker = DLQWorker()
 
 
 @asynccontextmanager
@@ -28,11 +29,13 @@ async def lifespan(app: FastAPI):
     await publisher.connect()
     await batch_processor.start()
     await consumer.start()
+    await dlq_worker.start()
     logger.info("[AI Service] 시작 완료")
 
     yield
 
     # shutdown
+    await dlq_worker.stop()
     await consumer.stop()
     await batch_processor.stop()
     await analyzer.close()

--- a/service-ai/pytest.ini
+++ b/service-ai/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+addopts = -q

--- a/service-ai/requirements-dev.txt
+++ b/service-ai/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0
+pytest-asyncio>=0.23

--- a/service-ai/requirements.txt
+++ b/service-ai/requirements.txt
@@ -4,6 +4,7 @@ pydantic==2.10.4
 pydantic-settings==2.7.1
 httpx==0.28.1
 aio-pika==9.5.4
+tiktoken>=0.7.0
 opentelemetry-sdk>=1.25.0
 opentelemetry-exporter-otlp>=1.25.0
 opentelemetry-instrumentation-fastapi>=0.46b0

--- a/service-ai/tests/conftest.py
+++ b/service-ai/tests/conftest.py
@@ -1,0 +1,23 @@
+"""pytest 공용 설정.
+
+- service-ai 디렉터리를 sys.path 에 추가 → app.* 임포트 가능
+- RABBITMQ_URL 기본값 주입 → env 의존 Settings 로드 보장
+- TIKTOKEN_DISABLE=1 → 오프라인 환경 BPE 다운로드 차단
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# service-ai/ 디렉터리 → sys.path 등록
+SERVICE_AI_ROOT = Path(__file__).resolve().parent.parent
+if str(SERVICE_AI_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_AI_ROOT))
+
+# Settings(rabbitmq_url: str) 필수 필드 → 더미 값 주입
+os.environ.setdefault("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+os.environ.setdefault("AI_PROVIDER", "stub")
+# tiktoken 네트워크 다운로드 무한 대기 방지 → 휴리스틱 폴백 강제
+os.environ.setdefault("TIKTOKEN_DISABLE", "1")

--- a/service-ai/tests/test_batch_ack_nack.py
+++ b/service-ai/tests/test_batch_ack_nack.py
@@ -1,0 +1,177 @@
+"""app.rabbitmq.batch — BatchProcessor ack/nack/재시도 동작 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.errors import NonRetriableError, RetriableError
+from app.models.schemas import AnalysisResult, CongestionEvent
+from app.rabbitmq.batch import BatchProcessor
+
+
+class FakeMessage:
+    """aio_pika.abc.AbstractIncomingMessage 최소 더미 구현."""
+
+    def __init__(self, tag: int) -> None:
+        self.tag = tag
+        self.acked = False
+        self.nacked = False
+        self.nack_requeue: bool | None = None
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def nack(self, requeue: bool = True) -> None:
+        self.nacked = True
+        self.nack_requeue = requeue
+
+
+class FakePublisher:
+    def __init__(self, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self.published: list[AnalysisResult] = []
+
+    async def publish_all(self, results: list[AnalysisResult]) -> None:
+        if self.should_fail:
+            raise RuntimeError("publish boom")
+        self.published.extend(results)
+
+
+class FakeAnalyzer:
+    def __init__(self, behaviour: str = "ok") -> None:
+        self.behaviour = behaviour
+        self.calls = 0
+
+    async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
+        self.calls += 1
+        if self.behaviour == "non_retriable":
+            raise NonRetriableError(error_code="queue_exceeded", message="full")
+        if self.behaviour == "retriable_then_ok":
+            if self.calls == 1:
+                raise RetriableError(
+                    error_code="token_quota_exceeded",
+                    message="tpm",
+                    retry_after=0.01,
+                )
+            return [self._result(e) for e in events]
+        if self.behaviour == "unknown_always":
+            raise RuntimeError("network boom")
+        return [self._result(e) for e in events]
+
+    @staticmethod
+    def _result(event: CongestionEvent) -> AnalysisResult:
+        return AnalysisResult(
+            area_name=event.area_name,
+            area_code=event.area_code,
+            congestion_level=event.congestion_level,
+            analysis_message="ok",
+            population_time=event.population_time,
+        )
+
+
+def _event(code: str) -> CongestionEvent:
+    return CongestionEvent(
+        area_name=f"area-{code}",
+        area_code=code,
+        congestion_level="BUSY",
+        max_people_count=100,
+        population_time="2026-04-11 12:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_success_path_acks_all_messages():
+    analyzer = FakeAnalyzer("ok")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
+
+    items = [(_event("A"), FakeMessage(1)), (_event("B"), FakeMessage(2))]
+    await bp._process(list(items))
+
+    assert all(msg.acked for _, msg in items)
+    assert not any(msg.nacked for _, msg in items)
+    assert len(publisher.published) == 2
+
+
+@pytest.mark.asyncio
+async def test_non_retriable_error_nacks_to_dlq():
+    analyzer = FakeAnalyzer("non_retriable")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
+
+    items = [(_event("A"), FakeMessage(1)), (_event("B"), FakeMessage(2))]
+    await bp._process(list(items))
+
+    for _, msg in items:
+        assert msg.nacked is True
+        assert msg.nack_requeue is False  # DLX 라우팅 → requeue=False
+        assert msg.acked is False
+
+
+@pytest.mark.asyncio
+async def test_retriable_error_rebuffers_without_ack_or_nack():
+    analyzer = FakeAnalyzer("retriable_then_ok")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
+
+    msg_a = FakeMessage(1)
+    msg_b = FakeMessage(2)
+    items = [(_event("A"), msg_a), (_event("B"), msg_b)]
+    await bp._process(list(items))
+
+    # 첫 처리 → re-buffer → ack/nack 둘 다 없음
+    assert not msg_a.acked and not msg_a.nacked
+    assert not msg_b.acked and not msg_b.nacked
+    # 버퍼 재삽입 확인
+    async with bp._lock:
+        assert len(bp._buffer) == 2
+
+
+@pytest.mark.asyncio
+async def test_unknown_exception_retries_then_dlqs(monkeypatch):
+    analyzer = FakeAnalyzer("unknown_always")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
+
+    # 재시도 대기 시간 0 으로 단축
+    async def fast_sleep(_):
+        return None
+
+    monkeypatch.setattr("app.rabbitmq.batch.asyncio.sleep", fast_sleep)
+
+    msg_a = FakeMessage(1)
+    items = [(_event("A"), msg_a)]
+
+    # 1차 _process: 첫 실패 → rebuffer
+    await bp._process(list(items))
+    assert not msg_a.acked and not msg_a.nacked
+    async with bp._lock:
+        assert len(bp._buffer) == 1
+        bp._buffer.clear()
+
+    # 2차 _process: 두 번째 실패 → rebuffer
+    await bp._process(list(items))
+    assert not msg_a.acked and not msg_a.nacked
+    async with bp._lock:
+        bp._buffer.clear()
+
+    # 3차 _process: MAX_BATCH_RETRY=2 초과 → DLQ
+    await bp._process(list(items))
+    assert msg_a.nacked is True
+    assert msg_a.nack_requeue is False
+
+
+@pytest.mark.asyncio
+async def test_publisher_failure_dlqs_successful_batch():
+    """분석 성공 + publish 실패 → DLQ 라우팅."""
+    analyzer = FakeAnalyzer("ok")
+    publisher = FakePublisher(should_fail=True)
+    bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
+
+    msg = FakeMessage(1)
+    items = [(_event("A"), msg)]
+    await bp._process(list(items))
+
+    assert msg.nacked is True
+    assert msg.nack_requeue is False
+    assert msg.acked is False

--- a/service-ai/tests/test_errors.py
+++ b/service-ai/tests/test_errors.py
@@ -1,0 +1,38 @@
+"""app.ai.errors 예외 계층 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.errors import AIServiceError, NonRetriableError, RetriableError
+
+
+def test_non_retriable_error_attributes():
+    err = NonRetriableError(error_code="queue_exceeded", message="queue full")
+    assert err.error_code == "queue_exceeded"
+    assert err.message == "queue full"
+    assert "queue_exceeded" in str(err)
+    assert isinstance(err, AIServiceError)
+    assert isinstance(err, Exception)
+
+
+def test_retriable_error_attributes():
+    err = RetriableError(
+        error_code="token_quota_exceeded",
+        message="tpm exceeded",
+        retry_after=12.5,
+    )
+    assert err.error_code == "token_quota_exceeded"
+    assert err.retry_after == 12.5
+    assert isinstance(err, AIServiceError)
+    assert isinstance(err, Exception)
+
+
+def test_errors_can_be_raised_and_caught():
+    with pytest.raises(NonRetriableError) as info:
+        raise NonRetriableError(error_code="x", message="y")
+    assert info.value.error_code == "x"
+
+    with pytest.raises(RetriableError) as info2:
+        raise RetriableError(error_code="a", message="b", retry_after=1.0)
+    assert info2.value.retry_after == 1.0

--- a/service-ai/tests/test_openai_client_429.py
+++ b/service-ai/tests/test_openai_client_429.py
@@ -1,0 +1,145 @@
+"""app.ai.openai_client._classify_429 — 429 응답 분류 테스트.
+
+- httpx.Response 직접 생성 → _classify_429 호출
+- 네트워크/respx 없이 모든 분기 검증
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.ai.errors import NonRetriableError, RetriableError
+from app.ai.openai_client import _classify_429, _extract_error_code, _parse_retry_after
+
+
+def _make_response(
+    body: dict | str,
+    headers: dict | None = None,
+) -> httpx.Response:
+    body_bytes = body.encode() if isinstance(body, str) else json.dumps(body).encode()
+    return httpx.Response(
+        status_code=429,
+        headers=headers or {},
+        content=body_bytes,
+    )
+
+
+def test_queue_exceeded_is_non_retriable():
+    # queue_exceeded → 헤더 retry=true 여도 NonRetriable
+    response = _make_response(
+        {"error": {"code": "queue_exceeded", "message": "queue full"}},
+        headers={"x-should-retry": "true"},
+    )
+    err = _classify_429(response)
+    assert isinstance(err, NonRetriableError)
+    assert err.error_code == "queue_exceeded"
+
+
+def test_x_should_retry_false_is_non_retriable_even_without_code():
+    # x-should-retry: false → code 없어도 NonRetriable
+    response = _make_response(
+        {"error": {"message": "generic 429"}},
+        headers={"x-should-retry": "false"},
+    )
+    err = _classify_429(response)
+    assert isinstance(err, NonRetriableError)
+
+
+def test_token_quota_exceeded_is_retriable_with_retry_after():
+    response = _make_response(
+        {"error": {"code": "token_quota_exceeded", "message": "tpm"}},
+        headers={"retry-after": "7", "x-should-retry": "true"},
+    )
+    err = _classify_429(response)
+    assert isinstance(err, RetriableError)
+    assert err.error_code == "token_quota_exceeded"
+    assert err.retry_after == pytest.approx(7.0)
+
+
+def test_token_quota_exceeded_fallbacks_to_reset_header():
+    # retry-after 누락 → x-ratelimit-reset-tokens 폴백
+    response = _make_response(
+        {"error": {"code": "token_quota_exceeded"}},
+        headers={"x-ratelimit-reset-tokens": "12.3s"},
+    )
+    err = _classify_429(response)
+    assert isinstance(err, RetriableError)
+    assert err.retry_after == pytest.approx(12.3, abs=0.1)
+
+
+def test_unknown_429_is_retriable_with_default_wait():
+    response = _make_response("not even json", headers={})
+    err = _classify_429(response)
+    assert isinstance(err, RetriableError)
+    assert err.retry_after > 0
+
+
+def test_extract_error_code_handles_bad_json():
+    assert _extract_error_code("") == ""
+    assert _extract_error_code("not json") == ""
+    assert _extract_error_code("[]") == ""  # list → error 필드 없음
+    assert _extract_error_code('{"error": {"code": "foo"}}') == "foo"
+    assert _extract_error_code('{"error": {"type": "bar"}}') == "bar"
+
+
+def test_parse_retry_after_with_missing_headers():
+    from app.ai.openai_client import DEFAULT_RETRY_AFTER
+
+    headers = httpx.Headers({})
+    assert _parse_retry_after(headers) == DEFAULT_RETRY_AFTER
+
+
+def test_parse_retry_after_plain_seconds():
+    headers = httpx.Headers({"retry-after": "60"})
+    assert _parse_retry_after(headers) == pytest.approx(60.0)
+
+
+def test_parse_retry_after_with_s_suffix():
+    headers = httpx.Headers({"retry-after": "0.12s"})
+    # 0.12 < 1.0 → max clamp 적용
+    assert _parse_retry_after(headers) == pytest.approx(1.0)
+
+    headers = httpx.Headers({"retry-after": "12.3s"})
+    assert _parse_retry_after(headers) == pytest.approx(12.3)
+
+
+def test_parse_retry_after_with_ms_suffix():
+    # 17ms = 0.017s → max clamp로 1.0초
+    headers = httpx.Headers({"retry-after": "17ms"})
+    assert _parse_retry_after(headers) == pytest.approx(1.0)
+
+    # 5000ms = 5.0s
+    headers = httpx.Headers({"x-ratelimit-reset-tokens": "5000ms"})
+    assert _parse_retry_after(headers) == pytest.approx(5.0)
+
+
+def test_parse_retry_after_rejects_http_date():
+    """RFC 7231 HTTP-Date 형식은 잘못 파싱하느니 default로 fall-back."""
+    from app.ai.openai_client import DEFAULT_RETRY_AFTER
+
+    # 표준 HTTP-Date — float() 실패해서 다음 헤더로 넘어가야 함 (catastrophic wait 방지)
+    headers = httpx.Headers({"retry-after": "Wed, 21 Oct 2015 07:28:00 GMT"})
+    assert _parse_retry_after(headers) == DEFAULT_RETRY_AFTER
+
+    # HTTP-Date + 폴백 헤더가 유효 → 폴백 사용
+    headers = httpx.Headers({
+        "retry-after": "Wed, 21 Oct 2015 07:28:00 GMT",
+        "x-ratelimit-reset-tokens": "8s",
+    })
+    assert _parse_retry_after(headers) == pytest.approx(8.0)
+
+
+def test_parse_retry_after_rejects_compound_format():
+    """'1m30s' 같은 복합 형식은 잘못 파싱하느니 default로 fall-back."""
+    from app.ai.openai_client import DEFAULT_RETRY_AFTER
+
+    headers = httpx.Headers({"retry-after": "1m30s"})
+    assert _parse_retry_after(headers) == DEFAULT_RETRY_AFTER
+
+
+def test_parse_retry_after_strips_whitespace():
+    headers = httpx.Headers({"retry-after": "  45  "})
+    assert _parse_retry_after(headers) == pytest.approx(45.0)

--- a/service-ai/tests/test_rate_limiter_tokens.py
+++ b/service-ai/tests/test_rate_limiter_tokens.py
@@ -1,0 +1,101 @@
+"""app.ai.rate_limiter — TPM/TPD 이중 버킷 테스트."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.ai.rate_limiter import RateLimiter, _TokenBucket, estimate_prompt_tokens
+
+
+@pytest.mark.asyncio
+async def test_acquire_fast_path_under_budget():
+    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    # 여유 충분 → 즉시 반환
+    await asyncio.wait_for(limiter.acquire(100), timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_acquire_blocks_when_tpm_exhausted(monkeypatch):
+    limiter = RateLimiter(tpm_limit=100, tpd_limit=1_000_000)
+    # 전체 예산 소진
+    await limiter.acquire(100)
+
+    # 다음 요청 → 버킷 비어 대기 필요
+    # asyncio.sleep 가로채 호출 여부만 확인
+    sleep_calls: list[float] = []
+
+    original_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        # 무한 루프 방지 → 버킷 즉시 충전
+        limiter._tpm._available = 100.0
+        limiter._tpd._available = 1_000_000.0
+        await original_sleep(0)
+
+    monkeypatch.setattr("app.ai.rate_limiter.asyncio.sleep", fake_sleep)
+
+    await asyncio.wait_for(limiter.acquire(50), timeout=1.0)
+    assert len(sleep_calls) >= 1
+    assert sleep_calls[0] > 0  # 실제 대기 시간 계산 확인
+
+
+def test_record_actual_adjusts_consumed_amount():
+    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    limiter._tpm._available = 1000.0
+    limiter._tpd._available = 10_000.0
+
+    # 추정 100 / 실제 150 → 추가 50 차감
+    limiter._tpm.consume(100)
+    limiter._tpd.consume(100)
+    limiter.record_actual(actual_tokens=150, estimated_tokens=100)
+    # 초기 1000 - 100 - 50 = 850
+    assert limiter._tpm._available == pytest.approx(850.0, abs=0.5)
+    assert limiter._tpd._available == pytest.approx(9850.0, abs=0.5)
+
+
+def test_record_actual_refunds_when_overestimated():
+    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    limiter._tpm._available = 1000.0
+    limiter._tpd._available = 10_000.0
+    limiter._tpm.consume(300)
+    limiter._tpd.consume(300)
+    # 추정 300 / 실제 200 → 100 환불
+    limiter.record_actual(actual_tokens=200, estimated_tokens=300)
+    assert limiter._tpm._available == pytest.approx(800.0, abs=0.5)
+    assert limiter._tpd._available == pytest.approx(9800.0, abs=0.5)
+
+
+@pytest.mark.asyncio
+async def test_acquire_blocks_when_tpd_exhausted(monkeypatch):
+    """TPD 소진 시 TPM 여유 있어도 대기 필요."""
+    limiter = RateLimiter(tpm_limit=1_000_000, tpd_limit=100)
+    await limiter.acquire(100)
+
+    sleep_calls: list[float] = []
+    original_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        limiter._tpm._available = 1_000_000.0
+        limiter._tpd._available = 100.0
+        await original_sleep(0)
+
+    monkeypatch.setattr("app.ai.rate_limiter.asyncio.sleep", fake_sleep)
+    await asyncio.wait_for(limiter.acquire(50), timeout=1.0)
+    assert sleep_calls and sleep_calls[0] > 0
+
+
+def test_token_bucket_wait_time_calculation():
+    bucket = _TokenBucket(capacity=60, window_seconds=60.0, name="T")
+    bucket._available = 0.0
+    # 누출률 = 60 / 60 = 1 token/s → 30 토큰 대기 = 30초
+    wait = bucket.wait_time(30)
+    assert wait == pytest.approx(30.0, abs=0.1)
+
+
+def test_estimate_prompt_tokens_returns_positive():
+    assert estimate_prompt_tokens("hello world") > 0
+    assert estimate_prompt_tokens("") >= 0


### PR DESCRIPTION
## Summary

dev에 머지된 #229 (fix/#228) 변경사항을 main에 반영하는 PR입니다.

### 포함 변경
- `f5dcb0e` fix: AI 분석 429 재발 차단 및 DLQ 기반 최종 일관성 확보 (#228) (#229)

### 주요 내용 (#228 / #229 본문 요약)
- 429 응답을 `body.error.code` + `x-should-retry` 헤더로 분류해 재시도 증폭 차단
- RabbitMQ DLX/DLQ 토폴로지 + DLQWorker 도입으로 메시지 손실 0
- RPM 기반 Rate Limiter → TPM+TPD 이중 leaky bucket으로 교체 (tiktoken 사전 추정 + 사후 보정)
- `_parse_retry_after`에서 ms 단위 / HTTP-Date 형식 안전 처리 (Gemini 리뷰 반영)
- 단위 테스트 28건 통과

### 머지 가능성
- merge-base = origin/main (`59705ac`)
- main이 dev의 ancestor → fast-forward 가능, 컨플릭트 0
- (squash 머지 시 새 SHA가 생기지만 tree는 동일)

### 배포 시 주의사항 (#229 본문에서 발췌)
기존 메인 큐 `ai.congestion.analysis`에 `x-dead-letter-exchange` 인자가 없기 때문에, 배포 후 최초 기동 시 `PRECONDITION_FAILED` 발생. 코드는 경고 로그 + passive 재선언으로 장애 없이 기동하지만 DLQ 라우팅은 비활성. DLQ 활성화하려면 1회 수동 마이그레이션 필요:
1. 소비 중단 상태에서 RabbitMQ Management UI → Queues → `ai.congestion.analysis` → Delete
2. 서비스 재시작 → consumer가 DLX 인자 포함하여 큐 재선언

## Test plan
- [x] service-ai 단위 테스트 28건 통과 (Docker `pytest -q`)
- [x] PR #229의 build-ai CI 통과
- [ ] 스테이징 배포 후 DLQ 라우팅 활성화 마이그레이션 수행
- [ ] 24h 모니터링: `AI 분석 최종 실패 - N건 폐기` 로그 미발생 확인