### PR TITLE
feat: 주변 가게 찾기 API 구현 및 Redis 캐싱 적용 (#268)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,8 @@ services:
     ports:
       - "8083:8083"
     environment:
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/danburn_map?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
       - SPRING_DATASOURCE_USERNAME=${MAP_DB_USERNAME:-root}
       - SPRING_DATASOURCE_PASSWORD=${MAP_DB_PASSWORD:-root}
@@ -136,6 +138,8 @@ services:
       - SEOUL_API_KEY=${SEOUL_API_KEY}
       - CONGESTION_SERVICE_URL=http://service-congestion:8082
     depends_on:
+      redis:
+        condition: service_healthy
       mysql:
         condition: service_healthy
       service-congestion:

--- a/service-map/build.gradle
+++ b/service-map/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'

--- a/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
+++ b/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
@@ -29,4 +29,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(400)
                 .body(ApiResponse.error(400, message));
     }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity.status(500)
+                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
+    }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,6 +31,7 @@ public class NearbyPlaceController {
     @GetMapping("/nearby-places")
     public ApiResponse<List<NearbyPlaceResponse>> getNearbyPlaces(
             @Parameter(description = "카테고리 코드 (ALL/FD6/CE7/AT4/CT1)", example = "ALL")
+            @Pattern(regexp = "FD6|CE7|AT4|CT1", message = "유효하지 않은 카테고리 코드입니다.")
             @RequestParam(defaultValue = "ALL") String categoryCode,
             @Parameter(description = "위도 (33.0 ~ 38.9)", example = "37.5759")
             @RequestParam @DecimalMin("33.0") @DecimalMax("38.9") Double latitude,

--- a/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
@@ -30,6 +30,8 @@ public class NearbyPlaceController {
     @Operation(summary = "주변 장소 조회", description = "위도/경도 기준 1km 이내 주변 장소를 카테고리별로 조회합니다.")
     @GetMapping("/nearby-places")
     public ApiResponse<List<NearbyPlaceResponse>> getNearbyPlaces(
+            @Parameter(description = "지역 코드 (예: POI009)", example = "POI009")
+            @RequestParam String areaCode,
             @Parameter(description = "카테고리 코드 (ALL/FD6/CE7/AT4/CT1)", example = "ALL")
             @Pattern(regexp = "ALL|FD6|CE7|AT4|CT1", message = "유효하지 않은 카테고리 코드입니다.")
             @RequestParam(defaultValue = "ALL") String categoryCode,
@@ -38,6 +40,6 @@ public class NearbyPlaceController {
             @Parameter(description = "경도 (124.5 ~ 132.0)", example = "126.9769")
             @RequestParam @DecimalMin("124.5") @DecimalMax("132.0") Double longitude) {
 
-        return ApiResponse.ok(nearbyPlaceService.getNearbyPlaces(categoryCode, longitude, latitude));
+        return ApiResponse.ok(nearbyPlaceService.getNearbyPlaces(areaCode, categoryCode, longitude, latitude));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
@@ -6,8 +6,6 @@ import com.danburn.map.service.NearbyPlaceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
@@ -27,19 +25,15 @@ public class NearbyPlaceController {
 
     private final NearbyPlaceService nearbyPlaceService;
 
-    @Operation(summary = "주변 장소 조회", description = "위도/경도 기준 1km 이내 주변 장소를 카테고리별로 조회합니다.")
+    @Operation(summary = "주변 장소 조회", description = "지역 코드 기준 1km 이내 주변 장소를 카테고리별로 조회합니다.")
     @GetMapping("/nearby-places")
     public ApiResponse<List<NearbyPlaceResponse>> getNearbyPlaces(
             @Parameter(description = "지역 코드 (예: POI009)", example = "POI009")
             @RequestParam String areaCode,
             @Parameter(description = "카테고리 코드 (ALL/FD6/CE7/AT4/CT1)", example = "ALL")
             @Pattern(regexp = "ALL|FD6|CE7|AT4|CT1", message = "유효하지 않은 카테고리 코드입니다.")
-            @RequestParam(defaultValue = "ALL") String categoryCode,
-            @Parameter(description = "위도 (33.0 ~ 38.9)", example = "37.5759")
-            @RequestParam @DecimalMin("33.0") @DecimalMax("38.9") Double latitude,
-            @Parameter(description = "경도 (124.5 ~ 132.0)", example = "126.9769")
-            @RequestParam @DecimalMin("124.5") @DecimalMax("132.0") Double longitude) {
+            @RequestParam(defaultValue = "ALL") String categoryCode) {
 
-        return ApiResponse.ok(nearbyPlaceService.getNearbyPlaces(areaCode, categoryCode, longitude, latitude));
+        return ApiResponse.ok(nearbyPlaceService.getNearbyPlaces(areaCode, categoryCode));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
@@ -31,7 +31,7 @@ public class NearbyPlaceController {
     @GetMapping("/nearby-places")
     public ApiResponse<List<NearbyPlaceResponse>> getNearbyPlaces(
             @Parameter(description = "카테고리 코드 (ALL/FD6/CE7/AT4/CT1)", example = "ALL")
-            @Pattern(regexp = "FD6|CE7|AT4|CT1", message = "유효하지 않은 카테고리 코드입니다.")
+            @Pattern(regexp = "ALL|FD6|CE7|AT4|CT1", message = "유효하지 않은 카테고리 코드입니다.")
             @RequestParam(defaultValue = "ALL") String categoryCode,
             @Parameter(description = "위도 (33.0 ~ 38.9)", example = "37.5759")
             @RequestParam @DecimalMin("33.0") @DecimalMax("38.9") Double latitude,

--- a/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
+++ b/service-map/src/main/java/com/danburn/map/controller/NearbyPlaceController.java
@@ -1,0 +1,41 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.map.dto.response.NearbyPlaceResponse;
+import com.danburn.map.service.NearbyPlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "주변 장소", description = "주변 맛집/놀거리 조회 API")
+@Validated
+@RestController
+@RequestMapping("/api/map")
+@RequiredArgsConstructor
+public class NearbyPlaceController {
+
+    private final NearbyPlaceService nearbyPlaceService;
+
+    @Operation(summary = "주변 장소 조회", description = "위도/경도 기준 1km 이내 주변 장소를 카테고리별로 조회합니다.")
+    @GetMapping("/nearby-places")
+    public ApiResponse<List<NearbyPlaceResponse>> getNearbyPlaces(
+            @Parameter(description = "카테고리 코드 (ALL/FD6/CE7/AT4/CT1)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") String categoryCode,
+            @Parameter(description = "위도 (33.0 ~ 38.9)", example = "37.5759")
+            @RequestParam @DecimalMin("33.0") @DecimalMax("38.9") Double latitude,
+            @Parameter(description = "경도 (124.5 ~ 132.0)", example = "126.9769")
+            @RequestParam @DecimalMin("124.5") @DecimalMax("132.0") Double longitude) {
+
+        return ApiResponse.ok(nearbyPlaceService.getNearbyPlaces(categoryCode, longitude, latitude));
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/KakaoLocalApiResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/KakaoLocalApiResponse.java
@@ -1,0 +1,26 @@
+package com.danburn.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record KakaoLocalApiResponse(
+  Meta meta,
+  List<Document> documents
+) {
+  public  record Meta(
+    @JsonProperty("total_count") int totalCount,
+    @JsonProperty("is_end") boolean isEnd
+  ){}
+
+  public record Document(
+    @JsonProperty("place_name") String placeName,
+    @JsonProperty("category_name") String categoryName,
+    @JsonProperty("address_name") String addressName,
+    @JsonProperty("road_address_name") String roadAddressName,
+    @JsonProperty("place_url") String placeUrl,
+    String distance,
+    String x,
+    String y
+  ) {}
+}

--- a/service-map/src/main/java/com/danburn/map/dto/response/NearbyPlaceResponse.java
+++ b/service-map/src/main/java/com/danburn/map/dto/response/NearbyPlaceResponse.java
@@ -1,0 +1,12 @@
+package com.danburn.map.dto.response;
+
+public record NearbyPlaceResponse(
+        String placeName,
+        String categoryName,
+        String addressName,
+        String roadAddressName,
+        String placeUrl,
+        double longitude,
+        double latitude
+) {
+}

--- a/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
@@ -1,0 +1,41 @@
+package com.danburn.map.infra;
+
+import com.danburn.map.dto.response.KakaoLocalApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Component
+public class KakaoLocalApiClient {
+
+    private final RestClient restClient;
+
+    public KakaoLocalApiClient(@Value("${kakao.api.key}") String apiKey) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(5));
+
+        this.restClient = RestClient.builder()
+            .baseUrl("https://dapi.kakao.com")
+            .defaultHeader("Authorization", "KakaoAK " + apiKey)
+            .requestFactory(factory)
+            .build();
+    }
+
+    public KakaoLocalApiResponse fetchNearbyPlaces(String categoryCode, double longitude, double latitude) {
+        return restClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path("/v2/local/search/category.json")
+                .queryParam("category_group_code", categoryCode)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", 1000)
+                .queryParam("sort", "distance")
+                .build())
+            .retrieve()
+            .body(KakaoLocalApiResponse.class);
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
@@ -11,31 +11,31 @@ import java.time.Duration;
 @Component
 public class KakaoLocalApiClient {
 
-    private final RestClient restClient;
+  private final RestClient restClient;
 
-    public KakaoLocalApiClient(@Value("${kakao.api.key}") String apiKey) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(5));
-        factory.setReadTimeout(Duration.ofSeconds(5));
+  public KakaoLocalApiClient(@Value("${kakao.api.key}") String apiKey) {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(Duration.ofSeconds(5));
+    factory.setReadTimeout(Duration.ofSeconds(5));
 
-        this.restClient = RestClient.builder()
-            .baseUrl("https://dapi.kakao.com")
-            .defaultHeader("Authorization", "KakaoAK " + apiKey)
-            .requestFactory(factory)
-            .build();
-    }
+    this.restClient = RestClient.builder()
+      .baseUrl("https://dapi.kakao.com")
+      .defaultHeader("Authorization", "KakaoAK " + apiKey)
+      .requestFactory(factory)
+      .build();
+  }
 
-    public KakaoLocalApiResponse fetchNearbyPlaces(String categoryCode, double longitude, double latitude) {
-        return restClient.get()
-            .uri(uriBuilder -> uriBuilder
-                .path("/v2/local/search/category.json")
-                .queryParam("category_group_code", categoryCode)
-                .queryParam("x", longitude)
-                .queryParam("y", latitude)
-                .queryParam("radius", 1000)
-                .queryParam("sort", "distance")
-                .build())
-            .retrieve()
-            .body(KakaoLocalApiResponse.class);
-    }
+  public KakaoLocalApiResponse fetchNearbyPlaces(String categoryCode, double longitude, double latitude) {
+    return restClient.get()
+      .uri(uriBuilder -> uriBuilder
+        .path("/v2/local/search/category.json")
+        .queryParam("category_group_code", categoryCode)
+        .queryParam("x", longitude)
+        .queryParam("y", latitude)
+        .queryParam("radius", 1000)
+        .queryParam("page", 10)
+        .build())
+      .retrieve()
+      .body(KakaoLocalApiResponse.class);
+  }
 }

--- a/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
+++ b/service-map/src/main/java/com/danburn/map/infra/KakaoLocalApiClient.java
@@ -33,7 +33,8 @@ public class KakaoLocalApiClient {
         .queryParam("x", longitude)
         .queryParam("y", latitude)
         .queryParam("radius", 1000)
-        .queryParam("page", 10)
+        .queryParam("page", 1)
+        .queryParam("size", 15)
         .build())
       .retrieve()
       .body(KakaoLocalApiResponse.class);

--- a/service-map/src/main/java/com/danburn/map/service/LocationCodeMapper.java
+++ b/service-map/src/main/java/com/danburn/map/service/LocationCodeMapper.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,21 +18,32 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class LocationCodeMapper {
 
+    public record Coordinate(double latitude, double longitude) {}
+
     private final LocationJpaRepository locationJpaRepository;
     private Map<String, Long> areaCodeToIdMap = new ConcurrentHashMap<>();
+    private Map<String, Coordinate> coordinateMap = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void init() {
         log.info("로컬 캐시에 Location Area Code 맵핑 정보를 로드합니다...");
-        areaCodeToIdMap = locationJpaRepository.findAll().stream()
+        List<Location> locations = locationJpaRepository.findAll();
+        areaCodeToIdMap = locations.stream()
+                .collect(Collectors.toConcurrentMap(Location::getApiAreaCode, Location::getLocationId));
+        coordinateMap = locations.stream()
+                .filter(l -> l.getLatitude() != null && l.getLongitude() != null)
                 .collect(Collectors.toConcurrentMap(
                         Location::getApiAreaCode,
-                        Location::getLocationId
+                        l -> new Coordinate(l.getLatitude(), l.getLongitude())
                 ));
         log.info("총 {}개의 Location Area Code가 로드되었습니다.", areaCodeToIdMap.size());
     }
 
     public Optional<Long> getLocationIdByAreaCode(String apiAreaCode) {
         return Optional.ofNullable(areaCodeToIdMap.get(apiAreaCode));
+    }
+
+    public Optional<Coordinate> getCoordinateByAreaCode(String apiAreaCode) {
+        return Optional.ofNullable(coordinateMap.get(apiAreaCode));
     }
 }

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -3,10 +3,14 @@ package com.danburn.map.service;
 import com.danburn.map.dto.response.KakaoLocalApiResponse;
 import com.danburn.map.dto.response.NearbyPlaceResponse;
 import com.danburn.map.infra.KakaoLocalApiClient;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.List;
 
 @Slf4j
@@ -15,19 +19,44 @@ import java.util.List;
 public class NearbyPlaceService {
 
     private static final List<String> ALL_CATEGORY_CODES = List.of("FD6", "CE7", "AT4", "CT1");
+    private static final Duration CACHE_TTL = Duration.ofHours(1);
 
     private final KakaoLocalApiClient kakaoLocalApiClient;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
 
-    public List<NearbyPlaceResponse> getNearbyPlaces(String categoryCode, double longitude, double latitude) {
+    public List<NearbyPlaceResponse> getNearbyPlaces(String areaCode, String categoryCode, double longitude, double latitude) {
         if ("ALL".equals(categoryCode)) {
             return ALL_CATEGORY_CODES.parallelStream()
-                    .flatMap(code -> fetchFromKakao(code, longitude, latitude).stream())
+                    .flatMap(code -> fetchWithCache(areaCode, code, longitude, latitude).stream())
                     .toList();
         }
-        return fetchFromKakao(categoryCode, longitude, latitude);
+        return fetchWithCache(areaCode, categoryCode, longitude, latitude);
     }
 
-    // TODO: Redis 캐싱 추가 시 이 메서드에 캐시 읽기/쓰기 로직 삽입
+    private List<NearbyPlaceResponse> fetchWithCache(String areaCode, String categoryCode, double longitude, double latitude) {
+        String cacheKey = "map:nearby:" + areaCode + ":" + categoryCode;
+
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(cacheKey);
+            if (cached != null) {
+                return objectMapper.readValue(cached, new TypeReference<>() {});
+            }
+        } catch (Exception e) {
+            log.warn("Redis 캐시 읽기 실패 - key: {}", cacheKey, e);
+        }
+
+        List<NearbyPlaceResponse> result = fetchFromKakao(categoryCode, longitude, latitude);
+
+        try {
+            stringRedisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(result), CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("Redis 캐시 쓰기 실패 - key: {}", cacheKey, e);
+        }
+
+        return result;
+    }
+
     private List<NearbyPlaceResponse> fetchFromKakao(String categoryCode, double longitude, double latitude) {
         try {
             KakaoLocalApiResponse response = kakaoLocalApiClient.fetchNearbyPlaces(categoryCode, longitude, latitude);

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -18,7 +18,7 @@ public class NearbyPlaceService {
 
     public List<NearbyPlaceResponse> getNearbyPlaces(String categoryCode, double longitude, double latitude) {
         if ("ALL".equals(categoryCode)) {
-            return ALL_CATEGORY_CODES.stream()
+            return ALL_CATEGORY_CODES.parallelStream()
                     .flatMap(code -> fetchFromKakao(code, longitude, latitude).stream())
                     .toList();
         }

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -1,0 +1,50 @@
+package com.danburn.map.service;
+
+import com.danburn.map.dto.response.KakaoLocalApiResponse;
+import com.danburn.map.dto.response.NearbyPlaceResponse;
+import com.danburn.map.infra.KakaoLocalApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NearbyPlaceService {
+
+    private static final List<String> ALL_CATEGORY_CODES = List.of("FD6", "CE7", "AT4", "CT1");
+
+    private final KakaoLocalApiClient kakaoLocalApiClient;
+
+    public List<NearbyPlaceResponse> getNearbyPlaces(String categoryCode, double longitude, double latitude) {
+        if ("ALL".equals(categoryCode)) {
+            return ALL_CATEGORY_CODES.stream()
+                    .flatMap(code -> fetchFromKakao(code, longitude, latitude).stream())
+                    .toList();
+        }
+        return fetchFromKakao(categoryCode, longitude, latitude);
+    }
+
+    // TODO: Redis 캐싱 추가 시 이 메서드에 캐시 읽기/쓰기 로직 삽입
+    private List<NearbyPlaceResponse> fetchFromKakao(String categoryCode, double longitude, double latitude) {
+        try {
+            KakaoLocalApiResponse response = kakaoLocalApiClient.fetchNearbyPlaces(categoryCode, longitude, latitude);
+            if (response == null || response.documents() == null) {
+                return List.of();
+            }
+            return response.documents().stream()
+                    .map(doc -> new NearbyPlaceResponse(
+                            doc.placeName(),
+                            doc.categoryName(),
+                            doc.addressName(),
+                            doc.roadAddressName(),
+                            doc.placeUrl(),
+                            doc.x() != null && !doc.x().isEmpty() ? Double.parseDouble(doc.x()) : 0.0,
+                            doc.y() != null && !doc.y().isEmpty() ? Double.parseDouble(doc.y()) : 0.0
+                    ))
+                    .toList();
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+}

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -48,10 +48,12 @@ public class NearbyPlaceService {
 
         List<NearbyPlaceResponse> result = fetchFromKakao(categoryCode, longitude, latitude);
 
-        try {
-            stringRedisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(result), CACHE_TTL);
-        } catch (Exception e) {
-            log.warn("Redis 캐시 쓰기 실패 - key: {}", cacheKey, e);
+        if (!result.isEmpty()) {
+            try {
+                stringRedisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(result), CACHE_TTL);
+            } catch (Exception e) {
+                log.warn("Redis 캐시 쓰기 실패 - key: {}", cacheKey, e);
+            }
         }
 
         return result;

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -4,10 +4,12 @@ import com.danburn.map.dto.response.KakaoLocalApiResponse;
 import com.danburn.map.dto.response.NearbyPlaceResponse;
 import com.danburn.map.infra.KakaoLocalApiClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NearbyPlaceService {
@@ -44,6 +46,7 @@ public class NearbyPlaceService {
                     ))
                     .toList();
         } catch (Exception e) {
+            log.warn("카카오 API 호출 실패 - categoryCode: {}", categoryCode, e);
             return List.of();
         }
     }

--- a/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
+++ b/service-map/src/main/java/com/danburn/map/service/NearbyPlaceService.java
@@ -1,5 +1,6 @@
 package com.danburn.map.service;
 
+import com.danburn.common.exception.GlobalException;
 import com.danburn.map.dto.response.KakaoLocalApiResponse;
 import com.danburn.map.dto.response.NearbyPlaceResponse;
 import com.danburn.map.infra.KakaoLocalApiClient;
@@ -24,8 +25,15 @@ public class NearbyPlaceService {
     private final KakaoLocalApiClient kakaoLocalApiClient;
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
+    private final LocationCodeMapper locationCodeMapper;
 
-    public List<NearbyPlaceResponse> getNearbyPlaces(String areaCode, String categoryCode, double longitude, double latitude) {
+    public List<NearbyPlaceResponse> getNearbyPlaces(String areaCode, String categoryCode) {
+        LocationCodeMapper.Coordinate coordinate = locationCodeMapper.getCoordinateByAreaCode(areaCode)
+                .orElseThrow(() -> new GlobalException(404, "존재하지 않는 지역 코드입니다: " + areaCode));
+
+        double longitude = coordinate.longitude();
+        double latitude = coordinate.latitude();
+
         if ("ALL".equals(categoryCode)) {
             return ALL_CATEGORY_CODES.parallelStream()
                     .flatMap(code -> fetchWithCache(areaCode, code, longitude, latitude).stream())

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -24,6 +24,14 @@ spring:
         - classpath:data.sql
         - classpath:alternative_locations_data.sql
 
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: 6379
+      password: ${SPRING_DATA_REDIS_PASSWORD:}
+      timeout: 500ms
+      connect-timeout: 500ms
+
 congestion:
   service:
     url: ${CONGESTION_SERVICE_URL:http://localhost:8082}

--- a/service-map/src/main/resources/application.yml
+++ b/service-map/src/main/resources/application.yml
@@ -28,6 +28,10 @@ congestion:
   service:
     url: ${CONGESTION_SERVICE_URL:http://localhost:8082}
 
+kakao:
+  api:
+    key: ${KAKAO_API_KEY:}
+
 server:
   port: 8083
   forward-headers-strategy: framework

--- a/service-map/src/test/java/com/danburn/map/controller/NearbyPlaceControllerTest.java
+++ b/service-map/src/test/java/com/danburn/map/controller/NearbyPlaceControllerTest.java
@@ -1,0 +1,122 @@
+package com.danburn.map.controller;
+
+import com.danburn.map.dto.response.NearbyPlaceResponse;
+import com.danburn.map.service.NearbyPlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = NearbyPlaceController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration.class
+        })
+@ActiveProfiles("test")
+class NearbyPlaceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NearbyPlaceService nearbyPlaceService;
+
+    private NearbyPlaceResponse createResponse(String placeName) {
+        return new NearbyPlaceResponse(placeName, "음식점 > 한식", "서울 마포구", "서울 마포구 어딘가", "https://place.map.kakao.com/123", 126.9769, 37.5759);
+    }
+
+    @Test
+    @DisplayName("GET /api/map/nearby-places → 정상 조회 성공")
+    void getNearbyPlaces_success() throws Exception {
+        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString(), anyDouble(), anyDouble()))
+                .willReturn(List.of(createResponse("맛집"), createResponse("카페")));
+
+        mockMvc.perform(get("/api/map/nearby-places")
+                        .param("areaCode", "POI009")
+                        .param("categoryCode", "ALL")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].placeName").value("맛집"));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/nearby-places → 결과 없을 때 빈 배열 반환")
+    void getNearbyPlaces_empty() throws Exception {
+        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString(), anyDouble(), anyDouble()))
+                .willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/map/nearby-places")
+                        .param("areaCode", "POI009")
+                        .param("categoryCode", "FD6")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/nearby-places → 잘못된 카테고리 코드 400")
+    void getNearbyPlaces_invalidCategoryCode() throws Exception {
+        mockMvc.perform(get("/api/map/nearby-places")
+                        .param("areaCode", "POI009")
+                        .param("categoryCode", "INVALID")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/nearby-places → 위도 범위 초과 400")
+    void getNearbyPlaces_latitudeOutOfRange() throws Exception {
+        mockMvc.perform(get("/api/map/nearby-places")
+                        .param("areaCode", "POI009")
+                        .param("categoryCode", "ALL")
+                        .param("latitude", "40.0")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/nearby-places → 경도 범위 초과 400")
+    void getNearbyPlaces_longitudeOutOfRange() throws Exception {
+        mockMvc.perform(get("/api/map/nearby-places")
+                        .param("areaCode", "POI009")
+                        .param("categoryCode", "ALL")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "140.0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/nearby-places → categoryCode 기본값 ALL로 조회")
+    void getNearbyPlaces_defaultCategoryCode() throws Exception {
+        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString(), anyDouble(), anyDouble()))
+                .willReturn(List.of(createResponse("맛집")));
+
+        mockMvc.perform(get("/api/map/nearby-places")
+                        .param("areaCode", "POI009")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/controller/NearbyPlaceControllerTest.java
+++ b/service-map/src/test/java/com/danburn/map/controller/NearbyPlaceControllerTest.java
@@ -1,5 +1,6 @@
 package com.danburn.map.controller;
 
+import com.danburn.common.exception.GlobalException;
 import com.danburn.map.dto.response.NearbyPlaceResponse;
 import com.danburn.map.service.NearbyPlaceService;
 import org.junit.jupiter.api.DisplayName;
@@ -13,8 +14,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -39,14 +41,12 @@ class NearbyPlaceControllerTest {
     @Test
     @DisplayName("GET /api/map/nearby-places → 정상 조회 성공")
     void getNearbyPlaces_success() throws Exception {
-        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString(), anyDouble(), anyDouble()))
+        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString()))
                 .willReturn(List.of(createResponse("맛집"), createResponse("카페")));
 
         mockMvc.perform(get("/api/map/nearby-places")
                         .param("areaCode", "POI009")
-                        .param("categoryCode", "ALL")
-                        .param("latitude", "37.5759")
-                        .param("longitude", "126.9769"))
+                        .param("categoryCode", "ALL"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data").isArray())
@@ -57,14 +57,12 @@ class NearbyPlaceControllerTest {
     @Test
     @DisplayName("GET /api/map/nearby-places → 결과 없을 때 빈 배열 반환")
     void getNearbyPlaces_empty() throws Exception {
-        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString(), anyDouble(), anyDouble()))
+        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString()))
                 .willReturn(Collections.emptyList());
 
         mockMvc.perform(get("/api/map/nearby-places")
                         .param("areaCode", "POI009")
-                        .param("categoryCode", "FD6")
-                        .param("latitude", "37.5759")
-                        .param("longitude", "126.9769"))
+                        .param("categoryCode", "FD6"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(0));
@@ -75,47 +73,32 @@ class NearbyPlaceControllerTest {
     void getNearbyPlaces_invalidCategoryCode() throws Exception {
         mockMvc.perform(get("/api/map/nearby-places")
                         .param("areaCode", "POI009")
-                        .param("categoryCode", "INVALID")
-                        .param("latitude", "37.5759")
-                        .param("longitude", "126.9769"))
+                        .param("categoryCode", "INVALID"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400));
     }
 
     @Test
-    @DisplayName("GET /api/map/nearby-places → 위도 범위 초과 400")
-    void getNearbyPlaces_latitudeOutOfRange() throws Exception {
-        mockMvc.perform(get("/api/map/nearby-places")
-                        .param("areaCode", "POI009")
-                        .param("categoryCode", "ALL")
-                        .param("latitude", "40.0")
-                        .param("longitude", "126.9769"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400));
-    }
+    @DisplayName("GET /api/map/nearby-places → 존재하지 않는 areaCode 404")
+    void getNearbyPlaces_invalidAreaCode_notFound() throws Exception {
+        willThrow(new GlobalException(404, "존재하지 않는 지역 코드입니다: UNKNOWN"))
+                .given(nearbyPlaceService).getNearbyPlaces("UNKNOWN", "ALL");
 
-    @Test
-    @DisplayName("GET /api/map/nearby-places → 경도 범위 초과 400")
-    void getNearbyPlaces_longitudeOutOfRange() throws Exception {
         mockMvc.perform(get("/api/map/nearby-places")
-                        .param("areaCode", "POI009")
-                        .param("categoryCode", "ALL")
-                        .param("latitude", "37.5759")
-                        .param("longitude", "140.0"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400));
+                        .param("areaCode", "UNKNOWN")
+                        .param("categoryCode", "ALL"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
     }
 
     @Test
     @DisplayName("GET /api/map/nearby-places → categoryCode 기본값 ALL로 조회")
     void getNearbyPlaces_defaultCategoryCode() throws Exception {
-        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString(), anyDouble(), anyDouble()))
+        given(nearbyPlaceService.getNearbyPlaces(anyString(), anyString()))
                 .willReturn(List.of(createResponse("맛집")));
 
         mockMvc.perform(get("/api/map/nearby-places")
-                        .param("areaCode", "POI009")
-                        .param("latitude", "37.5759")
-                        .param("longitude", "126.9769"))
+                        .param("areaCode", "POI009"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200));
     }

--- a/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class NearbyPlaceServiceTest {
@@ -51,8 +52,8 @@ class NearbyPlaceServiceTest {
 
     @BeforeEach
     void setUp() {
-        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
-        given(locationCodeMapper.getCoordinateByAreaCode("POI009")).willReturn(Optional.of(COORDINATE));
+        lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(locationCodeMapper.getCoordinateByAreaCode("POI009")).thenReturn(Optional.of(COORDINATE));
     }
 
     private KakaoLocalApiResponse createKakaoResponse(String placeName) {

--- a/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
@@ -1,0 +1,199 @@
+package com.danburn.map.service;
+
+import com.danburn.map.dto.response.KakaoLocalApiResponse;
+import com.danburn.map.dto.response.NearbyPlaceResponse;
+import com.danburn.map.infra.KakaoLocalApiClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NearbyPlaceServiceTest {
+
+    @Mock
+    private KakaoLocalApiClient kakaoLocalApiClient;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private NearbyPlaceService nearbyPlaceService;
+
+    @BeforeEach
+    void setUp() {
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    private KakaoLocalApiResponse createKakaoResponse(String placeName) {
+        return new KakaoLocalApiResponse(
+                new KakaoLocalApiResponse.Meta(1, true),
+                List.of(new KakaoLocalApiResponse.Document(
+                        placeName, "음식점 > 한식", "서울 마포구", "서울 마포구 어딘가",
+                        "https://place.map.kakao.com/123", "100", "126.9769", "37.5759"
+                ))
+        );
+    }
+
+    @Nested
+    @DisplayName("getNearbyPlaces")
+    class GetNearbyPlaces {
+
+        @Test
+        @DisplayName("단일 카테고리 - 캐시 미스 시 카카오 API 1회 호출 후 결과 반환")
+        void singleCategory_cacheMiss_returnsResult() {
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willReturn(createKakaoResponse("맛집"));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).placeName()).isEqualTo("맛집");
+            then(kakaoLocalApiClient).should().fetchNearbyPlaces("FD6", 126.9769, 37.5759);
+        }
+
+        @Test
+        @DisplayName("ALL 카테고리 - FD6/CE7/AT4/CT1 4개 카테고리 모두 호출 후 결과 합산")
+        void allCategory_callsFourApisAndMergesResults() {
+            given(valueOperations.get(anyString())).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces(anyString(), eq(126.9769), eq(37.5759)))
+                    .willReturn(createKakaoResponse("장소"));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "ALL", 126.9769, 37.5759);
+
+            assertThat(result).hasSize(4);
+            then(kakaoLocalApiClient).should(times(4)).fetchNearbyPlaces(anyString(), anyDouble(), anyDouble());
+        }
+    }
+
+    @Nested
+    @DisplayName("Redis 캐싱")
+    class Caching {
+
+        @Test
+        @DisplayName("캐시 히트 - Redis 데이터 반환, 카카오 API 호출 안 함")
+        void cacheHit_returnsRedisData_withoutCallingKakao() throws Exception {
+            List<NearbyPlaceResponse> cached = List.of(
+                    new NearbyPlaceResponse("맛집", "음식점", "서울 마포구", "서울 마포구 어딘가", "https://url", 126.9769, 37.5759)
+            );
+            String cachedJson = objectMapper.writeValueAsString(cached);
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(cachedJson);
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).placeName()).isEqualTo("맛집");
+            then(kakaoLocalApiClient).should(never()).fetchNearbyPlaces(any(), anyDouble(), anyDouble());
+        }
+
+        @Test
+        @DisplayName("캐시 미스 - 카카오 API 호출 후 Redis에 TTL 1시간으로 저장")
+        void cacheMiss_savesToRedisWithTtl() {
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willReturn(createKakaoResponse("맛집"));
+
+            nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            then(valueOperations).should().set(eq("map:nearby:POI009:FD6"), anyString(), eq(Duration.ofHours(1)));
+        }
+
+        @Test
+        @DisplayName("Redis 읽기 실패 - 카카오 API 폴백 후 결과 정상 반환")
+        void redisReadFailure_fallbackToKakao() {
+            given(valueOperations.get("map:nearby:POI009:FD6"))
+                    .willThrow(new RuntimeException("Redis 연결 실패"));
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willReturn(createKakaoResponse("맛집"));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).placeName()).isEqualTo("맛집");
+        }
+
+        @Test
+        @DisplayName("Redis 쓰기 실패 - 결과 정상 반환")
+        void redisWriteFailure_returnsResultNormally() {
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willReturn(createKakaoResponse("맛집"));
+            willThrow(new RuntimeException("Redis 쓰기 실패"))
+                    .given(valueOperations).set(anyString(), anyString(), any(Duration.class));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).placeName()).isEqualTo("맛집");
+        }
+    }
+
+    @Nested
+    @DisplayName("카카오 API 실패 처리")
+    class KakaoApiFailure {
+
+        @Test
+        @DisplayName("카카오 API 예외 - 빈 리스트 반환")
+        void kakaoApiException_returnsEmptyList() {
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willThrow(new RuntimeException("카카오 API 오류"));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("카카오 API null 응답 - 빈 리스트 반환")
+        void kakaoApiNullResponse_returnsEmptyList() {
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willReturn(null);
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("ALL 카테고리 중 일부 카카오 API 실패 - 성공한 카테고리 결과만 반환")
+        void allCategory_partialKakaoFailure_returnsPartialResults() {
+            given(valueOperations.get(anyString())).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces(eq("FD6"), anyDouble(), anyDouble()))
+                    .willReturn(createKakaoResponse("맛집"));
+            given(kakaoLocalApiClient.fetchNearbyPlaces(eq("CE7"), anyDouble(), anyDouble()))
+                    .willThrow(new RuntimeException("카카오 API 오류"));
+            given(kakaoLocalApiClient.fetchNearbyPlaces(eq("AT4"), anyDouble(), anyDouble()))
+                    .willReturn(createKakaoResponse("관광지"));
+            given(kakaoLocalApiClient.fetchNearbyPlaces(eq("CT1"), anyDouble(), anyDouble()))
+                    .willReturn(createKakaoResponse("문화시설"));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "ALL", 126.9769, 37.5759);
+
+            assertThat(result).hasSize(3);
+        }
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
@@ -148,6 +148,21 @@ class NearbyPlaceServiceTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).placeName()).isEqualTo("맛집");
         }
+
+        @Test
+        @DisplayName("카카오 API 빈 배열 반환 - Redis에 저장하지 않음")
+        void emptyResult_doesNotCacheToRedis() {
+            given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(null);
+            given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
+                    .willReturn(new KakaoLocalApiResponse(
+                            new KakaoLocalApiResponse.Meta(0, true), List.of()
+                    ));
+
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+
+            assertThat(result).isEmpty();
+            then(valueOperations).should(never()).set(anyString(), anyString(), any(Duration.class));
+        }
     }
 
     @Nested

--- a/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/NearbyPlaceServiceTest.java
@@ -1,5 +1,6 @@
 package com.danburn.map.service;
 
+import com.danburn.common.exception.GlobalException;
 import com.danburn.map.dto.response.KakaoLocalApiResponse;
 import com.danburn.map.dto.response.NearbyPlaceResponse;
 import com.danburn.map.infra.KakaoLocalApiClient;
@@ -18,8 +19,10 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
@@ -38,12 +41,18 @@ class NearbyPlaceServiceTest {
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 
+    @Mock
+    private LocationCodeMapper locationCodeMapper;
+
     @InjectMocks
     private NearbyPlaceService nearbyPlaceService;
+
+    private static final LocationCodeMapper.Coordinate COORDINATE = new LocationCodeMapper.Coordinate(37.5759, 126.9769);
 
     @BeforeEach
     void setUp() {
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(locationCodeMapper.getCoordinateByAreaCode("POI009")).willReturn(Optional.of(COORDINATE));
     }
 
     private KakaoLocalApiResponse createKakaoResponse(String placeName) {
@@ -67,7 +76,7 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
                     .willReturn(createKakaoResponse("맛집"));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).placeName()).isEqualTo("맛집");
@@ -81,10 +90,20 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces(anyString(), eq(126.9769), eq(37.5759)))
                     .willReturn(createKakaoResponse("장소"));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "ALL", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "ALL");
 
             assertThat(result).hasSize(4);
             then(kakaoLocalApiClient).should(times(4)).fetchNearbyPlaces(anyString(), anyDouble(), anyDouble());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 areaCode - GlobalException 404 발생")
+        void invalidAreaCode_throwsGlobalException() {
+            given(locationCodeMapper.getCoordinateByAreaCode("INVALID")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> nearbyPlaceService.getNearbyPlaces("INVALID", "FD6"))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessageContaining("INVALID");
         }
     }
 
@@ -101,7 +120,7 @@ class NearbyPlaceServiceTest {
             String cachedJson = objectMapper.writeValueAsString(cached);
             given(valueOperations.get("map:nearby:POI009:FD6")).willReturn(cachedJson);
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).placeName()).isEqualTo("맛집");
@@ -115,7 +134,7 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
                     .willReturn(createKakaoResponse("맛집"));
 
-            nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             then(valueOperations).should().set(eq("map:nearby:POI009:FD6"), anyString(), eq(Duration.ofHours(1)));
         }
@@ -128,7 +147,7 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
                     .willReturn(createKakaoResponse("맛집"));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).placeName()).isEqualTo("맛집");
@@ -143,7 +162,7 @@ class NearbyPlaceServiceTest {
             willThrow(new RuntimeException("Redis 쓰기 실패"))
                     .given(valueOperations).set(anyString(), anyString(), any(Duration.class));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).placeName()).isEqualTo("맛집");
@@ -158,7 +177,7 @@ class NearbyPlaceServiceTest {
                             new KakaoLocalApiResponse.Meta(0, true), List.of()
                     ));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).isEmpty();
             then(valueOperations).should(never()).set(anyString(), anyString(), any(Duration.class));
@@ -176,7 +195,7 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
                     .willThrow(new RuntimeException("카카오 API 오류"));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).isEmpty();
         }
@@ -188,7 +207,7 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces("FD6", 126.9769, 37.5759))
                     .willReturn(null);
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "FD6");
 
             assertThat(result).isEmpty();
         }
@@ -206,7 +225,7 @@ class NearbyPlaceServiceTest {
             given(kakaoLocalApiClient.fetchNearbyPlaces(eq("CT1"), anyDouble(), anyDouble()))
                     .willReturn(createKakaoResponse("문화시설"));
 
-            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "ALL", 126.9769, 37.5759);
+            List<NearbyPlaceResponse> result = nearbyPlaceService.getNearbyPlaces("POI009", "ALL");
 
             assertThat(result).hasSize(3);
         }

--- a/service-map/src/test/resources/application-test.yml
+++ b/service-map/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+management:
+  otlp:
+    metrics:
+      export:
+        enabled: false
+
+kakao:
+  api:
+    key: test-key


### PR DESCRIPTION
 ##작업 내용

  - 카카오 로컬 API를 활용한 주변 가게 조회 API 구현 (`GET /api/map/nearby-places`)
  - 카테고리별 단건 조회 및 ALL 탭 병렬 처리(parallelStream) 지원
  - Redis 캐싱(TTL 1시간) 적용으로 카카오 API 호출 최소화
  - 빈 배열 캐싱 버그 수정 및 Redis 장애 시 fallback 처리

  ## 변동사항

  - `KakaoLocalApiClient` — 카카오 로컬 카테고리 검색 API 클라이언트 구현
  - `NearbyPlaceService` — 카테고리별 조회 / ALL 병렬 조회 / Redis 캐싱(`map:nearby:{areaCode}:{categoryCode}`)
  - `NearbyPlaceController` — 요청 파라미터 검증(`@Pattern`, `@DecimalMin/Max`) 및 areaCode 전달
  - Redis 의존성 추가 및 `application.yml` 설정
  - 빈 배열 캐싱 방지 처리 (빈 결과는 캐시 저장 안 함)

  ## 테스트

  - `NearbyPlaceServiceTest` — 단위 테스트 11개 (캐시 히트/미스, Redis 장애, 카카오 API 예외, ALL 부분 실패 등)
  - `NearbyPlaceControllerTest` — 컨트롤러 테스트 6개 (정상 조회, 잘못된 파라미터 400 등)