### PR TITLE
feat: 대체지역 추천 mock data API 및 DTO 구현, 문화행사 mock data API 및 DTO 구현, 좌표 파싱 에러 수정

### DIFF
--- a/service-map/src/main/java/com/danburn/map/controller/AlternativeLocationController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/AlternativeLocationController.java
@@ -1,0 +1,34 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.map.dto.response.AlternativeLocationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "대체지역", description = "대체지역 추천 API")
+@RestController
+@RequestMapping("/api/map")
+public class AlternativeLocationController {
+
+    @Operation(summary = "대체지역 추천 조회", description = "혼잡 지역으로부터 거리와 분위기, 카테고리 기반으로 대체지역 3곳을 조회합니다.")
+    @GetMapping("/alternative-location")
+    public ApiResponse<List<AlternativeLocationResponse>> getAlternativeLocation(
+            @Parameter(description = "장소 코드 (예: POI009)", example = "POI009")
+            @RequestParam String areaCode) {
+
+        List<AlternativeLocationResponse> mockData = List.of(
+            new AlternativeLocationResponse("POI001", "광화문·덕수궁", 37.5759, 126.9769, 1, "여유"),
+            new AlternativeLocationResponse("POI002", "인사동·익선동", 37.5742, 126.9855, 2, "보통"),
+            new AlternativeLocationResponse("POI003", "북촌한옥마을", 37.5826, 126.9830, 3, "붐빔")
+        );
+
+        return ApiResponse.ok(mockData);
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/controller/CultureEventController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/CultureEventController.java
@@ -1,0 +1,61 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.map.dto.response.CultureEventResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "문화행사", description = "주변 문화행사 조회 API")
+@RestController
+@RequestMapping("/api/map")
+public class CultureEventController {
+
+    @Operation(summary = "주변 문화행사 조회", description = "위도/경도 기준 1km 이내 문화행사를 조회합니다.")
+    @GetMapping("/culture-events")
+    public ApiResponse<List<CultureEventResponse>> getCultureEvents(
+            @Parameter(description = "위도", example = "37.5759")
+            @RequestParam Double latitude,
+            @Parameter(description = "경도", example = "126.9769")
+            @RequestParam Double longitude) {
+
+        List<CultureEventResponse> mockData = List.of(
+            new CultureEventResponse(
+                "2026 핸드아티코리아",
+                "코엑스전시장 B홀",
+                "전시/미술",
+                LocalDate.of(2026, 8, 13), LocalDate.of(2026, 8, 16),
+                "정가 15,000원",
+                "https://handarty.co.kr/coex/visitors/guide/",
+                "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=8dd93ec4c4874b809cf11b6fa5f4b6e8&thumb=Y",
+                37.5118239121138, 127.059159043842),
+            new CultureEventResponse(
+                "2026 인터참코리아",
+                "코엑스 A홀, C홀",
+                "전시/미술",
+                LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 3),
+                "현장등록: 20,000원 (사전 등록 시, 무료 입장 가능)",
+                "https://www.intercharmkorea.com/ko-kr.html",
+                "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=5f2a4e2e793e49b987e5902a6e58cdf7&thumb=Y",
+                37.5118239121138, 127.059159043842),
+            new CultureEventResponse(
+                "[GS아트센터] 양인모 X 김치앤칩스",
+                "GS아트센터",
+                "클래식",
+                LocalDate.of(2026, 6, 30), LocalDate.of(2026, 6, 30),
+                "R 11만원, S 8만원, A 5만원",
+                "https://www.gsartscenter.com/program/detail/634",
+                "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=344dc2e128c94b82977c28aab4a1381d&thumb=Y",
+                37.5019949322814, 127.037336400239)
+        );
+
+        return ApiResponse.ok(mockData);
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/AlternativeLocationResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/AlternativeLocationResponse.java
@@ -1,0 +1,10 @@
+package com.danburn.map.dto.response;
+
+public record AlternativeLocationResponse(
+    String areaCode,
+    String locationName,
+    Double latitude,
+    Double longitude,
+    Integer priority,
+    String congestionLevel
+) {}

--- a/service-map/src/main/java/com/danburn/map/dto/response/CultureEventResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/CultureEventResponse.java
@@ -1,0 +1,16 @@
+package com.danburn.map.dto.response;
+
+import java.time.LocalDate;
+
+public record CultureEventResponse(
+    String title,
+    String place,
+    String codename,
+    LocalDate startDate,
+    LocalDate endDate,
+    String useFee,
+    String orgLink,
+    String mainImg,
+    Double latitude,
+    Double longitude
+) {}

--- a/service-map/src/main/java/com/danburn/map/dto/response/EventResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/EventResponse.java
@@ -1,4 +1,0 @@
-package com.danburn.map.dto.response;
-
-public class EventResponse {
-}

--- a/service-map/src/main/java/com/danburn/map/dto/response/SeoulCultureInfoApiResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/SeoulCultureInfoApiResponse.java
@@ -22,7 +22,7 @@ public record SeoulCultureInfoApiResponse(
             @JsonProperty("PROGRAM") String description,
             @JsonProperty("ORG_LINK") String orgLink,
             @JsonProperty("MAIN_IMG") String mainImg,
-            @JsonProperty("LAT") Double latitude,
-            @JsonProperty("LOT") Double longitude
+            @JsonProperty("LAT") String latitude,
+            @JsonProperty("LOT") String longitude
     ) {}
 }

--- a/service-map/src/main/java/com/danburn/map/service/EventUpsertService.java
+++ b/service-map/src/main/java/com/danburn/map/service/EventUpsertService.java
@@ -33,12 +33,14 @@ public class EventUpsertService {
 
         String mapKey = row.title() + "|" + row.place() + "|" + startDate;
         Event event = existingEventMap.get(mapKey);
+        Double parsedLatitude = parseCoordinate(row.latitude());
+        Double parsedLongitude = parseCoordinate(row.longitude());
 
         if (event != null) {
           event.updateDetails(
             row.description(), endDate, row.codename(), row.useFee(),
             row.inquiry(), row.orgLink(), row.mainImg(),
-            row.latitude(), row.longitude()
+            parsedLatitude, parsedLongitude
           );
           eventJpaRepository.save(event);
           updateCount++;
@@ -54,8 +56,8 @@ public class EventUpsertService {
             .useFee(row.useFee())
             .orgLink(row.orgLink())
             .mainImg(row.mainImg())
-            .latitude(row.latitude())
-            .longitude(row.longitude())
+            .latitude(parsedLatitude)
+            .longitude(parsedLongitude)
             .build();
           eventJpaRepository.save(newEvent);
 
@@ -76,6 +78,18 @@ public class EventUpsertService {
       return LocalDate.parse(dateStr.substring(0, 10));
     } catch (DateTimeParseException e) {
       log.debug("날짜 파싱 실패 (데이터: {}): {}", dateStr, e.getMessage());
+      return null;
+    }
+  }
+
+  private Double parseCoordinate(String value) {
+    if (value == null || value.isBlank()) return null;
+    try {
+      int tildeIdx = value.indexOf('~');
+      String cleaned = tildeIdx >= 0 ? value.substring(0, tildeIdx) : value;
+      return Double.parseDouble(cleaned.trim());
+    } catch (NumberFormatException e) {
+      log.debug("좌표 파싱 실패 (데이터: {}): {}", value, e.getMessage());
       return null;
     }
   }

--- a/service-map/src/main/java/com/danburn/map/service/EventUpsertService.java
+++ b/service-map/src/main/java/com/danburn/map/service/EventUpsertService.java
@@ -40,7 +40,8 @@ public class EventUpsertService {
           event.updateDetails(
             row.description(), endDate, row.codename(), row.useFee(),
             row.inquiry(), row.orgLink(), row.mainImg(),
-            parsedLatitude, parsedLongitude
+            (parsedLatitude != null && parsedLongitude != null) ? parsedLatitude : event.getLatitude(),
+            (parsedLatitude != null && parsedLongitude != null) ? parsedLongitude : event.getLongitude()
           );
           eventJpaRepository.save(event);
           updateCount++;
@@ -89,7 +90,7 @@ public class EventUpsertService {
       String cleaned = tildeIdx >= 0 ? value.substring(0, tildeIdx) : value;
       return Double.parseDouble(cleaned.trim());
     } catch (NumberFormatException e) {
-      log.debug("좌표 파싱 실패 (데이터: {}): {}", value, e.getMessage());
+      log.warn("좌표 파싱 실패 (데이터: {}): {}", value, e.getMessage());
       return null;
     }
   }

--- a/service-map/src/main/java/com/danburn/map/service/LocationCodeMapper.java
+++ b/service-map/src/main/java/com/danburn/map/service/LocationCodeMapper.java
@@ -31,7 +31,6 @@ public class LocationCodeMapper {
         log.info("총 {}개의 Location Area Code가 로드되었습니다.", areaCodeToIdMap.size());
     }
 
-    // 외부 서비스(Service)에서 호출할 매핑 메서드
     public Optional<Long> getLocationIdByAreaCode(String apiAreaCode) {
         return Optional.ofNullable(areaCodeToIdMap.get(apiAreaCode));
     }

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
작업 내용

- [x]  대체지역 추천 API  구현 (GET /api/map/alternative-location)
- [x] 주변 문화행사 조회 API 구현 (GET /api/map/culture-events)
- [x] 서울시 문화행사 API 좌표값 파싱 오류 수정 (LAT/LOT 필드 Double → String`변환)
- [x] 좌표 파싱 실패 시 기존 DB 값 유지하도록 수정 (위도·경도 둘 다 유효할 때만 업데이트)
- [x] ddl-auto create → update 변경


