### PR TITLE
chore: 컨테이너 로그 회전 + CD 사전 디스크 정리 (#275)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,17 @@ jobs:
             exit 1
           fi
 
+      - name: Pre-deploy disk cleanup
+        run: |
+          df -h /
+          # 7일 이상 안 쓴 이미지·빌드 캐시 정리 (운영 이미지는 필터로 제외)
+          sudo docker image prune -af --filter "until=168h" || true
+          sudo docker builder prune -af --filter "until=168h" || true
+          # 7일 이상 된 컨테이너 로그 truncate
+          sudo find /var/lib/docker/containers -name "*.log" -type f -mtime +7 \
+            -exec truncate -s 0 {} \; 2>/dev/null || true
+          df -h /
+
       - name: Pull and restart containers
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 services:
 
   # ── Infrastructure ──────────────────────────────────────────────────────────
 
   mysql:
     image: mysql:8.0
+    logging: *default-logging
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
       CONGESTION_DB_USERNAME: ${CONGESTION_DB_USERNAME:-}
@@ -25,6 +32,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    logging: *default-logging
     command: >
       sh -c "if [ -n \"$REDIS_PASSWORD\" ]; then
         redis-server --requirepass \"$REDIS_PASSWORD\";
@@ -45,6 +53,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
+    logging: *default-logging
     hostname: rabbitmq
     ports:
       - "5672:5672"
@@ -66,6 +75,7 @@ services:
 
   observability:
     image: grafana/otel-lgtm:latest
+    logging: *default-logging
     ports:
       - "3000:3000"   # Grafana UI
       - "4317:4317"   # OTel Collector gRPC
@@ -89,6 +99,7 @@ services:
     build:
       context: .
       dockerfile: service-congestion/Dockerfile
+    logging: *default-logging
     ports:
       - "8082:8082"
     environment:
@@ -124,6 +135,7 @@ services:
     build:
       context: .
       dockerfile: service-map/Dockerfile
+    logging: *default-logging
     ports:
       - "8083:8083"
     environment:
@@ -148,6 +160,7 @@ services:
     build:
       context: .
       dockerfile: service-mobility/Dockerfile
+    logging: *default-logging
     ports:
       - "8084:8084"
     environment:
@@ -167,6 +180,7 @@ services:
     build:
       context: ./service-ai
       dockerfile: Dockerfile
+    logging: *default-logging
     ports:
       - "8085:8085"
     environment:
@@ -188,6 +202,7 @@ services:
     build:
       context: .
       dockerfile: service-gateway/Dockerfile
+    logging: *default-logging
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary

PR #273 배포 시 deploy 서버 디스크 풀로 docker pull 실패 → 디스크 누적의 구조적 원인 차단.

- **A. 컨테이너 로그 회전** — `docker-compose.yml` 에 `x-logging` anchor 정의, 9개 서비스(mysql/redis/rabbitmq/observability + 5 application)에 일괄 적용. json-file driver, max-size=50m, max-file=3 → 컨테이너당 로그 최대 150MB 로 제한
- **B. CD 사전 디스크 정리 step** — `cd.yml` deploy 잡의 `Pull and restart containers` 앞에 prune step. `until=168h` 필터로 7일간 안 쓴 이미지·빌드 캐시만 정리 (운영 이미지 보호), 7일 이상 묵은 컨테이너 로그 truncate

C (observability retention) 는 otel-lgtm config override 가 필요해 별도 작업으로 분리 — 이슈 본문 deferred 표기.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` YAML 파싱 통과, 9개 서비스 모두 `logging` 블록 적용 확인
- [ ] dev → main 배포 후 `docker inspect backend-service-ai-1 --format '{{.HostConfig.LogConfig}}'` 로 회전 설정 적용 확인
- [ ] 다음 배포부터 `df -h /` 추이 모니터링 (50% 이하 유지 기대)

## 주의 (one-shot 정리는 별도)

이 PR 은 **앞으로의 누적**을 차단합니다. 이미 쌓여있는 컨테이너 로그는 자동 회전되지 않으므로, 운영 서버에서 한 번:

```bash
sudo find /var/lib/docker/containers -name "*.log" -type f -exec truncate -s 0 {} \;
```

또는 다음 배포 시 컨테이너 재생성되면서 자연 정리.

Closes #275