### PR TITLE
feat: 대체지역 혼잡도 연동 및 주변 문화행사 조회 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,9 +134,12 @@ services:
       - OTLP_TRACES_URL=http://observability:4318/v1/traces
       - LOKI_URL=http://observability:3100/loki/api/v1/push
       - SEOUL_API_KEY=${SEOUL_API_KEY}
+      - CONGESTION_SERVICE_URL=http://service-congestion:8082
     depends_on:
       mysql:
         condition: service_healthy
+      service-congestion:
+        condition: service_started
     networks:
       - backend-net
 

--- a/service-map/build.gradle
+++ b/service-map/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':service-common')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'

--- a/service-map/src/main/java/com/danburn/map/controller/AlternativeLocationController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/AlternativeLocationController.java
@@ -2,9 +2,11 @@ package com.danburn.map.controller;
 
 import com.danburn.common.response.ApiResponse;
 import com.danburn.map.dto.response.AlternativeLocationResponse;
+import com.danburn.map.service.AlternativeLocationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,7 +17,10 @@ import java.util.List;
 @Tag(name = "대체지역", description = "대체지역 추천 API")
 @RestController
 @RequestMapping("/api/map")
+@RequiredArgsConstructor
 public class AlternativeLocationController {
+
+    private final AlternativeLocationService alternativeLocationService;
 
     @Operation(summary = "대체지역 추천 조회", description = "혼잡 지역으로부터 거리와 분위기, 카테고리 기반으로 대체지역 3곳을 조회합니다.")
     @GetMapping("/alternative-location")
@@ -23,12 +28,6 @@ public class AlternativeLocationController {
             @Parameter(description = "장소 코드 (예: POI009)", example = "POI009")
             @RequestParam String areaCode) {
 
-        List<AlternativeLocationResponse> mockData = List.of(
-            new AlternativeLocationResponse("POI001", "광화문·덕수궁", 37.5759, 126.9769, 1, "여유"),
-            new AlternativeLocationResponse("POI002", "인사동·익선동", 37.5742, 126.9855, 2, "보통"),
-            new AlternativeLocationResponse("POI003", "북촌한옥마을", 37.5826, 126.9830, 3, "붐빔")
-        );
-
-        return ApiResponse.ok(mockData);
+        return ApiResponse.ok(alternativeLocationService.getAlternativeLocations(areaCode));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/CultureEventController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/CultureEventController.java
@@ -2,60 +2,38 @@ package com.danburn.map.controller;
 
 import com.danburn.common.response.ApiResponse;
 import com.danburn.map.dto.response.CultureEventResponse;
+import com.danburn.map.service.CultureEventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "문화행사", description = "주변 문화행사 조회 API")
+@Validated
 @RestController
 @RequestMapping("/api/map")
+@RequiredArgsConstructor
 public class CultureEventController {
+
+    private final CultureEventService cultureEventService;
 
     @Operation(summary = "주변 문화행사 조회", description = "위도/경도 기준 1km 이내 문화행사를 조회합니다.")
     @GetMapping("/culture-events")
     public ApiResponse<List<CultureEventResponse>> getCultureEvents(
-            @Parameter(description = "위도", example = "37.5759")
-            @RequestParam Double latitude,
-            @Parameter(description = "경도", example = "126.9769")
-            @RequestParam Double longitude) {
+            @Parameter(description = "위도 (33.0 ~ 38.9)", example = "37.5759")
+            @RequestParam @DecimalMin("33.0") @DecimalMax("38.9") Double latitude,
+            @Parameter(description = "경도 (124.5 ~ 132.0)", example = "126.9769")
+            @RequestParam @DecimalMin("124.5") @DecimalMax("132.0") Double longitude) {
 
-        List<CultureEventResponse> mockData = List.of(
-            new CultureEventResponse(
-                "2026 핸드아티코리아",
-                "코엑스전시장 B홀",
-                "전시/미술",
-                LocalDate.of(2026, 8, 13), LocalDate.of(2026, 8, 16),
-                "정가 15,000원",
-                "https://handarty.co.kr/coex/visitors/guide/",
-                "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=8dd93ec4c4874b809cf11b6fa5f4b6e8&thumb=Y",
-                37.5118239121138, 127.059159043842),
-            new CultureEventResponse(
-                "2026 인터참코리아",
-                "코엑스 A홀, C홀",
-                "전시/미술",
-                LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 3),
-                "현장등록: 20,000원 (사전 등록 시, 무료 입장 가능)",
-                "https://www.intercharmkorea.com/ko-kr.html",
-                "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=5f2a4e2e793e49b987e5902a6e58cdf7&thumb=Y",
-                37.5118239121138, 127.059159043842),
-            new CultureEventResponse(
-                "[GS아트센터] 양인모 X 김치앤칩스",
-                "GS아트센터",
-                "클래식",
-                LocalDate.of(2026, 6, 30), LocalDate.of(2026, 6, 30),
-                "R 11만원, S 8만원, A 5만원",
-                "https://www.gsartscenter.com/program/detail/634",
-                "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=344dc2e128c94b82977c28aab4a1381d&thumb=Y",
-                37.5019949322814, 127.037336400239)
-        );
-
-        return ApiResponse.ok(mockData);
+        return ApiResponse.ok(cultureEventService.getCultureEvents(latitude, longitude));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
+++ b/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.danburn.map.controller;
 
 import com.danburn.common.exception.GlobalException;
 import com.danburn.common.response.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,5 +17,16 @@ public class GlobalExceptionHandler {
         log.error("GlobalException: status={}, message={}", e.getStatus(), e.getMessage());
         return ResponseEntity.status(e.getStatus())
                 .body(ApiResponse.error(e.getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath().toString().replaceAll(".*\\.", "") + ": " + v.getMessage())
+                .findFirst()
+                .orElse("잘못된 입력값입니다.");
+        log.warn("ConstraintViolationException: {}", message);
+        return ResponseEntity.status(400)
+                .body(ApiResponse.error(400, message));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
+++ b/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGlobalException(GlobalException e) {
+        log.error("GlobalException: status={}, message={}", e.getStatus(), e.getMessage());
+        return ResponseEntity.status(e.getStatus())
+                .body(ApiResponse.error(e.getStatus(), e.getMessage()));
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/CongestionApiResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/CongestionApiResponse.java
@@ -1,0 +1,12 @@
+package com.danburn.map.dto.response;
+
+public record CongestionApiResponse(
+        int status,
+        String message,
+        CongestionData data
+) {
+    public record CongestionData(
+            String areaCode,
+            String congestionLevel
+    ) {}
+}

--- a/service-map/src/main/java/com/danburn/map/infra/CongestionApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/CongestionApiClient.java
@@ -1,0 +1,34 @@
+package com.danburn.map.infra;
+
+import com.danburn.map.dto.response.CongestionApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class CongestionApiClient {
+
+    private final WebClient webClient;
+
+    public CongestionApiClient(@Value("${congestion.service.url}") String congestionServiceUrl) {
+        this.webClient = WebClient.builder()
+                .baseUrl(congestionServiceUrl)
+                .build();
+    }
+
+    public Mono<String> getCongestionLevel(String areaCode) {
+        return webClient.get()
+                .uri("/api/congestion/{areaCode}", areaCode)
+                .retrieve()
+                .bodyToMono(CongestionApiResponse.class)
+                .mapNotNull(response ->
+                        response.data() != null ? response.data().congestionLevel() : null)
+                .onErrorResume(e -> {
+                    log.warn("혼잡도 조회 실패 - areaCode: {}, error: {}", areaCode, e.getMessage());
+                    return Mono.empty();
+                });
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/infra/CongestionApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/CongestionApiClient.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 @Slf4j
 @Component
 public class CongestionApiClient {
@@ -24,6 +26,8 @@ public class CongestionApiClient {
                 .uri("/api/congestion/{areaCode}", areaCode)
                 .retrieve()
                 .bodyToMono(CongestionApiResponse.class)
+                // Netty 3초 타임아웃
+                .timeout(Duration.ofSeconds(3))
                 .mapNotNull(response ->
                         response.data() != null ? response.data().congestionLevel() : null)
                 .onErrorResume(e -> {

--- a/service-map/src/main/java/com/danburn/map/service/AlternativeLocationService.java
+++ b/service-map/src/main/java/com/danburn/map/service/AlternativeLocationService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,9 @@ public class AlternativeLocationService {
                             )));
                 })
                 .collectList()
+                .timeout(Duration.ofSeconds(10))
+                .onErrorMap(e -> !(e instanceof GlobalException),
+                        e -> new GlobalException(503, "서비스 응답 지연으로 요청을 처리할 수 없습니다."))
                 .block();
 
         return responses.stream()

--- a/service-map/src/main/java/com/danburn/map/service/AlternativeLocationService.java
+++ b/service-map/src/main/java/com/danburn/map/service/AlternativeLocationService.java
@@ -1,0 +1,71 @@
+package com.danburn.map.service;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.map.domain.AlternativeLocation;
+import com.danburn.map.dto.response.AlternativeLocationResponse;
+import com.danburn.map.infra.CongestionApiClient;
+import com.danburn.map.repository.AlternativeLocationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlternativeLocationService {
+
+    private static final Map<String, Integer> CONGESTION_ORDER = Map.of(
+            "여유", 1,
+            "보통", 2,
+            "약간 붐빔", 3,
+            "붐빔", 4
+    );
+
+    private final LocationCodeMapper locationCodeMapper;
+    private final AlternativeLocationJpaRepository alternativeLocationJpaRepository;
+    private final CongestionApiClient congestionApiClient;
+
+    @Transactional(readOnly = true)
+    public List<AlternativeLocationResponse> getAlternativeLocations(String areaCode) {
+        Long locationId = locationCodeMapper.getLocationIdByAreaCode(areaCode)
+                .orElseThrow(() -> new GlobalException(404, "존재하지 않는 지역 코드입니다: " + areaCode));
+
+        List<AlternativeLocation> alternatives = alternativeLocationJpaRepository
+                .findAlternativeLocationIdOrderByPriority(locationId);
+
+        List<AlternativeLocationResponse> responses = Flux.fromIterable(alternatives)
+                .flatMap(alt -> {
+                    String altAreaCode = alt.getAlternativeLocation().getApiAreaCode();
+                    String locationName = alt.getAlternativeLocation().getLocationName();
+                    Double latitude = alt.getAlternativeLocation().getLatitude();
+                    Double longitude = alt.getAlternativeLocation().getLongitude();
+                    Integer priority = alt.getPriority();
+
+                    return congestionApiClient.getCongestionLevel(altAreaCode)
+                            .map(congestionLevel -> new AlternativeLocationResponse(
+                                    altAreaCode, locationName, latitude, longitude, priority, congestionLevel
+                            ))
+                            .switchIfEmpty(Mono.fromSupplier(() -> new AlternativeLocationResponse(
+                                    altAreaCode, locationName, latitude, longitude, priority, null
+                            )));
+                })
+                .collectList()
+                .block();
+
+        return responses.stream()
+                .sorted(Comparator
+                        .comparingInt((AlternativeLocationResponse r) ->
+                                r.congestionLevel() == null
+                                        ? Integer.MAX_VALUE
+                                        : CONGESTION_ORDER.getOrDefault(r.congestionLevel(), Integer.MAX_VALUE))
+                        .thenComparingInt(AlternativeLocationResponse::priority))
+                .toList();
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/service/CultureEventService.java
+++ b/service-map/src/main/java/com/danburn/map/service/CultureEventService.java
@@ -1,0 +1,48 @@
+package com.danburn.map.service;
+
+import com.danburn.map.domain.Event;
+import com.danburn.map.dto.response.CultureEventResponse;
+import com.danburn.map.repository.EventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CultureEventService {
+
+    private static final double RADIUS_METER = 1000.0;
+
+    private final EventJpaRepository eventJpaRepository;
+
+    @Transactional(readOnly = true)
+    public List<CultureEventResponse> getCultureEvents(Double latitude, Double longitude) {
+        log.debug("문화행사 조회 요청 - latitude: {}, longitude: {}", latitude, longitude);
+
+        List<Event> events = eventJpaRepository.findEventsWithinRadius(latitude, longitude, RADIUS_METER);
+        log.debug("{}km 이내 문화행사 {}건 조회 완료", (int)(RADIUS_METER / 1000), events.size());
+
+        return events.stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private CultureEventResponse toResponse(Event event) {
+        return new CultureEventResponse(
+                event.getEventTitle(),
+                event.getPlace(),
+                event.getCodename(),
+                event.getStartDate(),
+                event.getEndDate(),
+                event.getUseFee(),
+                event.getOrgLink(),
+                event.getMainImg(),
+                event.getLatitude(),
+                event.getLongitude()
+        );
+    }
+}

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    web-application-type: servlet
   application:
     name: service-map
   datasource:
@@ -21,6 +23,10 @@ spring:
       data-locations:
         - classpath:data.sql
         - classpath:alternative_locations_data.sql
+
+congestion:
+  service:
+    url: ${CONGESTION_SERVICE_URL:http://localhost:8082}
 
 server:
   port: 8083


### PR DESCRIPTION
## 작업 내용
**#252 대체지역 추천 API 혼잡도 연동**
- [x] CongestionApiClient WebClient 비동기 반환 (Mono<String>)
- [x] Flux.flatMap 병렬 호출로 대체지역별 혼잡도 동시 조회
- [x] switchIfEmpty로 혼잡도 API 실패 시 null 반환 처리
- [x] Map.of() null 키 조회 NPE 방지 처리

**#253 주변 문화행사 조회 구현**
- [x] CultureEventController mock 데이터 제거 및 서비스 레이어 연결
- [x] CultureEventService 구현 (위도/경도 기반 1km 이내 DB 공간 쿼리)
- [x] EventJpaRepository.findEventsWithinRadius() 활용
- [x] Event 엔티티 → CultureEventResponse 변환 로직 구현
- [x] 대한민국 위도/경도 범위 입력값 검증 추가