### PR TITLE
fix: RabbitMQ 컨테이너 hostname 고정으로 Mnesia 디렉토리 보존

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
+    hostname: rabbitmq
     ports:
       - "5672:5672"
       - "15672:15672"


### PR DESCRIPTION
## Summary

- `docker-compose.yml` 의 `rabbitmq` 서비스에 `hostname: rabbitmq` 추가
- #238 의 persistent volume 수정 보완 — 두 설정이 함께 있어야 실질적 persistence 달성

## Why (근본 원인)

RabbitMQ 는 Mnesia DB 를 `/var/lib/rabbitmq/mnesia/rabbit@<hostname>/` 경로에 저장합니다. 이 때 `<hostname>` 은 **컨테이너의 UTS namespace hostname** 을 사용하는데, Docker 는 별도 지정이 없으면 **컨테이너 ID 의 앞자리 12글자를 hostname 으로 할당**합니다.

결과적으로:

1. 첫 번째 기동: hostname = `a1b2c3d4e5f6` → `mnesia/rabbit@a1b2c3d4e5f6/` 에 데이터
2. `docker compose up -d rabbitmq` 로 재생성: hostname = `f6e5d4c3b2a1` (새 컨테이너 ID) → `mnesia/rabbit@f6e5d4c3b2a1/` 를 새로 생성, **이전 디렉토리는 volume 안에 그대로 있지만 broker 가 무시**
3. 결과: persistent volume 이 붙어있어도 실질적으로는 매번 새 빈 DB 로 시작

즉 #238 만으로는 불완전, `hostname: rabbitmq` 고정으로 RabbitMQ node name 이 항상 `rabbit@rabbitmq` 가 되어야 같은 Mnesia 디렉토리를 재사용합니다.

## Test plan

- [x] diff 확인 — `hostname: rabbitmq` 한 줄만 추가
- [ ] 배포 후 `docker compose up -d rabbitmq` 로 RMQ 재생성 → 이전 큐/상태 보존 확인 (이번 1회 검증)
- [ ] `docker exec <rabbitmq-container> hostname` 이 `rabbitmq` 출력하는지

## Related

- Dan-burn-go/Backend#238 (dev, merged), Dan-burn-go/Backend#239 (main, open) — volume 수정. 이 PR 과 함께 있어야 완성.
- Gemini code review 지적사항 반영