### PR TITLE
chore(release): dev → main promotion (CD 안정화)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ jobs:
   # ── Docker 이미지 병렬 빌드 & 푸시 (2개씩, GitHub-hosted) ──────────────────
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       max-parallel: 2
       matrix:
@@ -56,6 +57,7 @@ jobs:
   deploy:
     runs-on: self-hosted
     needs: build-and-push
+    timeout-minutes: 20
 
     steps:
       - name: Pull latest code
@@ -80,9 +82,9 @@ jobs:
           # 7일 이상 안 쓴 이미지·빌드 캐시 정리 (운영 이미지는 필터로 제외)
           sudo docker image prune -af --filter "until=168h" || true
           sudo docker builder prune -af --filter "until=168h" || true
-          # 7일 이상 된 컨테이너 로그 truncate
-          sudo find /var/lib/docker/containers -name "*.log" -type f -mtime +7 \
-            -exec truncate -s 0 {} \; 2>/dev/null || true
+          # 컨테이너 로그 누적은 docker-compose.yml x-logging(max-size=50m,max-file=3)
+          # 가 차단한다. find -exec truncate 는 실행중 컨테이너 log fd 와 충돌해
+          # 후속 docker compose 단계가 hang 되는 사례가 관측되어 제거됨.
           df -h /
 
       - name: Pull and restart containers


### PR DESCRIPTION
## Summary

dev 의 #278 (CD 배포 안정화) 작업을 main 으로 promotion → 실제 CD 트리거.

포함 커밋:
- \`cccaf86\` fix(cd): deploy job hang 차단 - timeout-minutes 추가 + Pre-deploy cleanup truncate 제거
- \`9608eaa\` Merge pull request #278 from Dan-burn-go/fix/cd-stability

상세는 #278 참조.

## Test plan

- [x] PR #278 CI 통과 (build-ai + build-java x5)
- [ ] 이 PR 머지 → main push → CD workflow 자동 트리거
- [ ] deploy job 이 20분 안에 'completed' 종료 (이전 40분 hang 사례 재현 안 됨)
- [ ] 운영 서버 docker ps 에 9개 컨테이너 healthy 상태 유지