### PR TITLE
fix(congestion): findAll DB 폴백 single-flight + Redis 백필 (#291)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Slf4j
 @Service
@@ -34,6 +36,10 @@ public class CongestionService {
     private final CongestionRedisRepository congestionRedisRepository;
     private final CongestionJpaRepository congestionJpaRepository;
     private final ObjectMapper objectMapper;
+
+    // findAll DB 폴백 single-flight 가드 (Redis 미스 폭주 시 DB 호출 1회로 압축)
+    private final ReentrantLock dbFallbackLock = new ReentrantLock();
+    private static final long DB_FALLBACK_LOCK_WAIT_MS = 300;
 
     /**
      * Redis에 배치 저장 (동기 — 프론트 서빙의 핵심 경로)
@@ -99,11 +105,83 @@ public class CongestionService {
                     .map(this::toResponse)
                     .toList();
         }
+        return findAllFromDbWithSingleFlight();
+    }
 
-        log.warn("Redis 캐시 전체 미스 - DB 폴백 조회");
-        return congestionJpaRepository.findLatestPerLocation().stream()
-                .map(this::toResponse)
-                .toList();
+    /**
+     * Redis 전체 미스 시 DB 폴백을 직렬화하고 결과를 Redis에 백필.
+     * 락을 못 잡은 요청은 Redis 재조회로 대체 — 동시 트래픽이 폭주해도
+     * DB 호출은 최대 1회로 압축되어 Hikari 풀 고갈을 막는다.
+     */
+    private List<CongestionResponse> findAllFromDbWithSingleFlight() {
+        boolean acquired = false;
+        try {
+            acquired = dbFallbackLock.tryLock(DB_FALLBACK_LOCK_WAIT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        if (!acquired) {
+            // 다른 스레드가 백필을 마쳤을 수 있으니 Redis 한 번 더 조회
+            List<CongestionRedisDto> retry = congestionRedisRepository.findAll();
+            if (!retry.isEmpty()) {
+                return retry.stream().map(this::toResponse).toList();
+            }
+            return Collections.emptyList();
+        }
+
+        try {
+            // double-check: 락 대기 중 다른 스레드가 백필했을 수 있음
+            List<CongestionRedisDto> cached = congestionRedisRepository.findAll();
+            if (!cached.isEmpty()) {
+                return cached.stream().map(this::toResponse).toList();
+            }
+
+            log.warn("Redis 캐시 전체 미스 - DB 폴백 조회");
+            List<Congestion> entities = congestionJpaRepository.findLatestPerLocation();
+            if (!entities.isEmpty()) {
+                try {
+                    congestionRedisRepository.saveAll(entities.stream()
+                            .map(this::toRedisDto)
+                            .toList());
+                } catch (Exception e) {
+                    log.warn("[CongestionService] DB 폴백 결과 Redis 백필 실패", e);
+                }
+            }
+            return entities.stream().map(this::toResponse).toList();
+        } finally {
+            dbFallbackLock.unlock();
+        }
+    }
+
+    // 백필 전용 변환. areaName은 엔티티에 없어 null — 다음 정상 적재 사이클에서 덮인다.
+    private CongestionRedisDto toRedisDto(Congestion entity) {
+        List<CongestionRedisDto.ForecastDto> forecasts;
+        if (entity.getForecast() == null || entity.getForecast().isBlank()) {
+            forecasts = Collections.emptyList();
+        } else {
+            try {
+                forecasts = objectMapper.readValue(
+                        entity.getForecast(),
+                        new TypeReference<List<CongestionRedisDto.ForecastDto>>() {}
+                );
+            } catch (JsonProcessingException e) {
+                log.warn("[CongestionService] 백필 forecast 파싱 실패 - areaCode={}", entity.getAreaCode());
+                forecasts = Collections.emptyList();
+            }
+        }
+        return new CongestionRedisDto(
+                null,
+                entity.getAreaCode(),
+                entity.getCongestionLevel().getDescription(),
+                entity.getCongestionMessage(),
+                entity.getMinPeopleCount(),
+                entity.getMaxPeopleCount(),
+                entity.getPopulationTime() != null
+                        ? entity.getPopulationTime().format(POPULATION_TIME_FORMATTER)
+                        : null,
+                forecasts
+        );
     }
 
     private CongestionResponse toResponse(CongestionRedisDto dto) {


### PR DESCRIPTION
## Summary
- Redis 캐시 전체 미스 구간(배포 직후 / prefix 변경 / flush)에 동시 요청이 각자 DB로 직행해 Hikari 풀(size 10)이 30초 안에 고갈되던 문제 차단
- `CongestionService.findAll()`의 DB 폴백을 `ReentrantLock`으로 직렬화 + DB 결과를 Redis에 즉시 백필

## Root cause
배포 후 다음 에러 폭주:
```
HikariPool-1 - Connection is not available, request timed out after 30001ms
(total=10, active=10, idle=0, waiting=6~7)
  at CongestionService.findAll(CongestionService.java:104)
    → CongestionJpaRepository.findLatestPerLocation
```
Redis가 비어있는 동안 동시 요청 N개가 전부 `findLatestPerLocation()`을 호출 → 풀 고갈. #285 prefix 변경 직후 새 prefix가 채워지기 전 윈도우에서 발생.

## Change
- `dbFallbackLock = new ReentrantLock()` 추가
- `findAll()`:
  1. Redis hit → 즉시 반환
  2. miss → `tryLock(300ms)` 시도
     - **획득**: double-check 후 DB 1회 조회 + `saveAllToRedis()` 백필 + 응답
     - **실패**: Redis 한번 더 조회 (다른 스레드가 백필했을 수 있음), 비면 빈 리스트
- 백필 DTO의 `areaName`은 엔티티에 없어 null. 다음 정상 적재 사이클(`CongestionScheduler`)에서 덮임. 응답 DTO엔 areaName 노출 없고 `AnomalyDetector`는 Redis dto를 읽지 않고 스케줄러가 넘긴 dto만 사용하므로 영향 없음

## Effect
- 동시 요청이 N개여도 DB 호출은 **최대 1회**로 압축 → 풀 고갈의 근본 차단
- prefix 변경뿐 아니라 **앞으로 Redis가 비는 모든 상황**(재시작, flush, 장애)에 동일 보호

## Test plan
- [x] `./gradlew :service-congestion:build` 통과 (테스트 포함)
- [ ] 배포 후 `/congestion` 부하 테스트로 풀 active < pool size 확인
- [ ] Redis 강제 flush 후에도 500 폭주 없이 한 사이클 안에 회복되는지 확인

Closes #291