### PR TITLE
fix: ai.congestion.analysis 큐 DLX 인자 추가로 service-ai 선언 스펙 일치

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/config/rabbitmq/RabbitMqConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/rabbitmq/RabbitMqConfig.java
@@ -3,6 +3,7 @@ package com.danburn.congestion.config.rabbitmq;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -18,6 +19,9 @@ public class RabbitMqConfig {
     public static final String AI_REPORT_ROUTING_KEY = "ai.report";
     public static final String AI_REPORT_QUEUE_NAME = "congestion.ai.report";
 
+    private static final String BUSY_QUEUE_DLX = "ai.congestion.dlx";
+    private static final String BUSY_QUEUE_DLX_ROUTING_KEY = BUSY_QUEUE_NAME;
+
     @Bean
     public TopicExchange congestionExchange() {
         return new TopicExchange(EXCHANGE_NAME);
@@ -25,7 +29,10 @@ public class RabbitMqConfig {
 
     @Bean
     public Queue congestionBusyQueue() {
-        return new Queue(BUSY_QUEUE_NAME, true);
+        return QueueBuilder.durable(BUSY_QUEUE_NAME)
+                .withArgument("x-dead-letter-exchange", BUSY_QUEUE_DLX)
+                .withArgument("x-dead-letter-routing-key", BUSY_QUEUE_DLX_ROUTING_KEY)
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
## Summary

- service-congestion 의 `ai.congestion.analysis` 큐 선언에 `x-dead-letter-exchange` / `x-dead-letter-routing-key` 인자 추가
- service-ai (`app/rabbitmq/consumer.py`) 의 main queue 선언 스펙과 완전 일치
- RMQ 재시작/재배포 시 발생하던 `PRECONDITION_FAILED(406)` 루프 원천 차단

## Context (장애 사례)

RMQ 재시작 후 service-ai 가 먼저 올라와 큐를 DLX 인자 포함으로 생성 → 뒤늦게 올라온 congestion 의 `RabbitAdmin.redeclareBeanDeclarables` 가 mismatch 로 터지면서:

1. `CachingConnectionFactory` 채널이 닫혀 **`congestion.events` → `ai.congestion.analysis` 바인딩 선언 실패** → publish 한 BUSY 이벤트가 silent drop (정방향 파손)
2. `SimpleMessageListenerContainer` 가 `FatalListenerStartupException: Mismatched queues` 로 aborted consumer → **`congestion.ai.report` 역방향 수신도 중단** (역방향 파손)

양쪽 선언 스펙을 동일하게 맞춰 레이스/재연결 어느 순서에서도 안전하도록 조정.


### 배포 순서

1. PR 머지 & CD 이미지 빌드 완료까지 대기
2. RabbitMQ Management UI 접속 → `Queues` 탭 → `ai.congestion.analysis` **Delete**
   - 또는 `rabbitmqctl delete_queue ai.congestion.analysis`
3. service-congestion + service-ai 재배포 (순서 무관, 둘 다 신버전이면 양쪽 선언 일치)
4. 검증
   - [ ] RMQ UI `ai.congestion.analysis` Features 에 `DLX: ai.congestion.dlx` 표시
   - [ ] Bindings 에 `congestion.events` → routing key `congestion.busy` 존재
   - [ ] service-congestion 로그에 `PRECONDITION_FAILED` / `Mismatched queues` 사라짐
   - [ ] service-ai 로그 `[Consumer] RabbitMQ 연결 완료` 정상 + 테스트 publish 1건 후 `[BatchProcessor] 배치 처리 시작` 확인

### 삭제 시 유실 범위

삭제 순간 큐에 남아있던 메시지는 함께 사라지지만, **재배포 완료 직후 service-ai 의 DLQWorker 가 DLQ 에 쌓인 과거 실패분을 자동 재처리**하므로 최종 일관성은 유지됩니다.

## Test plan

- [x] `./gradlew :service-congestion:compileJava` 컴파일 통과
- [ ] 로컬 docker-compose 에서 양쪽 서비스 기동 후 큐 Features 확인
- [ ] 스테이징에서 기존 큐 삭제 후 재배포 → 양방향 메시지 흐름 확인
- [ ] PRECONDITION 로그 사라짐 확인

## Related

- 이번 장애 발생 시각: 2026-04-11 14:31 KST (congestion `Shutdown Signal: channel error` 루프 발생)
- service-ai 쪽 DLX 선언: `service-ai/app/rabbitmq/consumer.py:73-76`