### PR TITLE
refactor: openai_client 토큰 예산 상수화 및 DLQWorker 첫 사이클 즉시 실행

### DIFF
--- a/service-ai/app/ai/openai_client.py
+++ b/service-ai/app/ai/openai_client.py
@@ -23,6 +23,9 @@ SYSTEM_PROMPT = (
 # retry-after 헤더 누락 시 기본 대기 시간(초)
 DEFAULT_RETRY_AFTER = 60.0
 
+# 배치당 응답 토큰 예산 경험치 (rate limiter 사전 추정용)
+RESPONSE_TOKEN_BUDGET = 400
+
 
 def _parse_retry_after(headers: httpx.Headers) -> float:
     """retry-after / x-ratelimit-reset-* 헤더에서 대기 시간(초) 파싱.
@@ -130,12 +133,10 @@ class OpenAIAnalyzer(AIAnalyzer):
         )
         user_message = f"{user_content}\n\n결과는 Markdown 없이 순수 JSON 객체로만 응답하세요."
 
-        # 프롬프트 토큰 사전 추정
-        # - 시스템 + 유저 메시지 + 응답 예산 경험치(배치당 약 400)
         estimated = (
             estimate_prompt_tokens(SYSTEM_PROMPT)
             + estimate_prompt_tokens(user_message)
-            + 400
+            + RESPONSE_TOKEN_BUDGET
         )
 
         await self._rate_limiter.acquire(estimated)

--- a/service-ai/app/rabbitmq/dlq_worker.py
+++ b/service-ai/app/rabbitmq/dlq_worker.py
@@ -63,9 +63,6 @@ class DLQWorker:
         try:
             while self._running:
                 try:
-                    await asyncio.sleep(settings.dlq_reprocess_interval_seconds)
-                    if not self._running:
-                        break
                     reprocessed = await self._reprocess_cycle()
                     if reprocessed > 0:
                         logger.info("[DLQWorker] 재처리 완료 - %d건", reprocessed)
@@ -73,6 +70,9 @@ class DLQWorker:
                     raise
                 except Exception as e:
                     logger.error("[DLQWorker] 사이클 실패 - %s", e)
+                if not self._running:
+                    break
+                await asyncio.sleep(settings.dlq_reprocess_interval_seconds)
         except asyncio.CancelledError:
             logger.info("[DLQWorker] 취소 신호 수신")
             raise


### PR DESCRIPTION
## Summary

Gemini code review 지적사항 중 2건 반영. 나머지 3건은 리팩터/설계 필요해서 별도 이슈로 트래킹 권장 (아래 참조).

## 반영 내역

### 1. `openai_client.py` — 매직 넘버 400 상수화

`estimated` 토큰 계산에서 사용되던 매직 `+ 400` 을 모듈 레벨 상수 `RESPONSE_TOKEN_BUDGET` 으로 분리. 값의 의미(배치당 응답 토큰 예산 경험치)를 이름에 반영.

동시에 같이 있던 2-line 설명 주석은 상수명이 self-documenting 해서 제거.

```python
RESPONSE_TOKEN_BUDGET = 400
...
estimated = (
    estimate_prompt_tokens(SYSTEM_PROMPT)
    + estimate_prompt_tokens(user_message)
    + RESPONSE_TOKEN_BUDGET
)
```

### 2. `dlq_worker.py` — `_run_loop` 첫 사이클 즉시 실행

기존 동작: 워커 시작 → `dlq_reprocess_interval_seconds` (기본 600초) 대기 → 첫 재처리 → ...

문제: 서비스 재기동/배포/오토스케일링이 10분 주기보다 빈번하면 DLQ 메시지가 영원히 처리되지 못할 수 있음.

변경: 작업 → sleep 순으로 순서 반전. 워커 시작 직후 1 사이클 즉시 실행되어 쌓여있던 DLQ 를 즉시 드레인. 이후 기존 주기로 반복.

graceful shutdown 은 `if not self._running: break` 를 cycle 과 sleep 사이에 배치해서 유지.

## 반영 안 한 지적사항 (별도 이슈 권장)

| # | 위치 | 이유 |
|---|---|---|
| batch.py retry_count race | HIGH | 실제 race 맞지만 영향 제한적 (재시도 횟수 빨리 소진 → DLQ → DLQWorker 재처리로 최종 일관성 유지). per-batch 재시도 상태 리팩터링 + 테스트 필요 |
| batch.py asyncio.sleep 블로킹 | MED | 타이머 루프 일시 정지 맞지만 add() 경로가 max_size 로 계속 동작. task 분리는 버퍼 lock 설계 재검토 필요 |
| dlq_worker 무한 루프 방어 | MED | 결정론적 실패 메시지의 느린 순환 루프 위험. `x-dlq-retry-count` 헤더 설계 + drop policy 필요 |

위 3건은 모두 **retry 동작 + 동시성** 영역이라 한꺼번에 재설계하는 게 나음. 이번 PR 에서 섞으면 리뷰 범위 폭증 + 회귀 위험 큼.

## Test plan

- [x] `python3 -m py_compile` 로 문법 검증 통과
- [x] diff 검토 — 함수 본문 구조 변경 없음, 순서만 반전
- [ ] 로컬 docker-compose 기동 → DLQWorker 첫 사이클 로그가 재기동 직후에 찍히는지 확인 (필요 시)

## Related

- Gemini code review on Dan-burn-go/Backend#238