### PR TITLE
fix(cd): deploy job hang 차단 - timeout-minutes + Pre-deploy cleanup 안전화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ jobs:
   # ── Docker 이미지 병렬 빌드 & 푸시 (2개씩, GitHub-hosted) ──────────────────
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       max-parallel: 2
       matrix:
@@ -56,6 +57,7 @@ jobs:
   deploy:
     runs-on: self-hosted
     needs: build-and-push
+    timeout-minutes: 20
 
     steps:
       - name: Pull latest code
@@ -80,9 +82,9 @@ jobs:
           # 7일 이상 안 쓴 이미지·빌드 캐시 정리 (운영 이미지는 필터로 제외)
           sudo docker image prune -af --filter "until=168h" || true
           sudo docker builder prune -af --filter "until=168h" || true
-          # 7일 이상 된 컨테이너 로그 truncate
-          sudo find /var/lib/docker/containers -name "*.log" -type f -mtime +7 \
-            -exec truncate -s 0 {} \; 2>/dev/null || true
+          # 컨테이너 로그 누적은 docker-compose.yml x-logging(max-size=50m,max-file=3)
+          # 가 차단한다. find -exec truncate 는 실행중 컨테이너 log fd 와 충돌해
+          # 후속 docker compose 단계가 hang 되는 사례가 관측되어 제거됨.
           df -h /
 
       - name: Pull and restart containers


### PR DESCRIPTION
## Summary

CD deploy job 이 self-hosted runner 에서 docker compose pull 후 stdout 파이프에서 hang 되어 40분간 침묵 → 다음 배포가 영구 막히는 증상 해결.

- **timeout-minutes 추가** — build-and-push 15분, deploy 20분. self-hosted runner.Worker hang 시 자동 종료해서 다음 CD 가능하게.
- **Pre-deploy cleanup 의 find -exec truncate 제거** — 운영 로그에서 이 라인 실행 직후 docker compose pull 이 hang 되는 패턴 두 번 관측. 컨테이너 로그 누적 차단은 PR #275 의 `docker-compose.yml` x-logging anchor (max-size 50m, max-file 3) 가 이미 책임.

기존 step 순서/내용은 모두 유지. image prune / builder prune 라인도 그대로.

## Test plan

- [x] PyYAML safe_load 로 cd.yml 파싱 통과, jobs.timeout-minutes 값 검증 (15, 20)
- [ ] PR CI(build-ai + build-java x5) 통과
- [ ] dev 머지 후 dev→main promotion → CD 실제 실행 → deploy job 이 20분 안에 'completed' 종료 (성공이든 fail이든 hang 없이)

## 배경

운영 로그 분석 결과(journalctl):
- 2026-05-14 07:28:03 Pre-deploy cleanup(이전 PR #275) 의 find/truncate 실행 직후 docker compose pull 시작
- 07:29:16 pull 첫 시도 종료. **이후 40분간 journal 침묵**
- 08:08:57 사용자가 runner 서비스 수동 restart
- 동일 패턴 08:09 ~ 08:50 재현

Worker 가 죽은 게 아니라 hang. timeout-minutes 가 없어서 GitHub UI 가 영원히 in_progress 로 남았음.