### PR TITLE
fix: AI 분석 파이프라인 안정화 - ack 연쇄 / 중복 race / 로깅 노이즈 (#271)

### DIFF
--- a/service-ai/app/ai/errors.py
+++ b/service-ai/app/ai/errors.py
@@ -1,11 +1,10 @@
 """AI 호출 실패 분류용 예외 계층.
 
-- Cerebras 429 응답: body.error.code + x-should-retry 헤더로 재시도 판정
+- Cerebras 429 응답: body.error.code 기준으로 재시도 판정
 - NonRetriableError: 재시도 금지 → 즉시 DLQ 라우팅
-  · queue_exceeded
-  · x-should-retry: false
+  · queue_exceeded (Free tier 큐 영구 포화)
 - RetriableError: retry_after 초 후 재시도 가능
-  · token_quota_exceeded
+  · token_quota_exceeded, 그 외 알 수 없는 429
 """
 
 from __future__ import annotations
@@ -25,7 +24,6 @@ class NonRetriableError(AIServiceError):
 
     대표 케이스
     - Cerebras queue_exceeded: Free tier 큐 포화 (재시도 시 즉시 재실패)
-    - x-should-retry: false 헤더: 서버가 명시적 재시도 금지
     """
 
 

--- a/service-ai/app/ai/openai/errors.py
+++ b/service-ai/app/ai/openai/errors.py
@@ -80,10 +80,10 @@ def _classify_429(response: httpx.Response) -> Exception:
         body_text,
     )
 
-    if error_code == "queue_exceeded" or not should_retry:
+    if error_code == "queue_exceeded":
         return NonRetriableError(
-            error_code=error_code or "non_retriable_429",
-            message=body_text or "429 Too Many Requests (non-retriable)",
+            error_code=error_code,
+            message=body_text or "429 Too Many Requests (queue exceeded)",
         )
 
     if error_code == "token_quota_exceeded":

--- a/service-ai/app/rabbitmq/batch.py
+++ b/service-ai/app/rabbitmq/batch.py
@@ -11,9 +11,6 @@ from app.rabbitmq.publisher import RabbitMQPublisher
 
 logger = logging.getLogger(__name__)
 
-MAX_BATCH_RETRY = 2
-RETRY_BASE_DELAY = 5.0  # 초기 대기 시간(초)
-
 # 배치 버퍼 항목 타입
 BatchItem = tuple[CongestionEvent, AbstractIncomingMessage]
 
@@ -23,7 +20,7 @@ class BatchProcessor:
 
     - 버퍼 항목: (event, IncomingMessage) 쌍
     - 처리 결과에 따라 ack / nack(requeue=False) 라우팅
-    - nack(requeue=False): DLX 경유 DLQ 이동
+    - nack(requeue=False): DLX 경유 DLQ 이동 (재시도는 DLQWorker 담당)
     """
 
     def __init__(
@@ -34,7 +31,6 @@ class BatchProcessor:
         self._analyzer = analyzer
         self._publisher = publisher
         self._buffer: list[BatchItem] = []
-        self._retry_count: int = 0
         self._lock = asyncio.Lock()
         self._timer_task: asyncio.Task | None = None
         self._running = False
@@ -86,8 +82,14 @@ class BatchProcessor:
         for _event, message in items:
             try:
                 await message.ack()
-            except Exception as e:  # pragma: no cover - 방어적 로깅
-                logger.error("[BatchProcessor] ack 실패 - %s", e)
+            except Exception as e:
+                # 첫 실패면 channel 이 죽은 것 → 나머지 ack 시도 무의미
+                logger.error(
+                    "[BatchProcessor] ack 실패 - %s: %r",
+                    type(e).__name__,
+                    e,
+                )
+                return
 
     async def _dlq_all(self, items: list[BatchItem], reason: str) -> None:
         """nack(requeue=False) → DLX 경유 DLQ 라우팅."""
@@ -99,12 +101,13 @@ class BatchProcessor:
         for _event, message in items:
             try:
                 await message.nack(requeue=False)
-            except Exception as e:  # pragma: no cover - 방어적 로깅
-                logger.error("[BatchProcessor] nack 실패 - %s", e)
-
-    async def _rebuffer(self, items: list[BatchItem]) -> None:
-        async with self._lock:
-            self._buffer.extend(items)
+            except Exception as e:
+                logger.error(
+                    "[BatchProcessor] nack 실패 - %s: %r",
+                    type(e).__name__,
+                    e,
+                )
+                return
 
     async def _process(self, items: list[BatchItem]) -> None:
         if not items:
@@ -114,50 +117,20 @@ class BatchProcessor:
 
         try:
             results = await self._analyzer.analyze(events)
-            self._retry_count = 0
         except NonRetriableError as e:
-            # 재시도 금지 → 즉시 DLQ
             await self._dlq_all(items, f"NonRetriableError: {e}")
-            self._retry_count = 0
             return
         except RetriableError as e:
-            # retry_after 대기 후 재버퍼링
-            logger.warning(
-                "[BatchProcessor] RetriableError - %.1f초 후 %d건 재시도 (%s)",
-                e.retry_after,
-                len(items),
-                e,
-            )
-            await asyncio.sleep(e.retry_after)
-            await self._rebuffer(items)
+            await self._dlq_all(items, f"RetriableError: {e}")
             return
         except Exception as e:
-            self._retry_count += 1
-            if self._retry_count <= MAX_BATCH_RETRY:
-                delay = RETRY_BASE_DELAY * (2 ** (self._retry_count - 1))
-                logger.warning(
-                    "[BatchProcessor] AI 분석 실패 (%d/%d) - %s, %.0f초 후 %d건 재시도",
-                    self._retry_count,
-                    MAX_BATCH_RETRY,
-                    e,
-                    delay,
-                    len(items),
-                )
-                await asyncio.sleep(delay)
-                await self._rebuffer(items)
-            else:
-                await self._dlq_all(
-                    items,
-                    f"최대 재시도 초과 ({MAX_BATCH_RETRY}회): {e}",
-                )
-                self._retry_count = 0
+            await self._dlq_all(items, f"AI 분석 실패: {type(e).__name__}: {e}")
             return
 
         # 분석 성공 → publish 시도
         try:
             await self._publisher.publish_all(results)
         except Exception as e:
-            # publish 실패 → DLQ 로 라우팅 (재처리 루프에 위임)
             await self._dlq_all(items, f"Publisher 실패: {e}")
             return
 

--- a/service-ai/tests/test_batch_ack_nack.py
+++ b/service-ai/tests/test_batch_ack_nack.py
@@ -109,7 +109,11 @@ async def test_non_retriable_error_nacks_to_dlq():
 
 
 @pytest.mark.asyncio
-async def test_retriable_error_rebuffers_without_ack_or_nack():
+async def test_retriable_error_nacks_to_dlq():
+    """RetriableError 도 즉시 DLQ → DLQWorker 가 다음 사이클에 메인 큐로 재발행.
+
+    in-process sleep+rebuffer 는 channel/heartbeat 단절을 일으켜 폐기됨.
+    """
     analyzer = FakeAnalyzer("retriable_then_ok")
     publisher = FakePublisher()
     bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
@@ -119,46 +123,31 @@ async def test_retriable_error_rebuffers_without_ack_or_nack():
     items = [(_event("A"), msg_a), (_event("B"), msg_b)]
     await bp._process(list(items))
 
-    # 첫 처리 → re-buffer → ack/nack 둘 다 없음
-    assert not msg_a.acked and not msg_a.nacked
-    assert not msg_b.acked and not msg_b.nacked
-    # 버퍼 재삽입 확인
+    for msg in (msg_a, msg_b):
+        assert msg.nacked is True
+        assert msg.nack_requeue is False
+        assert msg.acked is False
+    # 버퍼는 비어 있어야 함 (rebuffer 제거)
     async with bp._lock:
-        assert len(bp._buffer) == 2
+        assert bp._buffer == []
 
 
 @pytest.mark.asyncio
-async def test_unknown_exception_retries_then_dlqs(monkeypatch):
+async def test_unknown_exception_nacks_to_dlq():
     analyzer = FakeAnalyzer("unknown_always")
     publisher = FakePublisher()
     bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
 
-    # 재시도 대기 시간 0 으로 단축
-    async def fast_sleep(_):
-        return None
-
-    monkeypatch.setattr("app.rabbitmq.batch.asyncio.sleep", fast_sleep)
-
     msg_a = FakeMessage(1)
     items = [(_event("A"), msg_a)]
 
-    # 1차 _process: 첫 실패 → rebuffer
     await bp._process(list(items))
-    assert not msg_a.acked and not msg_a.nacked
-    async with bp._lock:
-        assert len(bp._buffer) == 1
-        bp._buffer.clear()
 
-    # 2차 _process: 두 번째 실패 → rebuffer
-    await bp._process(list(items))
-    assert not msg_a.acked and not msg_a.nacked
-    async with bp._lock:
-        bp._buffer.clear()
-
-    # 3차 _process: MAX_BATCH_RETRY=2 초과 → DLQ
-    await bp._process(list(items))
     assert msg_a.nacked is True
     assert msg_a.nack_requeue is False
+    assert msg_a.acked is False
+    async with bp._lock:
+        assert bp._buffer == []
 
 
 @pytest.mark.asyncio

--- a/service-ai/tests/test_openai_client_429.py
+++ b/service-ai/tests/test_openai_client_429.py
@@ -38,14 +38,16 @@ def test_queue_exceeded_is_non_retriable():
     assert err.error_code == "queue_exceeded"
 
 
-def test_x_should_retry_false_is_non_retriable_even_without_code():
-    # x-should-retry: false → code 없어도 NonRetriable
+def test_x_should_retry_false_alone_is_retriable():
+    # x-should-retry: false 만으로는 NonRetriable 로 보내지 않음 (high-traffic
+    # 일시 응답이 NonRetriable 로 잘못 분류되어 DLQ 로 빠지는 것을 방지).
     response = _make_response(
-        {"error": {"message": "generic 429"}},
+        {"error": {"message": "We're experiencing high traffic right now!"}},
         headers={"x-should-retry": "false"},
     )
     err = _classify_429(response)
-    assert isinstance(err, NonRetriableError)
+    assert isinstance(err, RetriableError)
+    assert err.retry_after > 0
 
 
 def test_token_quota_exceeded_is_retriable_with_retry_after():

--- a/service-congestion/src/main/java/com/danburn/congestion/event/AiReportEventConsumer.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/event/AiReportEventConsumer.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -25,7 +24,6 @@ public class AiReportEventConsumer {
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
 
-    @Transactional
     @RabbitListener(queues = RabbitMqConfig.AI_REPORT_QUEUE_NAME)
     public void handleAiReport(AiReportEvent event) {
         int inserted = aiReportRepository.insertIfAbsent(

--- a/service-congestion/src/main/java/com/danburn/congestion/event/AiReportEventConsumer.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/event/AiReportEventConsumer.java
@@ -1,16 +1,15 @@
 package com.danburn.congestion.event;
 
 import com.danburn.congestion.config.rabbitmq.RabbitMqConfig;
-import com.danburn.congestion.domain.AiReport;
 import com.danburn.congestion.repository.AiReportRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -26,23 +25,24 @@ public class AiReportEventConsumer {
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
 
+    @Transactional
     @RabbitListener(queues = RabbitMqConfig.AI_REPORT_QUEUE_NAME)
     public void handleAiReport(AiReportEvent event) {
-        AiReport aiReport = AiReport.builder()
-                .areaName(event.areaName())
-                .areaCode(event.areaCode())
-                .congestionLevel(event.congestionLevel())
-                .analysisMessage(event.analysisMessage())
-                .populationTime(event.populationTime())
-                .build();
+        int inserted = aiReportRepository.insertIfAbsent(
+                event.areaName(),
+                event.areaCode(),
+                event.congestionLevel(),
+                event.analysisMessage(),
+                event.populationTime());
 
-        try {
-            aiReportRepository.save(aiReport);
-            cacheToRedis(event);
-            log.info("[AiReportConsumer] AI 분석 결과 저장 완료 - areaCode={}", event.areaCode());
-        } catch (DataIntegrityViolationException e) {
-            log.warn("[AiReportConsumer] 중복 메시지 무시 - areaCode={}, populationTime={}", event.areaCode(), event.populationTime());
+        if (inserted == 0) {
+            log.warn("[AiReportConsumer] 중복 메시지 무시 - areaCode={}, populationTime={}",
+                    event.areaCode(), event.populationTime());
+            return;
         }
+
+        cacheToRedis(event);
+        log.info("[AiReportConsumer] AI 분석 결과 저장 완료 - areaCode={}", event.areaCode());
     }
 
     private void cacheToRedis(AiReportEvent event) {

--- a/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/infra/RealSeoulApiClient.java
@@ -101,11 +101,16 @@ public class RealSeoulApiClient implements SeoulApiClient {
 
             JsonNode dataArray = root.path("SeoulRtd.citydata_ppltn");
             if (dataArray.isMissingNode() || !dataArray.isArray() || dataArray.isEmpty()) {
-                String resultCode = root.path("RESULT").path("CODE").asText();
-                String resultMessage = root.path("RESULT").path("MESSAGE").asText();
-                log.warn("[SeoulApiClient] API 오류 응답 - area={}({}), code={}, message={}, raw={}",
-                        area.getName(), area.getCode(), resultCode, resultMessage,
-                        json.length() > 200 ? json.substring(0, 200) + "..." : json);
+                String resultCode = root.path("RESULT").path("RESULT.CODE").asText();
+                String resultMessage = root.path("RESULT").path("RESULT.MESSAGE").asText();
+                if ("INFO-000".equals(resultCode)) {
+                    log.debug("[SeoulApiClient] 인구 데이터 없음 - area={}({}), message={}",
+                            area.getName(), area.getCode(), resultMessage);
+                } else {
+                    log.warn("[SeoulApiClient] API 오류 응답 - area={}({}), code={}, message={}, raw={}",
+                            area.getName(), area.getCode(), resultCode, resultMessage,
+                            json.length() > 200 ? json.substring(0, 200) + "..." : json);
+                }
                 return null;
             }
 

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/AiReportRepository.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/AiReportRepository.java
@@ -5,12 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 public interface AiReportRepository extends JpaRepository<AiReport, Long> {
     Optional<AiReport> findTopByAreaCodeOrderByCreatedAtDesc(String areaCode);
 
     /** (area_code, population_time) UNIQUE 기준 atomic idempotent insert. 신규=1, 중복=0. */
+    @Transactional
     @Modifying
     @Query(value = "INSERT INTO ai_report " +
             "(area_name, area_code, congestion_level, analysis_message, population_time, created_at, updated_at) " +

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/AiReportRepository.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/AiReportRepository.java
@@ -2,9 +2,24 @@ package com.danburn.congestion.repository;
 
 import com.danburn.congestion.domain.AiReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface AiReportRepository extends JpaRepository<AiReport, Long> {
     Optional<AiReport> findTopByAreaCodeOrderByCreatedAtDesc(String areaCode);
-    
+
+    /** (area_code, population_time) UNIQUE 기준 atomic idempotent insert. 신규=1, 중복=0. */
+    @Modifying
+    @Query(value = "INSERT INTO ai_report " +
+            "(area_name, area_code, congestion_level, analysis_message, population_time, created_at, updated_at) " +
+            "VALUES (:areaName, :areaCode, :congestionLevel, :analysisMessage, :populationTime, NOW(), NOW()) " +
+            "ON DUPLICATE KEY UPDATE area_code = area_code",
+            nativeQuery = true)
+    int insertIfAbsent(@Param("areaName") String areaName,
+                       @Param("areaCode") String areaCode,
+                       @Param("congestionLevel") String congestionLevel,
+                       @Param("analysisMessage") String analysisMessage,
+                       @Param("populationTime") String populationTime);
 }

--- a/service-congestion/src/main/resources/logback-spring.xml
+++ b/service-congestion/src/main/resources/logback-spring.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="logback-common.xml"/>
+
+    <!-- WARN(코드 요약)이 ERROR(메시지)와 중복이라 ERROR 만 남김 -->
+    <logger name="org.hibernate.engine.jdbc.spi.SqlExceptionHelper" level="ERROR"/>
 </configuration>


### PR DESCRIPTION
## Summary

Grafana Loki 6h 로그(193건)에서 발견된 5가지 패턴을 한 번에 해결.

- **DB Duplicate (81건)**: `AiReportRepository.insertIfAbsent` (ON DUPLICATE KEY UPDATE) 로 원자적 idempotent insert. 동시 처리 race 차단.
- **RabbitMQ ack 실패 (60건)**: `BatchProcessor` RetriableError/Exception 경로의 `sleep + rebuffer` 폐기. 즉시 DLQ 라우팅하여 채널 단절 cascade 차단, 재시도는 기존 `DLQWorker` 위임.
- **429 분류 (DLQ 유실 6건/29메시지)**: `x-should-retry: false` 단독으로는 NonRetriable 분류하지 않도록 narrow. `queue_exceeded` 만 NonRetriable.
- **Hibernate 이중 로깅**: `SqlExceptionHelper` 레벨 ERROR 고정 (WARN 코드 요약 라인 제거).
- **Seoul API 빈 응답 (6건)**: RESULT 객체의 실제 키(`RESULT.CODE`, `RESULT.MESSAGE`) 파싱, INFO-000 빈 데이터 응답은 DEBUG 로 강등.

OpenAI 분당 quota(48건) 자체는 코드 외 운영 이슈로 별도 처리 필요 (한도 상향 / 동시성 제한 / 배치 튜닝).

Closes #271

## Test plan

- [x] `service-ai` pytest 43개 통과 (`tests/test_openai_client_429.py`, `tests/test_batch_ack_nack.py`, `tests/test_errors.py` 포함)
- [x] `./gradlew :service-congestion:test` 통과, `:compileJava` 통과
- [ ] dev 배포 후 Loki 로그로 확인:
  - `[BatchProcessor] ack 실패` 카운트 감소
  - `Duplicate entry … for key 'ai_report.UK…'` 카운트 감소 또는 소거
  - `[SeoulApiClient] API 오류 응답` 카운트 감소 (INFO-000 케이스는 DEBUG 로 빠짐)
- [ ] `INSERT … ON DUPLICATE KEY UPDATE area_code = area_code` MySQL 실행 시 신규=1 / 중복=0 반환 확인

## 주의

- service-congestion 의 `insertIfAbsent` 는 native query 라 JPA Auditing 을 우회하므로 `created_at`/`updated_at` 을 `NOW()` 로 명시 설정.
- `@Transactional` 을 listener 에 추가했으나 native modifying query 자체는 자동 커밋되므로, Redis 캐싱 실패가 DB 롤백을 일으키지 않도록 `cacheToRedis` 는 호출 시점 그대로 둠 (기존 동작 유지).