### PR TITLE
feat: 주변 장소 조회 API 구현

### DIFF
--- a/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
@@ -1,0 +1,41 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.map.dto.response.NearbyPlaceResponse;
+import com.danburn.map.service.NearbyPlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "주변 장소", description = "주변 맛집/놀거리 조회 API")
+@Validated
+@RestController
+@RequestMapping("/api/map")
+@RequiredArgsConstructor
+public class NearbyPlaceController {
+
+    private final NearbyPlaceService nearbyPlaceService;
+
+    @Operation(summary = "주변 장소 조회", description = "위도/경도 기준 1km 이내 주변 장소를 카테고리별로 조회합니다.")
+    @GetMapping("/nearby-places")
+    public ApiResponse<List<NearbyPlaceResponse>> getNearbyPlaces(
+            @Parameter(description = "카테고리 코드 (ALL/FD6/CE7/AT4/CT1)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") String categoryCode,
+            @Parameter(description = "위도 (33.0 ~ 38.9)", example = "37.5759")
+            @RequestParam @DecimalMin("33.0") @DecimalMax("38.9") Double latitude,
+            @Parameter(description = "경도 (124.5 ~ 132.0)", example = "126.9769")
+            @RequestParam @DecimalMin("124.5") @DecimalMax("132.0") Double longitude) {
+
+        return ApiResponse.ok(nearbyPlaceService.getNearbyPlaces(categoryCode, longitude, latitude));
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/KakaoLocalApiResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/KakaoLocalApiResponse.java
@@ -1,0 +1,26 @@
+package com.danburn.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record KakaoLocalApiResponse(
+  Meta meta,
+  List<Document> documents
+) {
+  public  record Meta(
+    @JsonProperty("total_count") int totalCount,
+    @JsonProperty("is_end") boolean isEnd
+  ){}
+
+  public record Document(
+    @JsonProperty("place_name") String placeName,
+    @JsonProperty("category_name") String categoryName,
+    @JsonProperty("address_name") String addressName,
+    @JsonProperty("road_address_name") String roadAddressName,
+    @JsonProperty("place_url") String placeUrl,
+    String distance,
+    String x,
+    String y
+  ) {}
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/NearbyPlaceResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/NearbyPlaceResponse.java
@@ -1,0 +1,12 @@
+package com.danburn.map.dto.response;
+
+public record NearbyPlaceResponse(
+        String placeName,
+        String categoryName,
+        String addressName,
+        String roadAddressName,
+        String placeUrl,
+        double longitude,
+        double latitude
+) {
+}

--- a/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
@@ -1,0 +1,41 @@
+package com.danburn.map.infra;
+
+import com.danburn.map.dto.response.KakaoLocalApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Component
+public class KakaoLocalApiClient {
+
+    private final RestClient restClient;
+
+    public KakaoLocalApiClient(@Value("${kakao.api.key}") String apiKey) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(5));
+
+        this.restClient = RestClient.builder()
+            .baseUrl("https://dapi.kakao.com")
+            .defaultHeader("Authorization", "KakaoAK " + apiKey)
+            .requestFactory(factory)
+            .build();
+    }
+
+    public KakaoLocalApiResponse fetchNearbyPlaces(String categoryCode, double longitude, double latitude) {
+        return restClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path("/v2/local/search/category.json")
+                .queryParam("category_group_code", categoryCode)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", 1000)
+                .queryParam("sort", "distance")
+                .build())
+            .retrieve()
+            .body(KakaoLocalApiResponse.class);
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
@@ -11,31 +11,31 @@ import java.time.Duration;
 @Component
 public class KakaoLocalApiClient {
 
-    private final RestClient restClient;
+  private final RestClient restClient;
 
-    public KakaoLocalApiClient(@Value("${kakao.api.key}") String apiKey) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(5));
-        factory.setReadTimeout(Duration.ofSeconds(5));
+  public KakaoLocalApiClient(@Value("${kakao.api.key}") String apiKey) {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(Duration.ofSeconds(5));
+    factory.setReadTimeout(Duration.ofSeconds(5));
 
-        this.restClient = RestClient.builder()
-            .baseUrl("https://dapi.kakao.com")
-            .defaultHeader("Authorization", "KakaoAK " + apiKey)
-            .requestFactory(factory)
-            .build();
-    }
+    this.restClient = RestClient.builder()
+      .baseUrl("https://dapi.kakao.com")
+      .defaultHeader("Authorization", "KakaoAK " + apiKey)
+      .requestFactory(factory)
+      .build();
+  }
 
-    public KakaoLocalApiResponse fetchNearbyPlaces(String categoryCode, double longitude, double latitude) {
-        return restClient.get()
-            .uri(uriBuilder -> uriBuilder
-                .path("/v2/local/search/category.json")
-                .queryParam("category_group_code", categoryCode)
-                .queryParam("x", longitude)
-                .queryParam("y", latitude)
-                .queryParam("radius", 1000)
-                .queryParam("sort", "distance")
-                .build())
-            .retrieve()
-            .body(KakaoLocalApiResponse.class);
-    }
+  public KakaoLocalApiResponse fetchNearbyPlaces(String categoryCode, double longitude, double latitude) {
+    return restClient.get()
+      .uri(uriBuilder -> uriBuilder
+        .path("/v2/local/search/category.json")
+        .queryParam("category_group_code", categoryCode)
+        .queryParam("x", longitude)
+        .queryParam("y", latitude)
+        .queryParam("radius", 1000)
+        .queryParam("page", 10)
+        .build())
+      .retrieve()
+      .body(KakaoLocalApiResponse.class);
+  }
 }

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -1,0 +1,50 @@
+package com.danburn.map.service;
+
+import com.danburn.map.dto.response.KakaoLocalApiResponse;
+import com.danburn.map.dto.response.NearbyPlaceResponse;
+import com.danburn.map.infra.KakaoLocalApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NearbyPlaceService {
+
+    private static final List<String> ALL_CATEGORY_CODES = List.of("FD6", "CE7", "AT4", "CT1");
+
+    private final KakaoLocalApiClient kakaoLocalApiClient;
+
+    public List<NearbyPlaceResponse> getNearbyPlaces(String categoryCode, double longitude, double latitude) {
+        if ("ALL".equals(categoryCode)) {
+            return ALL_CATEGORY_CODES.stream()
+                    .flatMap(code -> fetchFromKakao(code, longitude, latitude).stream())
+                    .toList();
+        }
+        return fetchFromKakao(categoryCode, longitude, latitude);
+    }
+
+    // TODO: Redis 캐싱 추가 시 이 메서드에 캐시 읽기/쓰기 로직 삽입
+    private List<NearbyPlaceResponse> fetchFromKakao(String categoryCode, double longitude, double latitude) {
+        try {
+            KakaoLocalApiResponse response = kakaoLocalApiClient.fetchNearbyPlaces(categoryCode, longitude, latitude);
+            if (response == null || response.documents() == null) {
+                return List.of();
+            }
+            return response.documents().stream()
+                    .map(doc -> new NearbyPlaceResponse(
+                            doc.placeName(),
+                            doc.categoryName(),
+                            doc.addressName(),
+                            doc.roadAddressName(),
+                            doc.placeUrl(),
+                            doc.x() != null && !doc.x().isEmpty() ? Double.parseDouble(doc.x()) : 0.0,
+                            doc.y() != null && !doc.y().isEmpty() ? Double.parseDouble(doc.y()) : 0.0
+                    ))
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+}

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -28,6 +28,10 @@ congestion:
   service:
     url: ${CONGESTION_SERVICE_URL:http://localhost:8082}
 
+kakao:
+  api:
+    key: ${KAKAO_API_KEY:}
+
 server:
   port: 8083
   forward-headers-strategy: framework


### PR DESCRIPTION
## 작업 내용

  - [x] 카카오 로컬 API 클라이언트 구현 (`KakaoLocalApiClient`)
  - [x] 카카오 API 응답 DTO 구현 (`KakaoLocalApiResponse`)
  - [x] 클라이언트 응답 DTO 구현 (`NearbyPlaceResponse`)
  - [x] 주변 장소 조회 서비스 구현 (`NearbyPlaceService`)
    - [x] 카테고리별 단일 조회 (FD6/CE7/AT4/CT1)
    - [x] 전체 탭 4개 카테고리 병합 조회 (ALL)
    - [x] 카카오 API 장애 시 빈 목록 반환
  - [x] 주변 장소 조회 컨트롤러 구현 (`GET /api/map/nearby-places`)

  ## 참고

  - Redis 캐싱은 추후 별도 작업으로 추가 예정
