### PR TITLE
feat: 대체지역 추천 API 실제 구현 및 WebClient 혼잡도 연동 (#258)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,9 +134,12 @@ services:
       - OTLP_TRACES_URL=http://observability:4318/v1/traces
       - LOKI_URL=http://observability:3100/loki/api/v1/push
       - SEOUL_API_KEY=${SEOUL_API_KEY}
+      - CONGESTION_SERVICE_URL=http://service-congestion:8082
     depends_on:
       mysql:
         condition: service_healthy
+      service-congestion:
+        condition: service_started
     networks:
       - backend-net
 

--- a/service-map/build.gradle
+++ b/service-map/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':service-common')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'

--- a/service-map/src/main/java/com/danburn/map/controller/AlternativeLocationController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/AlternativeLocationController.java
@@ -2,9 +2,11 @@ package com.danburn.map.controller;
 
 import com.danburn.common.response.ApiResponse;
 import com.danburn.map.dto.response.AlternativeLocationResponse;
+import com.danburn.map.service.AlternativeLocationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,7 +17,10 @@ import java.util.List;
 @Tag(name = "대체지역", description = "대체지역 추천 API")
 @RestController
 @RequestMapping("/api/map")
+@RequiredArgsConstructor
 public class AlternativeLocationController {
+
+    private final AlternativeLocationService alternativeLocationService;
 
     @Operation(summary = "대체지역 추천 조회", description = "혼잡 지역으로부터 거리와 분위기, 카테고리 기반으로 대체지역 3곳을 조회합니다.")
     @GetMapping("/alternative-location")
@@ -23,12 +28,6 @@ public class AlternativeLocationController {
             @Parameter(description = "장소 코드 (예: POI009)", example = "POI009")
             @RequestParam String areaCode) {
 
-        List<AlternativeLocationResponse> mockData = List.of(
-            new AlternativeLocationResponse("POI001", "광화문·덕수궁", 37.5759, 126.9769, 1, "여유"),
-            new AlternativeLocationResponse("POI002", "인사동·익선동", 37.5742, 126.9855, 2, "보통"),
-            new AlternativeLocationResponse("POI003", "북촌한옥마을", 37.5826, 126.9830, 3, "붐빔")
-        );
-
-        return ApiResponse.ok(mockData);
+        return ApiResponse.ok(alternativeLocationService.getAlternativeLocations(areaCode));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
+++ b/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGlobalException(GlobalException e) {
+        log.error("GlobalException: status={}, message={}", e.getStatus(), e.getMessage());
+        return ResponseEntity.status(e.getStatus())
+                .body(ApiResponse.error(e.getStatus(), e.getMessage()));
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/CongestionApiResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/CongestionApiResponse.java
@@ -1,0 +1,12 @@
+package com.danburn.map.dto.response;
+
+public record CongestionApiResponse(
+        int status,
+        String message,
+        CongestionData data
+) {
+    public record CongestionData(
+            String areaCode,
+            String congestionLevel
+    ) {}
+}

--- a/service-map/src/main/java/com/danburn/map/infra/CongestionApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/CongestionApiClient.java
@@ -1,0 +1,34 @@
+package com.danburn.map.infra;
+
+import com.danburn.map.dto.response.CongestionApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class CongestionApiClient {
+
+    private final WebClient webClient;
+
+    public CongestionApiClient(@Value("${congestion.service.url}") String congestionServiceUrl) {
+        this.webClient = WebClient.builder()
+                .baseUrl(congestionServiceUrl)
+                .build();
+    }
+
+    public Mono<String> getCongestionLevel(String areaCode) {
+        return webClient.get()
+                .uri("/api/congestion/{areaCode}", areaCode)
+                .retrieve()
+                .bodyToMono(CongestionApiResponse.class)
+                .mapNotNull(response ->
+                        response.data() != null ? response.data().congestionLevel() : null)
+                .onErrorResume(e -> {
+                    log.warn("혼잡도 조회 실패 - areaCode: {}, error: {}", areaCode, e.getMessage());
+                    return Mono.empty();
+                });
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/service/AlternativeLocationService.java
+++ b/service-map/src/main/java/com/danburn/map/service/AlternativeLocationService.java
@@ -1,0 +1,71 @@
+package com.danburn.map.service;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.map.domain.AlternativeLocation;
+import com.danburn.map.dto.response.AlternativeLocationResponse;
+import com.danburn.map.infra.CongestionApiClient;
+import com.danburn.map.repository.AlternativeLocationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlternativeLocationService {
+
+    private static final Map<String, Integer> CONGESTION_ORDER = Map.of(
+            "여유", 1,
+            "보통", 2,
+            "약간 붐빔", 3,
+            "붐빔", 4
+    );
+
+    private final LocationCodeMapper locationCodeMapper;
+    private final AlternativeLocationJpaRepository alternativeLocationJpaRepository;
+    private final CongestionApiClient congestionApiClient;
+
+    @Transactional(readOnly = true)
+    public List<AlternativeLocationResponse> getAlternativeLocations(String areaCode) {
+        Long locationId = locationCodeMapper.getLocationIdByAreaCode(areaCode)
+                .orElseThrow(() -> new GlobalException(404, "존재하지 않는 지역 코드입니다: " + areaCode));
+
+        List<AlternativeLocation> alternatives = alternativeLocationJpaRepository
+                .findAlternativeLocationIdOrderByPriority(locationId);
+
+        List<AlternativeLocationResponse> responses = Flux.fromIterable(alternatives)
+                .flatMap(alt -> {
+                    String altAreaCode = alt.getAlternativeLocation().getApiAreaCode();
+                    String locationName = alt.getAlternativeLocation().getLocationName();
+                    Double latitude = alt.getAlternativeLocation().getLatitude();
+                    Double longitude = alt.getAlternativeLocation().getLongitude();
+                    Integer priority = alt.getPriority();
+
+                    return congestionApiClient.getCongestionLevel(altAreaCode)
+                            .map(congestionLevel -> new AlternativeLocationResponse(
+                                    altAreaCode, locationName, latitude, longitude, priority, congestionLevel
+                            ))
+                            .switchIfEmpty(Mono.fromSupplier(() -> new AlternativeLocationResponse(
+                                    altAreaCode, locationName, latitude, longitude, priority, null
+                            )));
+                })
+                .collectList()
+                .block();
+
+        return responses.stream()
+                .sorted(Comparator
+                        .comparingInt((AlternativeLocationResponse r) ->
+                                r.congestionLevel() == null
+                                        ? Integer.MAX_VALUE
+                                        : CONGESTION_ORDER.getOrDefault(r.congestionLevel(), Integer.MAX_VALUE))
+                        .thenComparingInt(AlternativeLocationResponse::priority))
+                .toList();
+    }
+}

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    web-application-type: servlet
   application:
     name: service-map
   datasource:
@@ -21,6 +23,10 @@ spring:
       data-locations:
         - classpath:data.sql
         - classpath:alternative_locations_data.sql
+
+congestion:
+  service:
+    url: ${CONGESTION_SERVICE_URL:http://localhost:8082}
 
 server:
   port: 8083


### PR DESCRIPTION
* Refactor: #79에 대한 ai review 반영(#210) (#211)

* feat: Event Class 수정, 문화행사 Api DTO, Api Client 구현, EventBatch를 위한 EventService, EventSyncScheduler 구현(#79)(#109)

* refactor Entity Class uniqueConstraint(#210)

* RestClient timeout 코드 추가(#210)

* 위경도 기반 문화행사 탐색으로 인한 Event Class 내부 Location 참조 삭제(#210)

* Update service-map/src/main/java/com/danburn/map/config/RestClientConfig.java



* api reponse 값 중 list_total_count를 이용한  배치 횟수 계산 로직 추가(#210)

* AOP 적용을 위한 EventUpsert 분리(#210)

* refactor: 문화행사 배치 동기화 로직 최적화(#210)

* refactor: 테스트를 위한 Event Scheduler 동작 시간 변경(매시 정각)(#210)

---------




* Refactor: 스케줄링 활성화를 위한 @EnableScheduling 어노테이션 누락 수정(#221) (#222)

* feat: Event Class 수정, 문화행사 Api DTO, Api Client 구현, EventBatch를 위한 EventService, EventSyncScheduler 구현(#79)(#109)

* refactor Entity Class uniqueConstraint(#210)

* RestClient timeout 코드 추가(#210)

* 위경도 기반 문화행사 탐색으로 인한 Event Class 내부 Location 참조 삭제(#210)

* Update service-map/src/main/java/com/danburn/map/config/RestClientConfig.java



* api reponse 값 중 list_total_count를 이용한  배치 횟수 계산 로직 추가(#210)

* AOP 적용을 위한 EventUpsert 분리(#210)

* refactor: 문화행사 배치 동기화 로직 최적화(#210)

* refactor: 테스트를 위한 Event Scheduler 동작 시간 변경(매시 정각)(#210)

* EnableScheduling 어노테이션 누락 수정(#221)

---------




* Revert: 기한 지난 문화행사 삭제 메소드 @Transactional 추가 및 upsertEventBatch에서 findAll 중복 호출 제거 (#226)

* feat: Event Class 수정, 문화행사 Api DTO, Api Client 구현, EventBatch를 위한 EventService, EventSyncScheduler 구현(#79)(#109)

* refactor Entity Class uniqueConstraint(#210)

* RestClient timeout 코드 추가(#210)

* 위경도 기반 문화행사 탐색으로 인한 Event Class 내부 Location 참조 삭제(#210)

* Update service-map/src/main/java/com/danburn/map/config/RestClientConfig.java



* api reponse 값 중 list_total_count를 이용한  배치 횟수 계산 로직 추가(#210)

* AOP 적용을 위한 EventUpsert 분리(#210)

* refactor: 문화행사 배치 동기화 로직 최적화(#210)

* refactor: 테스트를 위한 Event Scheduler 동작 시간 변경(매시 정각)(#210)

* Event Entity 클래스 구조 변경으로 인해 ddl-auto를 create로 임시 변경(#225)

* 기한 지난 문화행사 삭제 @Transactional 추가(#225)

* upsertEventBatch에서 findAll 중복 호출 제거(#225)

---------




* chore: resolve dev conflict 문제 해결 (#231)

* fix: 배포 서버 혼잡도 API 연결 실패 수정 (#129) (#131) (#132)

- Dockerfile에 -Djava.net.preferIPv4Stack=true 추가 (Alpine JRE IPv6 우선 시도로 인한 타임아웃 방지)
- URI.create()로 직접 URL 생성하여 공백 포함 장소명 IllegalArgumentException 해결
- 에러 로그에 message 추가하여 디버깅 용이하도록 개선

* fix: CD 워크플로우 머지 충돌 마커 제거 (#133) (#134)

* fix: 배포 서버 혼잡도 API 연결 실패 수정 (#129) (#131)

- Dockerfile에 -Djava.net.preferIPv4Stack=true 추가 (Alpine JRE IPv6 우선 시도로 인한 타임아웃 방지)
- URI.create()로 직접 URL 생성하여 공백 포함 장소명 IllegalArgumentException 해결
- 에러 로그에 message 추가하여 디버깅 용이하도록 개선

* fix: CD 워크플로우 머지 충돌 마커 제거 (#133)

- cd.yml에 남아있던 <<<<<<< HEAD 마커 제거

* fix: CD git pull 재시도 로직 추가 (#135) (#136)

* fix: 배포 서버 혼잡도 API 연결 실패 수정 (#129) (#131)

- Dockerfile에 -Djava.net.preferIPv4Stack=true 추가 (Alpine JRE IPv6 우선 시도로 인한 타임아웃 방지)
- URI.create()로 직접 URL 생성하여 공백 포함 장소명 IllegalArgumentException 해결
- 에러 로그에 message 추가하여 디버깅 용이하도록 개선

* fix: CD 워크플로우 머지 충돌 마커 제거 (#133)

- cd.yml에 남아있던 <<<<<<< HEAD 마커 제거

* fix: CD git pull 재시도 로직 추가 및 충돌 마커 제거 (#135)

- git pull 실패 시 3회 재시도 (학교 클라우드 DNS 간헐적 실패 대응)
- cd.yml 충돌 마커 제거

* fix: Docker 네트워크 MTU 불일치 수정 배포 (#138)

* fix: 배포 서버 혼잡도 API 연결 실패 수정 (#129) (#131)

- Dockerfile에 -Djava.net.preferIPv4Stack=true 추가 (Alpine JRE IPv6 우선 시도로 인한 타임아웃 방지)
- URI.create()로 직접 URL 생성하여 공백 포함 장소명 IllegalArgumentException 해결
- 에러 로그에 message 추가하여 디버깅 용이하도록 개선

* fix: CD 워크플로우 머지 충돌 마커 제거 (#133)

- cd.yml에 남아있던 <<<<<<< HEAD 마커 제거

* fix: CD git pull 재시도 로직 추가 및 충돌 마커 제거 (#135)

- git pull 실패 시 3회 재시도 (학교 클라우드 DNS 간헐적 실패 대응)
- cd.yml 충돌 마커 제거

* fix: Docker 네트워크 MTU 불일치로 인한 외부 API 연결 실패 수정 (#137)

* dev → main 배포 (#22)

* set: 백엔드 기본 환경 세팅

* chore: 개발 환경 설정 개선

- .gitignore에 Gradle 및 빌드 관련 디렉토리 추가
- Git 추적에서 불필요한 .gradle/ 파일들 제거
- Gradle Wrapper 파일들 추가
- 환경변수 관리를 위한 .env.example 파일 생성

Made-with: Cursor

* set: 백엔드 기본 환경 세팅

* set: CI 프로세스 구축 빌드 및 테스트 자동화

* set: CI 프로세스 도커 빌드 검증

* set: CI 프로세스 MSA 버전으로 수정

* set: 도커 빌드 컨텍스트 이슈 해결

* set: CVE-2025-41249 보안 취약점 해결

* set: CVE-2025-22235 보안 취약점 해결

* set: 보안 취약점 해결

* set: CVE-보안 취약점 해결

Made-with: Cursor

* set: CVE-2025-22235 보안 취약점 해결

* set: CVE-2025-55752  보안 취약점 해결

* set:   보안 취약점 해결

* set:   보안 취약점 해결

* set:   보안 취약점 해결

* fix: Netty HTTP/2 DDoS 취약점 해결 (CVE-2025-55163)

Made-with: Cursor

* fix: zlib Buffer Overflow 취약점 해결 (CVE-2026-22184)

Made-with: Cursor

* set:   프로젝트 구조 수정

* 설계에 따른 MSA 세팅

* 패치가 아직 제공되지 않는 취약점 무시

* 패치가 아직 제공되지 않는 취약점 무시

* 패치가 아직 제공되지 않는 취약점 무시

* Feat: 도메인 모델 (DTO/Entity) 구현 (#10)

* set: 로깅 설정 파일

* set: 파일 구조 세팅

* feat: BaseEntity 공통 엔티티 추가

* feat: 혼잡도 레벨 Enum 추가

* feat: 인구 증감 추세 Enum 추가

* feat: 혼잡도 엔티티 구현

* feat: Redis 저장용 DTO 추가

* feat: 공공 API 응답 및 프론트 응답 DTO 추가

* fix: service-common JPA 의존성 추가

* fix: service-congestion JPA 의존성 추가 및 파일명 수정

* fix: 엔티티 파일명 대소문자 수정 (congestion → Congestion)

* fix: DTO Javadoc, 들여쓰기 수정 및 Enum 직렬화 개선 (#12) (#15)

* fix: BaseEntity JPA Auditing 설정 수정 (#14)

* fix: BaseEntity JPA Auditing 설정 수정 (#11)

* Apply suggestions from code review



---------



* fix: logback-spring.xml 공통 모듈로 중복 제거 (#16)

* fix: logback-spring.xml 공통 모듈로 중복 제거 (#13)

* fix: loki 의존성을 service-common으로 통합

* fix: Dockerfile 의존성 레이어 캐싱 분리로 빌드 시간 최적화 (#20)

* fix: Dockerfile 의존성 레이어 캐싱 분리로 빌드 시간 최적화 (#19)

* fix: 순차 빌드 배포 스크립트 추가 (#19)

---------



* dev → main 배포: Grafana 대시보드 프로비저닝 (#37) (#41)

* feat: Grafana 대시보드 프로비저닝 추가 (JVM + HTTP) (#37) (#38)

* feat: Grafana 대시보드 프로비저닝 추가 (JVM + HTTP) (#37)

* fix: Grafana 인증 환경변수 기본값 제거로 보안 강화 (#37)

* fix: 대시보드 PromQL  템플릿 변수 적용 (#37) (#40)

* feat: Grafana 대시보드 프로비저닝 추가 (JVM + HTTP) (#37)

* fix: Grafana 인증 환경변수 기본값 제거로 보안 강화 (#37)

* fix: 대시보드 PromQL 쿼리에 $service 템플릿 변수 적용 (#37)

* fix: Grafana 환경변수 미설정 시 시작 실패 처리 (#37) (#42)

* feat: Grafana 대시보드 프로비저닝 추가 (JVM + HTTP) (#37)

* fix: Grafana 인증 환경변수 기본값 제거로 보안 강화 (#37)

* fix: 대시보드 PromQL 쿼리에 $service 템플릿 변수 적용 (#37)

* fix: Grafana 환경변수 미설정 시 컨테이너 시작 실패하도록 변경 (#37)

* hotfix: Grafana root_url 설정 추가 (Cloudflare Tunnel 프록시 대응) (#43) (#46)

* hotfix: Grafana 익명 접근 Viewer로 변경 - 정적 파일 로딩 실패 해결 (#47) (#48)

* hotfix: 대시보드 메트릭 이름 OTLP 형식으로 수정 (#49) (#50)

* hotfix: Grafana 프로비저닝 마운트 경로 otel-lgtm 이미지에 맞게 수정 (#51) (#52)

* fix: Grafana 익명 접근 비활성화 - 로그인 필수로 변경

* fix: Grafana 마운트 경로 otel-lgtm 이미지에 맞게 동기화

* Release: dev → main 배포 (#86)

* feat: 혼잡도 조회 API 구현 (#18) (#65)

* feat: RedisTemplate Jackson 직렬화 설정 추가

congestionRedisTemplate 빈 등록 (Key: String, Value: CongestionRedisDto) JavaTimeModule로 Instant 직렬화 처리

* refactor: DTO 네이밍 locationName으로 통일

CongestionRedisDto에 locationName 필드 추가
CongestionResponse의 areaName → locationName 변경, locationId 추가

* feat: Redis 저장/조회 Repository 구현

CongestionRedisRepository 인터페이스 정의 (save/findByLocationId/findAll/delete) CongestionRedisRepositoryImpl: RedisTemplate으로 구현, TTL 10분, key 형식 congestion:{locationId}

* feat: Congestion JPA Repository 추가

DB 폴백 조회용 JPA Repository (최신 1건 조회, locationId별 이력 조회)

* feat: CongestionService 비즈니스 로직 구현

Redis 우선 조회 → DB 폴백 전략 적용
save(): Redis + DB 동시 저장 (이력 누적)
findByLocationId(): 단건 조회, 데이터 없으면 404
findAll(): 전체 조회, Redis 비어있으면 DB 폴백

* feat: CongestionController REST API 엔드포인트 구현

GET /api/congestion — 전체 122개 장소 혼잡도 조회
GET /api/congestion/{locationId} — 특정 장소 혼잡도 조회
GlobalExceptionHandler 추가 — GlobalException을 ApiResponse.error()로 변환

* refactor: 서비스별 DB 분리 (MSA 원칙 적용)

service-congestion DB를 danburn_map → danburn_congestion으로 변경 MySQL init 스크립트 추가 (danburn_congestion, danburn_mobility 자동 생성) docker-compose에 init 스크립트 마운트 및 DB URL 반영

* fix: Redis findAll() KEYS → SCAN + multiGet으로 성능 개선

* fix: DB 폴백 시 locationId별 최신 1건만 조회하도록 개선

* refactor: 패키지 com.danburn.domain → com.danburn.congestion으로 통일

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66) (#67)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* set: 로컬 테스트 환경 설정 업데이트 (#69)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* chore: 로컬 테스트 환경 설정 업데이트 (#68)

- docker-compose.yml에 SPRING_PROFILES_ACTIVE, Scheduler 환경변수 추가
- docker-compose.local.yml 추가 — 인프라(mysql, redis)만 띄우는 경량 설정
- .env.example에 Grafana, Congestion Scheduler, Service URL 설정 추가

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71) (#73)

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71)

- locationId(Long) → areaCode(String) 전환 (서울시 API 핫스팟 코드)
- PopulationTrend enum 삭제 (API 미제공 필드)
- congestionMessage, populationTime, forecast(JSON) 필드 추가
- Redis 키를 congestion:{areaCode}로 변경
- forecast null 안전 처리, populationTime 파싱 예외 처리 추가

* fix: CongestionService populationTime null 안전 처리 및 코드 간소화 (#71)

- populationTime 파싱을 별도 메서드(parsePopulationTime)로 추출
- forecast null 체크, 3중 try-catch 제거로 가독성 개선

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74) (#75)

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74)

- RealSeoulApiClient: 121개 장소 병렬 호출 (10스레드), JSON 파싱, RESULT.CODE 검증
- SeoulArea enum: 122개 장소 정의 (서울광장 API 미지원으로 주석 처리)
- StubSeoulApiClient: @Profile("stub")로 변경 (기본은 실제 API)
- application.yml에 seoul.api.key 환경변수 설정 추가
- .env.example에 SEOUL_API_KEY 항목 추가

* fix: API 클라이언트 코드 리뷰 반영 (#74)

- ExecutorService 필드 승격 + @PreDestroy 안전 종료
- API Key 미설정 시 기동 실패 (빈 키로 무의미한 호출 방지)
- 로그에 API Key 노출 방지 (e.getClass().getSimpleName()으로 변경)
- @ConditionalOnProperty/@ConditionalOnMissingBean으로 자동 전환

* fix: RestTemplate URI 템플릿 사용으로 API Key 로그 노출 근본 차단 (#74)

- URL 직접 조합 → URI 템플릿 플레이스홀더 방식으로 변경
- URLEncoder 수동 호출 제거 (RestTemplate이 자동 인코딩)

* Update service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java



* refactor: Gemini 코드 리뷰 반영 — 스레드풀 설정 외부화, enum 캐싱 (#74)

- 스레드풀 크기를 seoul.api.thread-pool-size로 설정 가능하게 변경 (기본값 10)
- SeoulArea.all() 리스트를 static final로 캐싱

* fix: RESULT.CODE 키 이름 복원 — 서울시 API가 점 포함 키 사용 (#74)

- 실제 API 응답 키가 "RESULT.CODE"/"RESULT.MESSAGE"임을 확인
- "CODE"/"MESSAGE"로 변경 시 파싱 실패하므로 원래대로 복원

* fix: 비동기 작업 실패 로그에서 예외 객체 대신 메시지만 출력 (#74)

---------



* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70) (#76)

* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70)

* refactor: AlternativeLocation 연관 관계 매핑 수정 (#70)

* refactor: id 컬럼 속성 중복 수정, builder parameter type 수정(#70)

* refactor:



* refactor: 연관 관계 수정으로 인한 파생 쿼리 메소드 수정(#70)



---------




* Feat: Congestion, Event, Store Entity Class  구현 및 각 Repository 구현, API 핫스팟 코드와 LocationId 매핑 테이블 구현(#77) (#78)

* refactor: AlternativeLocationId Class 필드 타입 수정(#77)

* feat: 혼잡도, 추천가게, 이벤트 Entity Class 구현과 관련 Repository 구현 및 메소드 이름 수정 (#77)

* feat: API 핫스팟 코드와 서버 내부 location_id 매핑을 위한 LocationCodeMapper 추가(#77)

* refactor: Congestion Class 생성자 AccessLevel 변경



* refactor: Store Class 생성자 AccessLevel 변경(#77)



* refactor: LocationCodeMapper 중복코드 수정(#77)

* refactor: AccessLevel import 수정(#77)

---------




* docs: PRD 문서 작성 및 README 추가 (#80) (#81)

* fix: Netty 4.1.132.Final 보안 취약점 패치 (CVE-2026-33870, CVE-2026-33871) (#83)

* fix: Netty 4.1.132.Final 업그레이드 (CVE-2026-33870, CVE-2026-33871) (#82)

- netty-codec-http 4.1.132.Final 추가 (HTTP/1.1 request smuggling 취약점)
- netty-codec-http2 4.1.124 → 4.1.132.Final (HTTP/2 취약점)
- netty-handler, netty-common 동일 버전으로 통일

* fix: Trivy 보안 스캔 제거 및 의존성 버전 오버라이드 정리 (#82)

- CI에서 Trivy scanner 단계 제거 (Java, AI 서비스 모두)
- build.gradle의 CVE 패치용 의존성 버전 오버라이드 전체 제거
- Spring Boot BOM이 관리하는 기본 버전으로 복원

* set: Portainer Docker Compose 분리 구성 추가 (#84) (#85)

* set: Portainer Docker Compose 분리 구성 추가 (#84)

* set: CD 워크플로우에 Portainer 자동 실행 추가 (#84)

---------





* Release: protobuf-java 의존성 수정 배포 (#89)

* feat: 혼잡도 조회 API 구현 (#18) (#65)

* feat: RedisTemplate Jackson 직렬화 설정 추가

congestionRedisTemplate 빈 등록 (Key: String, Value: CongestionRedisDto) JavaTimeModule로 Instant 직렬화 처리

* refactor: DTO 네이밍 locationName으로 통일

CongestionRedisDto에 locationName 필드 추가
CongestionResponse의 areaName → locationName 변경, locationId 추가

* feat: Redis 저장/조회 Repository 구현

CongestionRedisRepository 인터페이스 정의 (save/findByLocationId/findAll/delete) CongestionRedisRepositoryImpl: RedisTemplate으로 구현, TTL 10분, key 형식 congestion:{locationId}

* feat: Congestion JPA Repository 추가

DB 폴백 조회용 JPA Repository (최신 1건 조회, locationId별 이력 조회)

* feat: CongestionService 비즈니스 로직 구현

Redis 우선 조회 → DB 폴백 전략 적용
save(): Redis + DB 동시 저장 (이력 누적)
findByLocationId(): 단건 조회, 데이터 없으면 404
findAll(): 전체 조회, Redis 비어있으면 DB 폴백

* feat: CongestionController REST API 엔드포인트 구현

GET /api/congestion — 전체 122개 장소 혼잡도 조회
GET /api/congestion/{locationId} — 특정 장소 혼잡도 조회
GlobalExceptionHandler 추가 — GlobalException을 ApiResponse.error()로 변환

* refactor: 서비스별 DB 분리 (MSA 원칙 적용)

service-congestion DB를 danburn_map → danburn_congestion으로 변경 MySQL init 스크립트 추가 (danburn_congestion, danburn_mobility 자동 생성) docker-compose에 init 스크립트 마운트 및 DB URL 반영

* fix: Redis findAll() KEYS → SCAN + multiGet으로 성능 개선

* fix: DB 폴백 시 locationId별 최신 1건만 조회하도록 개선

* refactor: 패키지 com.danburn.domain → com.danburn.congestion으로 통일

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66) (#67)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* set: 로컬 테스트 환경 설정 업데이트 (#69)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* chore: 로컬 테스트 환경 설정 업데이트 (#68)

- docker-compose.yml에 SPRING_PROFILES_ACTIVE, Scheduler 환경변수 추가
- docker-compose.local.yml 추가 — 인프라(mysql, redis)만 띄우는 경량 설정
- .env.example에 Grafana, Congestion Scheduler, Service URL 설정 추가

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71) (#73)

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71)

- locationId(Long) → areaCode(String) 전환 (서울시 API 핫스팟 코드)
- PopulationTrend enum 삭제 (API 미제공 필드)
- congestionMessage, populationTime, forecast(JSON) 필드 추가
- Redis 키를 congestion:{areaCode}로 변경
- forecast null 안전 처리, populationTime 파싱 예외 처리 추가

* fix: CongestionService populationTime null 안전 처리 및 코드 간소화 (#71)

- populationTime 파싱을 별도 메서드(parsePopulationTime)로 추출
- forecast null 체크, 3중 try-catch 제거로 가독성 개선

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74) (#75)

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74)

- RealSeoulApiClient: 121개 장소 병렬 호출 (10스레드), JSON 파싱, RESULT.CODE 검증
- SeoulArea enum: 122개 장소 정의 (서울광장 API 미지원으로 주석 처리)
- StubSeoulApiClient: @Profile("stub")로 변경 (기본은 실제 API)
- application.yml에 seoul.api.key 환경변수 설정 추가
- .env.example에 SEOUL_API_KEY 항목 추가

* fix: API 클라이언트 코드 리뷰 반영 (#74)

- ExecutorService 필드 승격 + @PreDestroy 안전 종료
- API Key 미설정 시 기동 실패 (빈 키로 무의미한 호출 방지)
- 로그에 API Key 노출 방지 (e.getClass().getSimpleName()으로 변경)
- @ConditionalOnProperty/@ConditionalOnMissingBean으로 자동 전환

* fix: RestTemplate URI 템플릿 사용으로 API Key 로그 노출 근본 차단 (#74)

- URL 직접 조합 → URI 템플릿 플레이스홀더 방식으로 변경
- URLEncoder 수동 호출 제거 (RestTemplate이 자동 인코딩)

* Update service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java



* refactor: Gemini 코드 리뷰 반영 — 스레드풀 설정 외부화, enum 캐싱 (#74)

- 스레드풀 크기를 seoul.api.thread-pool-size로 설정 가능하게 변경 (기본값 10)
- SeoulArea.all() 리스트를 static final로 캐싱

* fix: RESULT.CODE 키 이름 복원 — 서울시 API가 점 포함 키 사용 (#74)

- 실제 API 응답 키가 "RESULT.CODE"/"RESULT.MESSAGE"임을 확인
- "CODE"/"MESSAGE"로 변경 시 파싱 실패하므로 원래대로 복원

* fix: 비동기 작업 실패 로그에서 예외 객체 대신 메시지만 출력 (#74)

---------



* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70) (#76)

* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70)

* refactor: AlternativeLocation 연관 관계 매핑 수정 (#70)

* refactor: id 컬럼 속성 중복 수정, builder parameter type 수정(#70)

* refactor:



* refactor: 연관 관계 수정으로 인한 파생 쿼리 메소드 수정(#70)



---------




* Feat: Congestion, Event, Store Entity Class  구현 및 각 Repository 구현, API 핫스팟 코드와 LocationId 매핑 테이블 구현(#77) (#78)

* refactor: AlternativeLocationId Class 필드 타입 수정(#77)

* feat: 혼잡도, 추천가게, 이벤트 Entity Class 구현과 관련 Repository 구현 및 메소드 이름 수정 (#77)

* feat: API 핫스팟 코드와 서버 내부 location_id 매핑을 위한 LocationCodeMapper 추가(#77)

* refactor: Congestion Class 생성자 AccessLevel 변경



* refactor: Store Class 생성자 AccessLevel 변경(#77)



* refactor: LocationCodeMapper 중복코드 수정(#77)

* refactor: AccessLevel import 수정(#77)

---------




* docs: PRD 문서 작성 및 README 추가 (#80) (#81)

* fix: Netty 4.1.132.Final 보안 취약점 패치 (CVE-2026-33870, CVE-2026-33871) (#83)

* fix: Netty 4.1.132.Final 업그레이드 (CVE-2026-33870, CVE-2026-33871) (#82)

- netty-codec-http 4.1.132.Final 추가 (HTTP/1.1 request smuggling 취약점)
- netty-codec-http2 4.1.124 → 4.1.132.Final (HTTP/2 취약점)
- netty-handler, netty-common 동일 버전으로 통일

* fix: Trivy 보안 스캔 제거 및 의존성 버전 오버라이드 정리 (#82)

- CI에서 Trivy scanner 단계 제거 (Java, AI 서비스 모두)
- build.gradle의 CVE 패치용 의존성 버전 오버라이드 전체 제거
- Spring Boot BOM이 관리하는 기본 버전으로 복원

* set: Portainer Docker Compose 분리 구성 추가 (#84) (#85)

* set: Portainer Docker Compose 분리 구성 추가 (#84)

* set: CD 워크플로우에 Portainer 자동 실행 추가 (#84)

* fix: service-congestion, service-map, service-transport에 protobuf-java 의존성 추가 (#87) (#88)

---------





* chore: redeploy

* chore: redeploy after docker restart

* Release: CD retry 로직 및 병렬 빌드 배포 (#92)

* feat: 혼잡도 조회 API 구현 (#18) (#65)

* feat: RedisTemplate Jackson 직렬화 설정 추가

congestionRedisTemplate 빈 등록 (Key: String, Value: CongestionRedisDto) JavaTimeModule로 Instant 직렬화 처리

* refactor: DTO 네이밍 locationName으로 통일

CongestionRedisDto에 locationName 필드 추가
CongestionResponse의 areaName → locationName 변경, locationId 추가

* feat: Redis 저장/조회 Repository 구현

CongestionRedisRepository 인터페이스 정의 (save/findByLocationId/findAll/delete) CongestionRedisRepositoryImpl: RedisTemplate으로 구현, TTL 10분, key 형식 congestion:{locationId}

* feat: Congestion JPA Repository 추가

DB 폴백 조회용 JPA Repository (최신 1건 조회, locationId별 이력 조회)

* feat: CongestionService 비즈니스 로직 구현

Redis 우선 조회 → DB 폴백 전략 적용
save(): Redis + DB 동시 저장 (이력 누적)
findByLocationId(): 단건 조회, 데이터 없으면 404
findAll(): 전체 조회, Redis 비어있으면 DB 폴백

* feat: CongestionController REST API 엔드포인트 구현

GET /api/congestion — 전체 122개 장소 혼잡도 조회
GET /api/congestion/{locationId} — 특정 장소 혼잡도 조회
GlobalExceptionHandler 추가 — GlobalException을 ApiResponse.error()로 변환

* refactor: 서비스별 DB 분리 (MSA 원칙 적용)

service-congestion DB를 danburn_map → danburn_congestion으로 변경 MySQL init 스크립트 추가 (danburn_congestion, danburn_mobility 자동 생성) docker-compose에 init 스크립트 마운트 및 DB URL 반영

* fix: Redis findAll() KEYS → SCAN + multiGet으로 성능 개선

* fix: DB 폴백 시 locationId별 최신 1건만 조회하도록 개선

* refactor: 패키지 com.danburn.domain → com.danburn.congestion으로 통일

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66) (#67)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* set: 로컬 테스트 환경 설정 업데이트 (#69)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* chore: 로컬 테스트 환경 설정 업데이트 (#68)

- docker-compose.yml에 SPRING_PROFILES_ACTIVE, Scheduler 환경변수 추가
- docker-compose.local.yml 추가 — 인프라(mysql, redis)만 띄우는 경량 설정
- .env.example에 Grafana, Congestion Scheduler, Service URL 설정 추가

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71) (#73)

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71)

- locationId(Long) → areaCode(String) 전환 (서울시 API 핫스팟 코드)
- PopulationTrend enum 삭제 (API 미제공 필드)
- congestionMessage, populationTime, forecast(JSON) 필드 추가
- Redis 키를 congestion:{areaCode}로 변경
- forecast null 안전 처리, populationTime 파싱 예외 처리 추가

* fix: CongestionService populationTime null 안전 처리 및 코드 간소화 (#71)

- populationTime 파싱을 별도 메서드(parsePopulationTime)로 추출
- forecast null 체크, 3중 try-catch 제거로 가독성 개선

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74) (#75)

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74)

- RealSeoulApiClient: 121개 장소 병렬 호출 (10스레드), JSON 파싱, RESULT.CODE 검증
- SeoulArea enum: 122개 장소 정의 (서울광장 API 미지원으로 주석 처리)
- StubSeoulApiClient: @Profile("stub")로 변경 (기본은 실제 API)
- application.yml에 seoul.api.key 환경변수 설정 추가
- .env.example에 SEOUL_API_KEY 항목 추가

* fix: API 클라이언트 코드 리뷰 반영 (#74)

- ExecutorService 필드 승격 + @PreDestroy 안전 종료
- API Key 미설정 시 기동 실패 (빈 키로 무의미한 호출 방지)
- 로그에 API Key 노출 방지 (e.getClass().getSimpleName()으로 변경)
- @ConditionalOnProperty/@ConditionalOnMissingBean으로 자동 전환

* fix: RestTemplate URI 템플릿 사용으로 API Key 로그 노출 근본 차단 (#74)

- URL 직접 조합 → URI 템플릿 플레이스홀더 방식으로 변경
- URLEncoder 수동 호출 제거 (RestTemplate이 자동 인코딩)

* Update service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java



* refactor: Gemini 코드 리뷰 반영 — 스레드풀 설정 외부화, enum 캐싱 (#74)

- 스레드풀 크기를 seoul.api.thread-pool-size로 설정 가능하게 변경 (기본값 10)
- SeoulArea.all() 리스트를 static final로 캐싱

* fix: RESULT.CODE 키 이름 복원 — 서울시 API가 점 포함 키 사용 (#74)

- 실제 API 응답 키가 "RESULT.CODE"/"RESULT.MESSAGE"임을 확인
- "CODE"/"MESSAGE"로 변경 시 파싱 실패하므로 원래대로 복원

* fix: 비동기 작업 실패 로그에서 예외 객체 대신 메시지만 출력 (#74)

---------



* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70) (#76)

* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70)

* refactor: AlternativeLocation 연관 관계 매핑 수정 (#70)

* refactor: id 컬럼 속성 중복 수정, builder parameter type 수정(#70)

* refactor:



* refactor: 연관 관계 수정으로 인한 파생 쿼리 메소드 수정(#70)



---------




* Feat: Congestion, Event, Store Entity Class  구현 및 각 Repository 구현, API 핫스팟 코드와 LocationId 매핑 테이블 구현(#77) (#78)

* refactor: AlternativeLocationId Class 필드 타입 수정(#77)

* feat: 혼잡도, 추천가게, 이벤트 Entity Class 구현과 관련 Repository 구현 및 메소드 이름 수정 (#77)

* feat: API 핫스팟 코드와 서버 내부 location_id 매핑을 위한 LocationCodeMapper 추가(#77)

* refactor: Congestion Class 생성자 AccessLevel 변경



* refactor: Store Class 생성자 AccessLevel 변경(#77)



* refactor: LocationCodeMapper 중복코드 수정(#77)

* refactor: AccessLevel import 수정(#77)

---------




* docs: PRD 문서 작성 및 README 추가 (#80) (#81)

* fix: Netty 4.1.132.Final 보안 취약점 패치 (CVE-2026-33870, CVE-2026-33871) (#83)

* fix: Netty 4.1.132.Final 업그레이드 (CVE-2026-33870, CVE-2026-33871) (#82)

- netty-codec-http 4.1.132.Final 추가 (HTTP/1.1 request smuggling 취약점)
- netty-codec-http2 4.1.124 → 4.1.132.Final (HTTP/2 취약점)
- netty-handler, netty-common 동일 버전으로 통일

* fix: Trivy 보안 스캔 제거 및 의존성 버전 오버라이드 정리 (#82)

- CI에서 Trivy scanner 단계 제거 (Java, AI 서비스 모두)
- build.gradle의 CVE 패치용 의존성 버전 오버라이드 전체 제거
- Spring Boot BOM이 관리하는 기본 버전으로 복원

* set: Portainer Docker Compose 분리 구성 추가 (#84) (#85)

* set: Portainer Docker Compose 분리 구성 추가 (#84)

* set: CD 워크플로우에 Portainer 자동 실행 추가 (#84)

* fix: service-congestion, service-map, service-transport에 protobuf-java 의존성 추가 (#87) (#88)

* fix: CD docker pull retry 로직 추가 및 빌드 2개씩 병렬화 (#90) (#91)

---------





* chore: redeploy all services

* chore: redeploy congestion

* Release: MySQL init 통합 및 RabbitMQ 추가 배포 (#93) (#98)

* feat: 혼잡도 조회 API 구현 (#18) (#65)

* feat: RedisTemplate Jackson 직렬화 설정 추가

congestionRedisTemplate 빈 등록 (Key: String, Value: CongestionRedisDto) JavaTimeModule로 Instant 직렬화 처리

* refactor: DTO 네이밍 locationName으로 통일

CongestionRedisDto에 locationName 필드 추가
CongestionResponse의 areaName → locationName 변경, locationId 추가

* feat: Redis 저장/조회 Repository 구현

CongestionRedisRepository 인터페이스 정의 (save/findByLocationId/findAll/delete) CongestionRedisRepositoryImpl: RedisTemplate으로 구현, TTL 10분, key 형식 congestion:{locationId}

* feat: Congestion JPA Repository 추가

DB 폴백 조회용 JPA Repository (최신 1건 조회, locationId별 이력 조회)

* feat: CongestionService 비즈니스 로직 구현

Redis 우선 조회 → DB 폴백 전략 적용
save(): Redis + DB 동시 저장 (이력 누적)
findByLocationId(): 단건 조회, 데이터 없으면 404
findAll(): 전체 조회, Redis 비어있으면 DB 폴백

* feat: CongestionController REST API 엔드포인트 구현

GET /api/congestion — 전체 122개 장소 혼잡도 조회
GET /api/congestion/{locationId} — 특정 장소 혼잡도 조회
GlobalExceptionHandler 추가 — GlobalException을 ApiResponse.error()로 변환

* refactor: 서비스별 DB 분리 (MSA 원칙 적용)

service-congestion DB를 danburn_map → danburn_congestion으로 변경 MySQL init 스크립트 추가 (danburn_congestion, danburn_mobility 자동 생성) docker-compose에 init 스크립트 마운트 및 DB URL 반영

* fix: Redis findAll() KEYS → SCAN + multiGet으로 성능 개선

* fix: DB 폴백 시 locationId별 최신 1건만 조회하도록 개선

* refactor: 패키지 com.danburn.domain → com.danburn.congestion으로 통일

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66) (#67)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* set: 로컬 테스트 환경 설정 업데이트 (#69)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* chore: 로컬 테스트 환경 설정 업데이트 (#68)

- docker-compose.yml에 SPRING_PROFILES_ACTIVE, Scheduler 환경변수 추가
- docker-compose.local.yml 추가 — 인프라(mysql, redis)만 띄우는 경량 설정
- .env.example에 Grafana, Congestion Scheduler, Service URL 설정 추가

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71) (#73)

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71)

- locationId(Long) → areaCode(String) 전환 (서울시 API 핫스팟 코드)
- PopulationTrend enum 삭제 (API 미제공 필드)
- congestionMessage, populationTime, forecast(JSON) 필드 추가
- Redis 키를 congestion:{areaCode}로 변경
- forecast null 안전 처리, populationTime 파싱 예외 처리 추가

* fix: CongestionService populationTime null 안전 처리 및 코드 간소화 (#71)

- populationTime 파싱을 별도 메서드(parsePopulationTime)로 추출
- forecast null 체크, 3중 try-catch 제거로 가독성 개선

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74) (#75)

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74)

- RealSeoulApiClient: 121개 장소 병렬 호출 (10스레드), JSON 파싱, RESULT.CODE 검증
- SeoulArea enum: 122개 장소 정의 (서울광장 API 미지원으로 주석 처리)
- StubSeoulApiClient: @Profile("stub")로 변경 (기본은 실제 API)
- application.yml에 seoul.api.key 환경변수 설정 추가
- .env.example에 SEOUL_API_KEY 항목 추가

* fix: API 클라이언트 코드 리뷰 반영 (#74)

- ExecutorService 필드 승격 + @PreDestroy 안전 종료
- API Key 미설정 시 기동 실패 (빈 키로 무의미한 호출 방지)
- 로그에 API Key 노출 방지 (e.getClass().getSimpleName()으로 변경)
- @ConditionalOnProperty/@ConditionalOnMissingBean으로 자동 전환

* fix: RestTemplate URI 템플릿 사용으로 API Key 로그 노출 근본 차단 (#74)

- URL 직접 조합 → URI 템플릿 플레이스홀더 방식으로 변경
- URLEncoder 수동 호출 제거 (RestTemplate이 자동 인코딩)

* Update service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java



* refactor: Gemini 코드 리뷰 반영 — 스레드풀 설정 외부화, enum 캐싱 (#74)

- 스레드풀 크기를 seoul.api.thread-pool-size로 설정 가능하게 변경 (기본값 10)
- SeoulArea.all() 리스트를 static final로 캐싱

* fix: RESULT.CODE 키 이름 복원 — 서울시 API가 점 포함 키 사용 (#74)

- 실제 API 응답 키가 "RESULT.CODE"/"RESULT.MESSAGE"임을 확인
- "CODE"/"MESSAGE"로 변경 시 파싱 실패하므로 원래대로 복원

* fix: 비동기 작업 실패 로그에서 예외 객체 대신 메시지만 출력 (#74)

---------



* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70) (#76)

* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70)

* refactor: AlternativeLocation 연관 관계 매핑 수정 (#70)

* refactor: id 컬럼 속성 중복 수정, builder parameter type 수정(#70)

* refactor:



* refactor: 연관 관계 수정으로 인한 파생 쿼리 메소드 수정(#70)



---------




* Feat: Congestion, Event, Store Entity Class  구현 및 각 Repository 구현, API 핫스팟 코드와 LocationId 매핑 테이블 구현(#77) (#78)

* refactor: AlternativeLocationId Class 필드 타입 수정(#77)

* feat: 혼잡도, 추천가게, 이벤트 Entity Class 구현과 관련 Repository 구현 및 메소드 이름 수정 (#77)

* feat: API 핫스팟 코드와 서버 내부 location_id 매핑을 위한 LocationCodeMapper 추가(#77)

* refactor: Congestion Class 생성자 AccessLevel 변경



* refactor: Store Class 생성자 AccessLevel 변경(#77)



* refactor: LocationCodeMapper 중복코드 수정(#77)

* refactor: AccessLevel import 수정(#77)

---------




* docs: PRD 문서 작성 및 README 추가 (#80) (#81)

* fix: Netty 4.1.132.Final 보안 취약점 패치 (CVE-2026-33870, CVE-2026-33871) (#83)

* fix: Netty 4.1.132.Final 업그레이드 (CVE-2026-33870, CVE-2026-33871) (#82)

- netty-codec-http 4.1.132.Final 추가 (HTTP/1.1 request smuggling 취약점)
- netty-codec-http2 4.1.124 → 4.1.132.Final (HTTP/2 취약점)
- netty-handler, netty-common 동일 버전으로 통일

* fix: Trivy 보안 스캔 제거 및 의존성 버전 오버라이드 정리 (#82)

- CI에서 Trivy scanner 단계 제거 (Java, AI 서비스 모두)
- build.gradle의 CVE 패치용 의존성 버전 오버라이드 전체 제거
- Spring Boot BOM이 관리하는 기본 버전으로 복원

* set: Portainer Docker Compose 분리 구성 추가 (#84) (#85)

* set: Portainer Docker Compose 분리 구성 추가 (#84)

* set: CD 워크플로우에 Portainer 자동 실행 추가 (#84)

* fix: service-congestion, service-map, service-transport에 protobuf-java 의존성 추가 (#87) (#88)

* fix: CD docker pull retry 로직 추가 및 빌드 2개씩 병렬화 (#90) (#91)

* fix: MySQL DB 생성을 init 스크립트로 통합 (#93) (#94)

* Revise monitoring and logging sections (#95)

Updated monitoring and logging tools in README.

* fix: MySQL DB init 스크립트 통합 및 RabbitMQ 추가 (#93) (#96)

---------





* Release: SEOUL_API_KEY 주입 및 congestion 서비스 기동 수정 (#102)

* feat: 혼잡도 조회 API 구현 (#18) (#65)

* feat: RedisTemplate Jackson 직렬화 설정 추가

congestionRedisTemplate 빈 등록 (Key: String, Value: CongestionRedisDto) JavaTimeModule로 Instant 직렬화 처리

* refactor: DTO 네이밍 locationName으로 통일

CongestionRedisDto에 locationName 필드 추가
CongestionResponse의 areaName → locationName 변경, locationId 추가

* feat: Redis 저장/조회 Repository 구현

CongestionRedisRepository 인터페이스 정의 (save/findByLocationId/findAll/delete) CongestionRedisRepositoryImpl: RedisTemplate으로 구현, TTL 10분, key 형식 congestion:{locationId}

* feat: Congestion JPA Repository 추가

DB 폴백 조회용 JPA Repository (최신 1건 조회, locationId별 이력 조회)

* feat: CongestionService 비즈니스 로직 구현

Redis 우선 조회 → DB 폴백 전략 적용
save(): Redis + DB 동시 저장 (이력 누적)
findByLocationId(): 단건 조회, 데이터 없으면 404
findAll(): 전체 조회, Redis 비어있으면 DB 폴백

* feat: CongestionController REST API 엔드포인트 구현

GET /api/congestion — 전체 122개 장소 혼잡도 조회
GET /api/congestion/{locationId} — 특정 장소 혼잡도 조회
GlobalExceptionHandler 추가 — GlobalException을 ApiResponse.error()로 변환

* refactor: 서비스별 DB 분리 (MSA 원칙 적용)

service-congestion DB를 danburn_map → danburn_congestion으로 변경 MySQL init 스크립트 추가 (danburn_congestion, danburn_mobility 자동 생성) docker-compose에 init 스크립트 마운트 및 DB URL 반영

* fix: Redis findAll() KEYS → SCAN + multiGet으로 성능 개선

* fix: DB 폴백 시 locationId별 최신 1건만 조회하도록 개선

* refactor: 패키지 com.danburn.domain → com.danburn.congestion으로 통일

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66) (#67)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* set: 로컬 테스트 환경 설정 업데이트 (#69)

* feat: 혼잡도 데이터 갱신 Scheduler 구현 (#66)

- SeoulApiClient 인터페이스 및 StubSeoulApiClient 더미 구현체 추가
- CongestionScheduler 5분 주기 — Redis 동기 + DB 비동기 저장
- CongestionLevel, PopulationTrend에 fromDescription() 추가 (trim 적용)
- @EnableScheduling, @EnableAsync 활성화
- locationId를 areaName 해시 기반으로 임시 할당
- StubSeoulApiClient에 @Profile(local, dev) 적용

* feat: Redis pipeline 배치 저장 및 DB 정리 Scheduler 추가 (#66)

- Redis pipeline(SessionCallback) 기반 saveAll 구현, TTL 15분
- CongestionService를 saveAllToRedis(동기)/saveAllToDb(@Async) 분리
- DataCleanupScheduler — 매일 새벽 3시 7일 이전 데이터 삭제 (Service 위임)
- deleteByCreatedAtBefore Instant 타입 통일, @Modifying 옵션 추가
- pipeline 타입 캐스팅 명시, 설정값 application.yml 일원화

* fix: AsyncConfig 스레드풀 추가, hashCode 음수 버그 수정, 트랜잭션 정합성 개선 (#66)

- AsyncConfig 추가 — ThreadPoolTaskExecutor(core=2, max=4) + 예외 핸들러
- locationId hashCode를 unsigned 변환 (Integer.MIN_VALUE 음수 방지)
- saveAllToDb에서 try-catch 제거 — @Transactional 롤백 정상 동작 보장

* chore: 로컬 테스트 환경 설정 업데이트 (#68)

- docker-compose.yml에 SPRING_PROFILES_ACTIVE, Scheduler 환경변수 추가
- docker-compose.local.yml 추가 — 인프라(mysql, redis)만 띄우는 경량 설정
- .env.example에 Grafana, Congestion Scheduler, Service URL 설정 추가

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71) (#73)

* refactor: 혼잡도 데이터 구조 서울시 공공 API 실제 응답에 맞게 재설계 (#71)

- locationId(Long) → areaCode(String) 전환 (서울시 API 핫스팟 코드)
- PopulationTrend enum 삭제 (API 미제공 필드)
- congestionMessage, populationTime, forecast(JSON) 필드 추가
- Redis 키를 congestion:{areaCode}로 변경
- forecast null 안전 처리, populationTime 파싱 예외 처리 추가

* fix: CongestionService populationTime null 안전 처리 및 코드 간소화 (#71)

- populationTime 파싱을 별도 메서드(parsePopulationTime)로 추출
- forecast null 체크, 3중 try-catch 제거로 가독성 개선

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74) (#75)

* feat: 서울시 실시간 인구데이터 공공 API 클라이언트 구현 (#74)

- RealSeoulApiClient: 121개 장소 병렬 호출 (10스레드), JSON 파싱, RESULT.CODE 검증
- SeoulArea enum: 122개 장소 정의 (서울광장 API 미지원으로 주석 처리)
- StubSeoulApiClient: @Profile("stub")로 변경 (기본은 실제 API)
- application.yml에 seoul.api.key 환경변수 설정 추가
- .env.example에 SEOUL_API_KEY 항목 추가

* fix: API 클라이언트 코드 리뷰 반영 (#74)

- ExecutorService 필드 승격 + @PreDestroy 안전 종료
- API Key 미설정 시 기동 실패 (빈 키로 무의미한 호출 방지)
- 로그에 API Key 노출 방지 (e.getClass().getSimpleName()으로 변경)
- @ConditionalOnProperty/@ConditionalOnMissingBean으로 자동 전환

* fix: RestTemplate URI 템플릿 사용으로 API Key 로그 노출 근본 차단 (#74)

- URL 직접 조합 → URI 템플릿 플레이스홀더 방식으로 변경
- URLEncoder 수동 호출 제거 (RestTemplate이 자동 인코딩)

* Update service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java



* refactor: Gemini 코드 리뷰 반영 — 스레드풀 설정 외부화, enum 캐싱 (#74)

- 스레드풀 크기를 seoul.api.thread-pool-size로 설정 가능하게 변경 (기본값 10)
- SeoulArea.all() 리스트를 static final로 캐싱

* fix: RESULT.CODE 키 이름 복원 — 서울시 API가 점 포함 키 사용 (#74)

- 실제 API 응답 키가 "RESULT.CODE"/"RESULT.MESSAGE"임을 확인
- "CODE"/"MESSAGE"로 변경 시 파싱 실패하므로 원래대로 복원

* fix: 비동기 작업 실패 로그에서 예외 객체 대신 메시지만 출력 (#74)

---------



* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70) (#76)

* feat: Location, AlternativeLocation Entity Class, Each Repository implement(#70)

* refactor: AlternativeLocation 연관 관계 매핑 수정 (#70)

* refactor: id 컬럼 속성 중복 수정, builder parameter type 수정(#70)

* refactor:



* refactor: 연관 관계 수정으로 인한 파생 쿼리 메소드 수정(#70)



---------




* Feat: Congestion, Event, Store Entity Class  구현 및 각 Repository 구현, API 핫스팟 코드와 LocationId 매핑 테이블 구현(#77) (#78)

* refactor: AlternativeLocationId Class 필드 타입 수정(#77)

* feat: 혼잡도, 추천가게, 이벤트 Entity Class 구현과 관련 Repository 구현 및 메소드 이름 수정 (#77)

* feat: API 핫스팟 코드와 서버 내부 location_id 매핑을 위한 LocationCodeMapper 추가(#77)

* refactor: Congestion Class 생성자 AccessLevel 변경



* refactor: Store Class 생성자 AccessLevel 변경(#77)



* refactor: LocationCodeMapper 중복코드 수정(#77)

* refactor: AccessLevel import 수정(#77)

---------




* docs: PRD 문서 작성 및 README 추가 (#80) (#81)

* fix: Netty 4.1.132.Final 보안 취약점 패치 (CVE-2026-33870, CVE-2026-33871) (#83)

* fix: Netty 4.1.132.Final 업그레이드 (CVE-2026-33870, CVE-2026-33871) (#82)

- netty-codec-http 4.1.132.Final 추가 (HTTP/1.1 request smuggling 취약점)
- netty-codec-http2 4.1.124 → 4.1.132.Final (HTTP/2 취약점)
- netty-handler, netty-common 동일 버전으로 통일

* fix: Trivy 보안 스캔 제거 및 의존성 버전 오버라이드 정리 (#82)

- CI에서 Trivy scanner 단계 제거 (Java, AI 서비스 모두)
- build.gradle의 CVE 패치용 의존성 버전 오버라이드 전체 제거
- Spring Boot BOM이 관리하는 기본 버전으로 복원

* set: Portainer Docker Compose 분리 구성 추가 (#84) (#85)

* set: Portainer Docker Compose 분리 구성 추가 (#84)

* set: CD 워크플로우에 Portainer 자동 실행 추가 (#84)

* fix: service-congestion, service-map, service-transport에 protobuf-java 의존성 추가 (#87) (#88)

* fix: CD docker pull retry 로직 추가 및 빌드 2개씩 병렬화 (#90) (#91)

* fix: MySQL DB 생성을 init 스크립트로 통합 (#93) (#94)

* Revise monitoring and logging sections (#95)

Updated monitoring and logging tools in README.

* fix: MySQL DB init 스크립트 통합 및 RabbitMQ 추가 (#93) (#96)

---------





* Release: 환경변수 분리 및 Infisical 연동 (#103) (#105)

* feat: 혼잡도 조회 API 구현 (#18) (#65)

* feat: RedisTemplate Jackson 직렬화 설정 추가

congestionRedisTemplate 빈 등록 (Key: String, Value: CongestionRedisDto) JavaTimeModule로 Instant 직렬화 처리

* refactor: DTO 네이밍 locationName으로 통일

CongestionRedisDto에 locationName 필드 추가
CongestionResponse의 areaName → locationName 변경, locationId 추가

* feat: Redis 저장/조회 Repository 구현

CongestionRedisRepository 인터페이스 정의 (save/findByLocationId/findAll/delete) CongestionRedisRepositoryImpl: RedisTemplate으로 구현, TTL 10분, key 형식 congestion:{locationId}

* feat: Congestion JPA Repository 추가

DB 폴백 조회용 JPA Repository (최신 1건 조회, locationId별 이력 조회)

* feat: CongestionService 비즈니스 로직 구현

Redis 우선 조회 → DB 폴백 전략 적용
save(): Redis + DB 동시 저장 (이력 누적)
findByLocationId(): 단건 조회, 데이터 없으면 404
findAll(): 전체 조회, Redis 비어있으면 DB 폴백

* feat: CongestionController REST API 엔드포인트 구현

GET /api/congestion — 전체 122개 장소 혼잡도…