### PR TITLE
chore(release): dev → main promotion (#275)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,17 @@ jobs:
             exit 1
           fi
 
+      - name: Pre-deploy disk cleanup
+        run: |
+          df -h /
+          # 7일 이상 안 쓴 이미지·빌드 캐시 정리 (운영 이미지는 필터로 제외)
+          sudo docker image prune -af --filter "until=168h" || true
+          sudo docker builder prune -af --filter "until=168h" || true
+          # 7일 이상 된 컨테이너 로그 truncate
+          sudo find /var/lib/docker/containers -name "*.log" -type f -mtime +7 \
+            -exec truncate -s 0 {} \; 2>/dev/null || true
+          df -h /
+
       - name: Pull and restart containers
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "3"
+
 services:
 
   # ── Infrastructure ──────────────────────────────────────────────────────────
 
   mysql:
     image: mysql:8.0
+    logging: *default-logging
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
       CONGESTION_DB_USERNAME: ${CONGESTION_DB_USERNAME:-}
@@ -25,6 +32,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    logging: *default-logging
     command: >
       sh -c "if [ -n \"$REDIS_PASSWORD\" ]; then
         redis-server --requirepass \"$REDIS_PASSWORD\";
@@ -45,6 +53,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
+    logging: *default-logging
     hostname: rabbitmq
     ports:
       - "5672:5672"
@@ -66,6 +75,7 @@ services:
 
   observability:
     image: grafana/otel-lgtm:latest
+    logging: *default-logging
     ports:
       - "3000:3000"   # Grafana UI
       - "4317:4317"   # OTel Collector gRPC
@@ -89,6 +99,7 @@ services:
     build:
       context: .
       dockerfile: service-congestion/Dockerfile
+    logging: *default-logging
     ports:
       - "8082:8082"
     environment:
@@ -124,6 +135,7 @@ services:
     build:
       context: .
       dockerfile: service-map/Dockerfile
+    logging: *default-logging
     ports:
       - "8083:8083"
     environment:
@@ -148,6 +160,7 @@ services:
     build:
       context: .
       dockerfile: service-mobility/Dockerfile
+    logging: *default-logging
     ports:
       - "8084:8084"
     environment:
@@ -167,6 +180,7 @@ services:
     build:
       context: ./service-ai
       dockerfile: Dockerfile
+    logging: *default-logging
     ports:
       - "8085:8085"
     environment:
@@ -188,6 +202,7 @@ services:
     build:
       context: .
       dockerfile: service-gateway/Dockerfile
+    logging: *default-logging
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## Summary

dev 의 #275 작업(컨테이너 로그 회전 + CD 사전 디스크 정리)을 main 으로 promotion.

포함 커밋:
- `5b2ab69` chore: 컨테이너 로그 회전 + CD 사전 디스크 정리 (#275)
- `124f271` Merge pull request #276 from Dan-burn-go/fix/#275

상세는 #275, #276 참조.

## Test plan

- [x] CI 전체 통과 (PR #276)
- [x] `docker compose config` YAML 파싱 통과
- [ ] 배포 후 `docker inspect backend-service-ai-1 --format '{{.HostConfig.LogConfig}}'` 로 회전 설정 적용 확인
- [ ] 다음 배포부터 deploy 서버 `df -h /` 추이 모니터링

## 주의

이 PR 머지 = main push → CD 트리거. 이번 CD 부터 새 Pre-deploy disk cleanup step 이 적용됩니다.