### PR TITLE
fix(congestion): Redis 네임스페이스 분리로 SCAN 역직렬화 실패 차단 (#285)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -24,7 +24,7 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
 
     private final RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
 
-    private static final String KEY_PREFIX = "congestion:";
+    private static final String KEY_PREFIX = "congestion:dto:";
     private static final long TTL_MINUTES = 15;
 
     @Override


### PR DESCRIPTION
## Summary
- `CongestionRedisRepositoryImpl.KEY_PREFIX`를 `congestion:` → `congestion:dto:`로 분리
- `SCAN congestion:*`가 `HourlyAvgCacheService`(`congestion:hourly-avg:...`, plain double) / `AnomalyDetector`(`congestion:anomaly-armed:...`) 키까지 매칭해 `multiGet` 단계에서 `MismatchedInputException`으로 /congestion 조회가 500 나던 문제 해결
- DTO 전용 네임스페이스 확보로 향후 같은 prefix를 쓰는 캐시가 더 늘어도 안전

## Root Cause
```
SerializationException: Cannot construct instance of CongestionRedisDto ...
no double/Double-argument constructor/factory method to deserialize from Number value (45664.3)
  at CongestionRedisRepositoryImpl.findAll(CongestionRedisRepositoryImpl.java:74)
```
`Jackson2JsonRedisSerializer<CongestionRedisDto>`로 묶인 `congestionRedisTemplate`이 `multiGet` 결과 전부를 DTO로 역직렬화 시도 → hourly-avg 값(45664.3)에서 터짐.

## Impact
- 변경 파일: `CongestionRedisRepositoryImpl.java` 1개 (KEY_PREFIX 1줄)
- prod Redis의 기존 `congestion:{areaCode}` 키는 TTL 15분 후 자연 만료, `saveAll` 사이클로 새 prefix(`congestion:dto:{areaCode}`)에 재적재

## Test plan
- [x] `./gradlew :service-congestion:build` 통과 (테스트 포함)
- [ ] 배포 후 `/congestion` 류 엔드포인트 200 응답 확인
- [ ] Redis CLI에서 `congestion:dto:*` 키 생성 확인 + 기존 `congestion:{areaCode}` 키는 TTL 만료로 사라지는지 확인

Closes #285