### PR TITLE
release: dev → main (#274 BUSY anomaly 분리 + tool_choice 결정성)

### DIFF
--- a/service-ai/app/ai/interface.py
+++ b/service-ai/app/ai/interface.py
@@ -7,8 +7,18 @@ class AIAnalyzer(ABC):
     """AI 혼잡 원인 분석 인터페이스"""
 
     @abstractmethod
-    async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
-        """혼잡도 이벤트 배치를 받아 원인 분석 결과를 반환한다."""
+    async def analyze(
+        self,
+        events: list[CongestionEvent],
+        *,
+        mode: str = "normal",
+    ) -> list[AnalysisResult]:
+        """혼잡도 이벤트 배치를 받아 원인 분석 결과를 반환한다.
+
+        mode:
+          - "normal": 일반 분석. tools 조건부 주입.
+          - "anomaly": 이상 패턴 분석. SYSTEM_PROMPT_ANOMALY + tool_choice='required'.
+        """
 
     async def close(self) -> None:
         """리소스 정리. 기본 구현은 아무것도 하지 않음."""

--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -19,7 +19,7 @@ import httpx
 from app.ai.interface import AIAnalyzer
 from app.ai.mcp.client import MCPClient
 from app.ai.openai.errors import _classify_429
-from app.ai.openai.prompt import build_system_prompt
+from app.ai.openai.prompt import build_anomaly_system_prompt, build_system_prompt
 from app.ai.rate_limiter import RateLimiter, estimate_prompt_tokens
 from app.config import settings
 from app.models.schemas import AnalysisResult, CongestionEvent
@@ -43,8 +43,14 @@ class OpenAIAnalyzer(AIAnalyzer):
         )
         self._mcp_client = mcp_client
 
-    async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
-        system_prompt = build_system_prompt()
+    async def analyze(
+        self,
+        events: list[CongestionEvent],
+        *,
+        mode: str = "normal",
+    ) -> list[AnalysisResult]:
+        is_anomaly = mode == "anomaly"
+        system_prompt = build_anomaly_system_prompt() if is_anomaly else build_system_prompt()
         user_content = json.dumps(
             [e.model_dump() for e in events], ensure_ascii=False
         )
@@ -66,8 +72,11 @@ class OpenAIAnalyzer(AIAnalyzer):
                 self._rate_limiter.tpd_used_ratio(),
             )
 
+        # anomaly 모드 + tools 사용 가능 → tool_choice='required' 로 강제 호출
+        tool_choice = "required" if (is_anomaly and not tools_disabled and tools) else None
+
         # hop 1
-        message = await self._call_llm(messages, tools)
+        message = await self._call_llm(messages, tools, tool_choice=tool_choice)
         tool_calls = message.get("tool_calls") or []
 
         # tool calls 있으면 실행 후 hop 2 (max_hops=1 고정)
@@ -124,6 +133,8 @@ class OpenAIAnalyzer(AIAnalyzer):
         self,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None,
+        *,
+        tool_choice: str | None = None,
     ) -> dict[str, Any]:
         """LLM 1회 호출. RateLimiter acquire/record + 429 분류.
 
@@ -139,6 +150,8 @@ class OpenAIAnalyzer(AIAnalyzer):
             }
             if tools:
                 body["tools"] = tools
+                if tool_choice is not None:
+                    body["tool_choice"] = tool_choice
 
             response = await self._client.post("/chat/completions", json=body)
 

--- a/service-ai/app/ai/openai/prompt.py
+++ b/service-ai/app/ai/openai/prompt.py
@@ -36,5 +36,30 @@ analysis_message는 한 문장으로 짧게 (예: "강남역 콘서트로 인한
 """
 
 
+SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데이터를 분석하는 전문가입니다.
+현재 날짜: {today}
+
+입력된 이벤트는 **이상 패턴(anomaly)** 으로 사전 분류된 BUSY 이벤트입니다.
+각 이벤트는 `max_people_count`(현재값) 과 `avg_max_people`(해당 시간대 7일 평균),
+`ratio`(현재/평균) 필드를 포함할 수 있습니다.
+
+[필수 규칙]
+- 이상 패턴이므로 일반론(출퇴근, 점심 등) 만으로 설명하지 마세요.
+- 외부 원인(축제, 콘서트, 시위, 행사, 사고, 공사, 날씨 이벤트 등) 을 확인하기 위해
+  반드시 search_web 도구를 1회 이상 호출하세요.
+- 검색 쿼리는 지역명 + 현재 날짜 + 가능한 키워드(예: 축제/행사/콘서트/시위/사고) 조합으로 구성.
+- 검색 결과를 근거로 가장 가능성 높은 원인을 한 문장으로 요약.
+- 외부 원인 단서가 부족하면 "원인 불명, 추가 모니터링 필요" 라고 명시.
+
+응답은 반드시 {{"results": [...]}} 형태의 JSON 객체로,
+각 항목에 area_code, area_name, analysis_message 필드를 포함하세요.
+analysis_message는 한 문장으로 짧게.
+"""
+
+
 def build_system_prompt() -> str:
     return SYSTEM_PROMPT_TEMPLATE.format(today=datetime.now(KST).date().isoformat())
+
+
+def build_anomaly_system_prompt() -> str:
+    return SYSTEM_PROMPT_ANOMALY_TEMPLATE.format(today=datetime.now(KST).date().isoformat())

--- a/service-ai/app/ai/stub.py
+++ b/service-ai/app/ai/stub.py
@@ -5,13 +5,19 @@ from app.models.schemas import AnalysisResult, CongestionEvent
 class StubAnalyzer(AIAnalyzer):
     """테스트용 Stub — 고정 메시지를 반환한다."""
 
-    async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
+    async def analyze(
+        self,
+        events: list[CongestionEvent],
+        *,
+        mode: str = "normal",
+    ) -> list[AnalysisResult]:
+        tag = "Stub-Anomaly" if mode == "anomaly" else "Stub"
         return [
             AnalysisResult(
                 area_name=e.area_name,
                 area_code=e.area_code,
                 congestion_level=e.congestion_level,
-                analysis_message=f"[Stub] {e.area_name}({e.area_code}) 지역이 {e.congestion_level} 상태입니다. "
+                analysis_message=f"[{tag}] {e.area_name}({e.area_code}) 지역이 {e.congestion_level} 상태입니다. "
                                  f"인근 행사 및 출퇴근 시간대 영향으로 추정됩니다.",
                 population_time=e.population_time,
             )

--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # ── RabbitMQ ──
     rabbitmq_url: str  # amqp://{user}:{pass}@{host}:{port}/
     rabbitmq_queue: str = "ai.congestion.analysis"
+    rabbitmq_anomaly_queue: str = "ai.congestion.anomaly"
 
     # ── RabbitMQ DLX / DLQ ──
     # - DLX: direct, durable

--- a/service-ai/app/models/schemas.py
+++ b/service-ai/app/models/schemas.py
@@ -7,6 +7,9 @@ class CongestionEvent(BaseModel):
     congestion_level: str
     max_people_count: int
     population_time: str
+    # anomaly 메시지에서만 실려옴 (일반 메시지엔 None)
+    avg_max_people: float | None = None
+    ratio: float | None = None
 
 
 class AnalysisResult(BaseModel):

--- a/service-ai/app/rabbitmq/batch.py
+++ b/service-ai/app/rabbitmq/batch.py
@@ -21,15 +21,29 @@ class BatchProcessor:
     - 버퍼 항목: (event, IncomingMessage) 쌍
     - 처리 결과에 따라 ack / nack(requeue=False) 라우팅
     - nack(requeue=False): DLX 경유 DLQ 이동 (재시도는 DLQWorker 담당)
+    - mode: "normal" 또는 "anomaly". analyzer 에 전달되어 시스템 프롬프트/tool_choice 분기.
+    - max_size / window_seconds 인자 미지정 시 settings 기본값 사용.
+      anomaly 큐는 max_size=1 로 즉시 처리.
     """
 
     def __init__(
         self,
         analyzer: AIAnalyzer,
         publisher: RabbitMQPublisher,
+        *,
+        mode: str = "normal",
+        max_size: int | None = None,
+        window_seconds: float | None = None,
+        name: str | None = None,
     ) -> None:
         self._analyzer = analyzer
         self._publisher = publisher
+        self._mode = mode
+        self._max_size = max_size if max_size is not None else settings.batch_max_size
+        self._window_seconds = (
+            window_seconds if window_seconds is not None else settings.batch_window_seconds
+        )
+        self._name = name or mode
         self._buffer: list[BatchItem] = []
         self._lock = asyncio.Lock()
         self._timer_task: asyncio.Task | None = None
@@ -39,9 +53,11 @@ class BatchProcessor:
         self._running = True
         self._timer_task = asyncio.create_task(self._timer_loop())
         logger.info(
-            "[BatchProcessor] 시작 (window=%ss, max_size=%d)",
-            settings.batch_window_seconds,
-            settings.batch_max_size,
+            "[BatchProcessor:%s] 시작 (mode=%s, window=%ss, max_size=%d)",
+            self._name,
+            self._mode,
+            self._window_seconds,
+            self._max_size,
         )
 
     async def stop(self) -> None:
@@ -59,7 +75,7 @@ class BatchProcessor:
         items: list[BatchItem] | None = None
         async with self._lock:
             self._buffer.append((event, message))
-            if len(self._buffer) >= settings.batch_max_size:
+            if len(self._buffer) >= self._max_size:
                 items = self._buffer.copy()
                 self._buffer.clear()
         if items is not None:
@@ -67,7 +83,7 @@ class BatchProcessor:
 
     async def _timer_loop(self) -> None:
         while self._running:
-            await asyncio.sleep(settings.batch_window_seconds)
+            await asyncio.sleep(self._window_seconds)
             await self._flush()
 
     async def _flush(self) -> None:
@@ -113,10 +129,10 @@ class BatchProcessor:
         if not items:
             return
         events = [event for event, _ in items]
-        logger.info("[BatchProcessor] 배치 처리 시작 - %d건", len(events))
+        logger.info("[BatchProcessor:%s] 배치 처리 시작 - %d건", self._name, len(events))
 
         try:
-            results = await self._analyzer.analyze(events)
+            results = await self._analyzer.analyze(events, mode=self._mode)
         except NonRetriableError as e:
             await self._dlq_all(items, f"NonRetriableError: {e}")
             return
@@ -136,7 +152,8 @@ class BatchProcessor:
 
         await self._ack_all(items)
         logger.info(
-            "[BatchProcessor] 배치 처리 완료 - 분석=%d건, 입력=%d건",
+            "[BatchProcessor:%s] 배치 처리 완료 - 분석=%d건, 입력=%d건",
+            self._name,
             len(results),
             len(items),
         )

--- a/service-ai/app/rabbitmq/consumer.py
+++ b/service-ai/app/rabbitmq/consumer.py
@@ -18,13 +18,19 @@ MAX_RECONNECT_DELAY = 30
 class RabbitMQConsumer:
     """RabbitMQ 혼잡도 이벤트 수신 → BatchProcessor 전달.
 
-    - DLX/DLQ 토폴로지 선언
-    - 메인 큐: x-dead-letter-exchange 인자 포함
+    - DLX/DLQ 토폴로지 선언 (공유 DLX/DLQ)
+    - 메인 큐: x-dead-letter-exchange 인자 포함, DLQ routing key 는 settings.rabbitmq_queue 공유
     - ack/nack: BatchProcessor 담당 (여기서는 파싱 실패만 즉시 DLQ)
+    - queue_name 인자로 일반(`ai.congestion.analysis`) / anomaly(`ai.congestion.anomaly`) 분기
     """
 
-    def __init__(self, batch_processor: BatchProcessor) -> None:
+    def __init__(
+        self,
+        batch_processor: BatchProcessor,
+        queue_name: str | None = None,
+    ) -> None:
         self._batch = batch_processor
+        self._queue_name = queue_name or settings.rabbitmq_queue
         self._connection: aio_pika.abc.AbstractRobustConnection | None = None
         self._channel: aio_pika.abc.AbstractChannel | None = None
         self._running = False
@@ -45,8 +51,8 @@ class RabbitMQConsumer:
         """DLX, DLQ, 메인 큐 선언.
 
         - 1) DLX (direct, durable)
-        - 2) DLQ (TTL + max-length) → DLX 에 바인딩
-        - 3) 메인 큐 (x-dead-letter-exchange 인자 포함)
+        - 2) DLQ (TTL + max-length) → DLX 에 바인딩 (공유, routing_key=settings.rabbitmq_queue)
+        - 3) 메인 큐 (x-dead-letter-exchange 인자 포함, dead-letter-routing-key 는 공유 DLQ 키)
         - 기존 메인 큐가 DLX 인자 없이 존재 → PRECONDITION_FAILED 발생
           · 대응: 경고 로그 + passive 재선언 (마이그레이션 안내)
           · 마이그레이션: 관리 UI 에서 큐 삭제 또는 재선언 스크립트 필요
@@ -58,7 +64,7 @@ class RabbitMQConsumer:
             durable=True,
         )
 
-        # 2. DLQ 선언 (TTL + max-length)
+        # 2. DLQ 선언 (TTL + max-length, 모든 메인 큐가 공유)
         dlq = await channel.declare_queue(
             settings.rabbitmq_dlq_name,
             durable=True,
@@ -76,7 +82,7 @@ class RabbitMQConsumer:
         }
         try:
             queue = await channel.declare_queue(
-                settings.rabbitmq_queue,
+                self._queue_name,
                 durable=True,
                 arguments=main_args,
             )
@@ -84,7 +90,7 @@ class RabbitMQConsumer:
             logger.warning(
                 "[Consumer] 메인 큐 '%s' 가 DLX 인자 없이 이미 존재합니다. "
                 "DLQ 라우팅 활성화 → RabbitMQ Management UI 에서 큐 삭제 후 재시작 필요. 원인: %s",
-                settings.rabbitmq_queue,
+                self._queue_name,
                 e,
             )
             # PRECONDITION_FAILED → 채널 닫힘 가능성 → 새 채널 확보
@@ -92,7 +98,7 @@ class RabbitMQConsumer:
                 self._channel = await self._connection.channel()  # type: ignore[union-attr]
                 await self._channel.set_qos(prefetch_count=5)
                 queue = await self._channel.declare_queue(
-                    settings.rabbitmq_queue,
+                    self._queue_name,
                     durable=True,
                 )
             except Exception:
@@ -112,7 +118,7 @@ class RabbitMQConsumer:
 
                 logger.info(
                     "[Consumer] RabbitMQ 연결 완료 - queue=%s, dlq=%s, dlx=%s",
-                    settings.rabbitmq_queue,
+                    self._queue_name,
                     settings.rabbitmq_dlq_name,
                     settings.dlq_dlx_name,
                 )
@@ -136,6 +142,8 @@ class RabbitMQConsumer:
                 congestion_level=body["congestionLevel"],
                 max_people_count=body["maxPeopleCount"],
                 population_time=body["populationTime"],
+                avg_max_people=body.get("avgMaxPeople"),
+                ratio=body.get("ratio"),
             )
         except Exception as e:
             logger.error("[Consumer] 메시지 파싱 실패, DLQ 라우팅 - %s", e)

--- a/service-ai/main.py
+++ b/service-ai/main.py
@@ -19,8 +19,19 @@ logger = logging.getLogger(__name__)
 mcp_client = MCPClient()
 analyzer = create_analyzer(mcp_client)
 publisher = RabbitMQPublisher()
-batch_processor = BatchProcessor(analyzer, publisher)
-consumer = RabbitMQConsumer(batch_processor)
+batch_processor = BatchProcessor(analyzer, publisher, name="normal")
+anomaly_batch_processor = BatchProcessor(
+    analyzer,
+    publisher,
+    mode="anomaly",
+    max_size=1,
+    name="anomaly",
+)
+consumer = RabbitMQConsumer(batch_processor, queue_name=settings.rabbitmq_queue)
+anomaly_consumer = RabbitMQConsumer(
+    anomaly_batch_processor,
+    queue_name=settings.rabbitmq_anomaly_queue,
+)
 dlq_worker = DLQWorker()
 
 
@@ -31,7 +42,9 @@ async def lifespan(app: FastAPI):
     await mcp_client.start()
     await publisher.connect()
     await batch_processor.start()
+    await anomaly_batch_processor.start()
     await consumer.start()
+    await anomaly_consumer.start()
     await dlq_worker.start()
     logger.info("[AI Service] 시작 완료")
 
@@ -39,7 +52,9 @@ async def lifespan(app: FastAPI):
 
     # shutdown
     await dlq_worker.stop()
+    await anomaly_consumer.stop()
     await consumer.stop()
+    await anomaly_batch_processor.stop()
     await batch_processor.stop()
     await analyzer.close()
     await publisher.close()

--- a/service-ai/tests/test_batch_ack_nack.py
+++ b/service-ai/tests/test_batch_ack_nack.py
@@ -42,7 +42,12 @@ class FakeAnalyzer:
         self.behaviour = behaviour
         self.calls = 0
 
-    async def analyze(self, events: list[CongestionEvent]) -> list[AnalysisResult]:
+    async def analyze(
+        self,
+        events: list[CongestionEvent],
+        *,
+        mode: str = "normal",
+    ) -> list[AnalysisResult]:
         self.calls += 1
         if self.behaviour == "non_retriable":
             raise NonRetriableError(error_code="queue_exceeded", message="full")

--- a/service-congestion/src/main/java/com/danburn/congestion/config/rabbitmq/RabbitMqConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/rabbitmq/RabbitMqConfig.java
@@ -16,6 +16,8 @@ public class RabbitMqConfig {
     public static final String EXCHANGE_NAME = "congestion.events";
     public static final String BUSY_ROUTING_KEY = "congestion.busy";
     public static final String BUSY_QUEUE_NAME = "ai.congestion.analysis";
+    public static final String ANOMALY_ROUTING_KEY = "congestion.busy.anomaly";
+    public static final String ANOMALY_QUEUE_NAME = "ai.congestion.anomaly";
     public static final String AI_REPORT_ROUTING_KEY = "ai.report";
     public static final String AI_REPORT_QUEUE_NAME = "congestion.ai.report";
 
@@ -40,6 +42,21 @@ public class RabbitMqConfig {
         return BindingBuilder.bind(congestionBusyQueue)
                 .to(congestionExchange)
                 .with(BUSY_ROUTING_KEY);
+    }
+
+    @Bean
+    public Queue congestionAnomalyQueue() {
+        return QueueBuilder.durable(ANOMALY_QUEUE_NAME)
+                .withArgument("x-dead-letter-exchange", BUSY_QUEUE_DLX)
+                .withArgument("x-dead-letter-routing-key", BUSY_QUEUE_DLX_ROUTING_KEY)
+                .build();
+    }
+
+    @Bean
+    public Binding congestionAnomalyBinding(Queue congestionAnomalyQueue, TopicExchange congestionExchange) {
+        return BindingBuilder.bind(congestionAnomalyQueue)
+                .to(congestionExchange)
+                .with(ANOMALY_ROUTING_KEY);
     }
 
     @Bean

--- a/service-congestion/src/main/java/com/danburn/congestion/event/CongestionAnomalyEvent.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/event/CongestionAnomalyEvent.java
@@ -1,0 +1,14 @@
+package com.danburn.congestion.event;
+
+/**
+ * BUSY 구간 중 current/avg 비율 임계 초과 시 RabbitMQ 로 발행되는 anomaly 이벤트
+ */
+public record CongestionAnomalyEvent(
+        String areaName,
+        String areaCode,
+        String congestionLevel,
+        Integer maxPeopleCount,
+        Double avgMaxPeople,
+        Double ratio,
+        String populationTime
+) {}

--- a/service-congestion/src/main/java/com/danburn/congestion/event/CongestionEventPublisher.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/event/CongestionEventPublisher.java
@@ -22,4 +22,15 @@ public class CongestionEventPublisher {
         log.info("[EventPublisher] BUSY 이벤트 발행 - areaCode={}, time={}",
                 event.areaCode(), event.populationTime());
     }
+
+    public void publishAnomalyEvent(CongestionAnomalyEvent event) {
+        rabbitTemplate.convertAndSend(
+                RabbitMqConfig.EXCHANGE_NAME,
+                RabbitMqConfig.ANOMALY_ROUTING_KEY,
+                event
+        );
+        log.info("[EventPublisher] ANOMALY 이벤트 발행 - areaCode={}, current={}, avg={}, ratio={}, time={}",
+                event.areaCode(), event.maxPeopleCount(), event.avgMaxPeople(),
+                event.ratio(), event.populationTime());
+    }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/scheduler/CongestionScheduler.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/scheduler/CongestionScheduler.java
@@ -1,10 +1,13 @@
 package com.danburn.congestion.scheduler;
 
+import com.danburn.congestion.domain.CongestionLevel;
 import com.danburn.congestion.dto.CongestionRedisDto;
 import com.danburn.congestion.dto.response.CongestionApiResponse;
+import com.danburn.congestion.event.CongestionAnomalyEvent;
 import com.danburn.congestion.event.CongestionBusyEvent;
 import com.danburn.congestion.event.CongestionEventPublisher;
 import com.danburn.congestion.infra.SeoulApiClient;
+import com.danburn.congestion.service.AnomalyDetector;
 import com.danburn.congestion.service.CongestionService;
 import com.danburn.congestion.service.CongestionStateTracker;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ public class CongestionScheduler {
     private final SeoulApiClient seoulApiClient;
     private final CongestionService congestionService;
     private final CongestionStateTracker stateTracker;
+    private final AnomalyDetector anomalyDetector;
     private final CongestionEventPublisher eventPublisher;
 
     @Scheduled(
@@ -97,6 +101,32 @@ public class CongestionScheduler {
                 log.warn("[CongestionScheduler] 이벤트 발행 실패 - areaCode={}, reason={}",
                         areaCode, e.getMessage());
             }
+        }
+
+        List<CongestionRedisDto> busyDtos = dtos.stream()
+                .filter(dto -> {
+                    if (dto.congestionLevel() == null) return false;
+                    try {
+                        return CongestionLevel.fromDescription(dto.congestionLevel()) == CongestionLevel.BUSY;
+                    } catch (IllegalArgumentException e) {
+                        return false;
+                    }
+                })
+                .toList();
+
+        for (CongestionAnomalyEvent event : anomalyDetector.detectAnomalies(busyDtos)) {
+            try {
+                eventPublisher.publishAnomalyEvent(event);
+            } catch (Exception e) {
+                log.warn("[CongestionScheduler] anomaly 이벤트 발행 실패 - areaCode={}, reason={}",
+                        event.areaCode(), e.getMessage());
+            }
+        }
+
+        try {
+            anomalyDetector.releaseArmedForNonBusy(dtos);
+        } catch (Exception e) {
+            log.warn("[CongestionScheduler] anomaly armed 정리 실패 - reason={}", e.getMessage());
         }
     }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -1,0 +1,156 @@
+package com.danburn.congestion.service;
+
+import com.danburn.congestion.domain.CongestionLevel;
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.event.CongestionAnomalyEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * BUSY 구간 중 current/avg 비율 임계 초과 anomaly 감지.
+ *
+ * - rising-edge 1회 발행: Redis SETNX armed 플래그(`congestion:anomaly-armed:{areaCode}`, TTL 24h)
+ * - BUSY 해제 시 armed 플래그 명시 삭제 (BUSY 재진입 시 재발행 허용)
+ * - baseline 부재 시 보수적으로 anomaly=true fallback
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnomalyDetector {
+
+    private static final String ARMED_KEY_PREFIX = "congestion:anomaly-armed:";
+    private static final Duration ARMED_TTL = Duration.ofHours(24);
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final HourlyAvgCacheService hourlyAvgCacheService;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Value("${congestion.anomaly.max-people-ratio:1.5}")
+    private double ratioThreshold;
+
+    public List<CongestionAnomalyEvent> detectAnomalies(List<CongestionRedisDto> busyDtos) {
+        if (busyDtos.isEmpty()) {
+            return List.of();
+        }
+        int hour = LocalDateTime.now(KST).getHour();
+        List<CongestionAnomalyEvent> events = new ArrayList<>();
+
+        for (CongestionRedisDto dto : busyDtos) {
+            String areaCode = dto.areaCode();
+            Integer current = dto.maxPeopleCount();
+            if (current == null) {
+                continue;
+            }
+
+            Optional<Double> avgOpt = hourlyAvgCacheService.getAvgMax(areaCode, hour);
+            double avgMax = avgOpt.orElse(0.0);
+
+            boolean anomaly;
+            double ratio;
+            if (avgOpt.isEmpty()) {
+                anomaly = true;
+                ratio = -1.0;
+                log.info("[AnomalyDetector] baseline 부재 fallback - areaCode={}", areaCode);
+            } else {
+                ratio = current.doubleValue() / avgMax;
+                anomaly = ratio >= ratioThreshold;
+            }
+
+            if (!anomaly) {
+                continue;
+            }
+
+            if (!tryArm(areaCode)) {
+                continue;
+            }
+
+            events.add(new CongestionAnomalyEvent(
+                    dto.areaName(),
+                    areaCode,
+                    dto.congestionLevel(),
+                    current,
+                    roundOne(avgMax),
+                    ratio < 0 ? null : roundTwo(ratio),
+                    dto.populationTime()
+            ));
+        }
+        return events;
+    }
+
+    public void releaseArmedForNonBusy(List<CongestionRedisDto> currentDtos) {
+        Set<String> armedKeys = scanArmedKeys();
+        if (armedKeys.isEmpty()) {
+            return;
+        }
+        Set<String> currentBusyCodes = new HashSet<>();
+        for (CongestionRedisDto dto : currentDtos) {
+            if (dto.congestionLevel() == null) {
+                continue;
+            }
+            try {
+                if (CongestionLevel.fromDescription(dto.congestionLevel()) == CongestionLevel.BUSY) {
+                    currentBusyCodes.add(dto.areaCode());
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        List<String> toDelete = new ArrayList<>();
+        for (String key : armedKeys) {
+            String areaCode = key.substring(ARMED_KEY_PREFIX.length());
+            if (!currentBusyCodes.contains(areaCode)) {
+                toDelete.add(key);
+            }
+        }
+        if (!toDelete.isEmpty()) {
+            stringRedisTemplate.delete(toDelete);
+            log.info("[AnomalyDetector] armed 플래그 해제 - {}건", toDelete.size());
+        }
+    }
+
+    private boolean tryArm(String areaCode) {
+        String key = ARMED_KEY_PREFIX + areaCode;
+        try {
+            Boolean set = stringRedisTemplate.opsForValue().setIfAbsent(key, "1", ARMED_TTL);
+            return Boolean.TRUE.equals(set);
+        } catch (Exception e) {
+            log.warn("[AnomalyDetector] armed 마킹 실패 - areaCode={}, reason={}", areaCode, e.getMessage());
+            return false;
+        }
+    }
+
+    private Set<String> scanArmedKeys() {
+        Set<String> keys = new HashSet<>();
+        ScanOptions options = ScanOptions.scanOptions().match(ARMED_KEY_PREFIX + "*").count(1000).build();
+        try (Cursor<String> cursor = stringRedisTemplate.scan(options)) {
+            while (cursor.hasNext()) {
+                keys.add(cursor.next());
+            }
+        } catch (Exception e) {
+            log.warn("[AnomalyDetector] armed 키 스캔 실패 - reason={}", e.getMessage());
+        }
+        return keys;
+    }
+
+    private static double roundOne(double v) {
+        return Math.round(v * 10) / 10.0;
+    }
+
+    private static double roundTwo(double v) {
+        return Math.round(v * 100) / 100.0;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/service/HourlyAvgCacheService.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/HourlyAvgCacheService.java
@@ -1,0 +1,70 @@
+package com.danburn.congestion.service;
+
+import com.danburn.congestion.dto.response.CongestionTrendResponse;
+import com.danburn.congestion.dto.response.CongestionTrendResponse.TrendData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 시간대별 avgMaxPeople baseline 캐싱 (Redis, TTL 1h)
+ *
+ * key: congestion:hourly-avg:{areaCode}:{hour}
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HourlyAvgCacheService {
+
+    private static final String KEY_PREFIX = "congestion:hourly-avg:";
+    private static final Duration TTL = Duration.ofHours(1);
+    private static final int LOOKBACK_DAYS = 7;
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final CongestionAnalysisService analysisService;
+
+    public Optional<Double> getAvgMax(String areaCode, int hour) {
+        String key = KEY_PREFIX + areaCode + ":" + hour;
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(key);
+            if (cached != null) {
+                return Optional.of(Double.parseDouble(cached));
+            }
+        } catch (NumberFormatException e) {
+            log.warn("[HourlyAvgCache] 캐시 파싱 실패 - key={}, reason={}", key, e.getMessage());
+        } catch (Exception e) {
+            log.warn("[HourlyAvgCache] 캐시 조회 실패 - key={}, reason={}", key, e.getMessage());
+        }
+
+        Optional<Double> avgMax = loadAvgMaxFromDb(areaCode, hour);
+        avgMax.ifPresent(value -> writeCache(key, value));
+        return avgMax;
+    }
+
+    private Optional<Double> loadAvgMaxFromDb(String areaCode, int hour) {
+        try {
+            CongestionTrendResponse trend = analysisService.getHourlyTrend(areaCode, LOOKBACK_DAYS);
+            return trend.data().stream()
+                    .filter(d -> d.key() == hour)
+                    .map(TrendData::avgMaxPeople)
+                    .filter(v -> v > 0)
+                    .findFirst();
+        } catch (Exception e) {
+            log.warn("[HourlyAvgCache] DB baseline 조회 실패 - areaCode={}, hour={}, reason={}",
+                    areaCode, hour, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private void writeCache(String key, double value) {
+        try {
+            stringRedisTemplate.opsForValue().set(key, Double.toString(value), TTL);
+        } catch (Exception e) {
+            log.warn("[HourlyAvgCache] 캐시 저장 실패 - key={}, reason={}", key, e.getMessage());
+        }
+    }
+}

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -71,3 +71,5 @@ congestion:
   cleanup:
     cron: ${CONGESTION_CLEANUP_CRON:0 0 3 * * *}
     retention-days: ${CONGESTION_CLEANUP_RETENTION_DAYS:7}
+  anomaly:
+    max-people-ratio: ${CONGESTION_ANOMALY_MAX_PEOPLE_RATIO:1.5}

--- a/service-congestion/src/test/java/com/danburn/congestion/scheduler/CongestionSchedulerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/scheduler/CongestionSchedulerTest.java
@@ -4,6 +4,7 @@ import com.danburn.congestion.dto.CongestionRedisDto;
 import com.danburn.congestion.dto.response.CongestionApiResponse;
 import com.danburn.congestion.event.CongestionEventPublisher;
 import com.danburn.congestion.infra.SeoulApiClient;
+import com.danburn.congestion.service.AnomalyDetector;
 import com.danburn.congestion.service.CongestionService;
 import com.danburn.congestion.service.CongestionStateTracker;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +33,9 @@ class CongestionSchedulerTest {
 
     @Mock
     private CongestionStateTracker stateTracker;
+
+    @Mock
+    private AnomalyDetector anomalyDetector;
 
     @Mock
     private CongestionEventPublisher eventPublisher;


### PR DESCRIPTION
## Summary
dev → main promotion. 본 사이클에 포함된 변경:

- #274 BUSY anomaly 감지 이벤트 분리 + AI MCP tool_choice 결정성 확보 (PR #280)

## 포함된 변경 요약

### service-congestion
- 신규 \`HourlyAvgCacheService\` — Redis 시간대별 avgMaxPeople baseline 캐싱 (TTL 1h, lookback 7d)
- 신규 \`AnomalyDetector\` — current/avg ≥ 1.5 시 anomaly 발행, Redis SETNX armed 플래그로 BUSY 당 1회만, BUSY 해제 시 cleanup
- 신규 \`CongestionAnomalyEvent\` DTO (avgMaxPeople, ratio)
- 새 routing_key \`congestion.busy.anomaly\` + 큐 \`ai.congestion.anomaly\` (공유 DLX/DLQ)
- env \`CONGESTION_ANOMALY_MAX_PEOPLE_RATIO\` (default 1.5)

### service-ai
- 두 번째 RabbitMQConsumer + max_size=1 BatchProcessor (즉시 처리)
- \`OpenAIAnalyzer\` mode=anomaly 시 \`SYSTEM_PROMPT_ANOMALY\` + \`tool_choice="required"\`
- TPD soft limit 도달 시 자연 폴백 유지

## 운영 적용 시 주의
- 첫 배포 시 \`CONGESTION_ANOMALY_MAX_PEOPLE_RATIO=2.0\` 으로 보수적 시작 후 며칠 관측 → 1.5 로 하향 권장 (env 만으로 가능)
- 빠른 비활성화 필요 시 threshold 를 999.0 으로 임시 변경
- anomaly 분석은 tool 강제이므로 TPD 사용량 증가 모니터링

## Test plan
- [x] dev PR(#280) CI 5/5 통과 (build-ai, build-java x4)
- [ ] main 머지 후 운영 배포 → Grafana \`[Analysis]\` 로그에서 \`tool_called: true\` 비율 확인
- [ ] Grafana \`tool_results\` 검색 결과 확인
- [ ] DLQ(\`ai.congestion.dlq\`) 적재 없는지 확인