### PR TITLE
fix: RabbitMQ 컨테이너에 persistent volume 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-guest}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-guest}
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
       interval: 10s
@@ -211,6 +213,7 @@ services:
 
 volumes:
   mysql-data:
+  rabbitmq-data:
 
 networks:
   backend-net:


### PR DESCRIPTION
## Summary

- `docker-compose.yml` 의 `rabbitmq` 서비스에 named volume `rabbitmq-data` 를 `/var/lib/rabbitmq` 로 마운트
- 최상위 `volumes:` 에 `rabbitmq-data:` 선언 추가
- RMQ 컨테이너 재시작/재생성 시 큐/익스체인지/바인딩/DLQ 메시지가 사라지던 문제 수정

## Context (장애 연결)

2026-04-11 14:31 KST 에 발생한 `ai.congestion.analysis` 큐 PRECONDITION 장애의 **진짜 트리거**가 이거였음. 기존 `docker-compose.yml:46-60` 의 rabbitmq 서비스 정의에 `volumes:` 필드가 없어, 컨테이너 재시작 시 `/var/lib/rabbitmq` 가 빈 상태로 시작되면서:

1. durable 로 선언한 큐/익스체인지/바인딩 전부 증발
2. 재기동된 두 서비스(service-ai, service-congestion)가 각자 큐 재선언 시도 → 레이스 조건 + 스펙 불일치로 PRECONDITION_FAILED 루프 (Dan-burn-go/Backend#236 / Dan-burn-go/Backend#237 로 수정)
3. DLQ 에 쌓여있던 과거 실패 메시지도 함께 유실 → **service-ai 의 DLQWorker 기반 최종 일관성 보장이 실질적으로 깨져 있던 상태**

mysql 서비스는 이미 `mysql-data` volume 으로 같은 패턴을 쓰고 있었기 때문에 이번 수정은 동일 패턴을 rabbitmq 에도 적용하는 작업.

## ⚠️ 배포 시 주의사항

이 변경은 compose 파일 수정이라 `docker compose up -d` 로 재배포 시 **RMQ 컨테이너가 한 번 재생성됨**. 그 시점에:

- 현재 존재하는 큐/익스체인지/바인딩/DLQ 메시지 **1회 초기화** (이번만)
- 양쪽 서비스(service-congestion, service-ai)가 이미 스펙 통일된 신버전(#236/#237 반영)이므로 부팅 시 자동 재선언 → 토폴로지 자가복구
- 재배포 순간 publish 되는 이벤트 일부 유실 가능 (수용 가능 수준)
- **이번 1회만 초기화 감수하면 다음부터는 RMQ 재시작해도 상태 보존**

### 배포 순서

1. PR 머지 & 서버에서 compose 파일 반영
2. `docker compose up -d rabbitmq` → 새 volume 으로 rabbitmq 재생성
3. `docker compose restart service-congestion service-ai` → 큐 재선언
4. 검증
   - [ ] RMQ UI 에서 `ai.congestion.analysis`, `ai.congestion.dlq`, `ai.congestion.dlx`, `congestion.ai.report` 모두 표시
   - [ ] `ai.congestion.analysis` Features 에 DLX 뱃지 + Bindings 에 `congestion.events → congestion.busy`
   - [ ] service-congestion 로그에 `PRECONDITION_FAILED` 없음
   - [ ] 자연스러운 BUSY 이벤트 또는 테스트 publish 로 end-to-end 흐름 확인

## Test plan

- [x] `git diff` 로 변경 범위 + 들여쓰기 확인 (mysql-data 와 동일 패턴)
- [ ] 배포 후 RMQ 컨테이너 수동 재시작 → 큐 잔존 확인 (이번 PR 이후 최초 1회만 추가 검증)

## Related

- Dan-burn-go/Backend#236 (dev), Dan-burn-go/Backend#237 (main) — 이번 장애 1차 대응 (큐 DLX 인자 통일)
- 이 PR 은 **같은 장애의 근본 원인 수정** (1차는 증상, 이게 진짜 원인)