### PR TITLE
chore(release): dev → main promotion (#291, #287)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
@@ -22,6 +22,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Slf4j
 @Service
@@ -34,6 +36,10 @@ public class CongestionService {
     private final CongestionRedisRepository congestionRedisRepository;
     private final CongestionJpaRepository congestionJpaRepository;
     private final ObjectMapper objectMapper;
+
+    // findAll DB 폴백 single-flight 가드 (Redis 미스 폭주 시 DB 호출 1회로 압축)
+    private final ReentrantLock dbFallbackLock = new ReentrantLock();
+    private static final long DB_FALLBACK_LOCK_WAIT_MS = 300;
 
     /**
      * Redis에 배치 저장 (동기 — 프론트 서빙의 핵심 경로)
@@ -99,11 +105,83 @@ public class CongestionService {
                     .map(this::toResponse)
                     .toList();
         }
+        return findAllFromDbWithSingleFlight();
+    }
 
-        log.warn("Redis 캐시 전체 미스 - DB 폴백 조회");
-        return congestionJpaRepository.findLatestPerLocation().stream()
-                .map(this::toResponse)
-                .toList();
+    /**
+     * Redis 전체 미스 시 DB 폴백을 직렬화하고 결과를 Redis에 백필.
+     * 락을 못 잡은 요청은 Redis 재조회로 대체 — 동시 트래픽이 폭주해도
+     * DB 호출은 최대 1회로 압축되어 Hikari 풀 고갈을 막는다.
+     */
+    private List<CongestionResponse> findAllFromDbWithSingleFlight() {
+        boolean acquired = false;
+        try {
+            acquired = dbFallbackLock.tryLock(DB_FALLBACK_LOCK_WAIT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        if (!acquired) {
+            // 다른 스레드가 백필을 마쳤을 수 있으니 Redis 한 번 더 조회
+            List<CongestionRedisDto> retry = congestionRedisRepository.findAll();
+            if (!retry.isEmpty()) {
+                return retry.stream().map(this::toResponse).toList();
+            }
+            return Collections.emptyList();
+        }
+
+        try {
+            // double-check: 락 대기 중 다른 스레드가 백필했을 수 있음
+            List<CongestionRedisDto> cached = congestionRedisRepository.findAll();
+            if (!cached.isEmpty()) {
+                return cached.stream().map(this::toResponse).toList();
+            }
+
+            log.warn("Redis 캐시 전체 미스 - DB 폴백 조회");
+            List<Congestion> entities = congestionJpaRepository.findLatestPerLocation();
+            if (!entities.isEmpty()) {
+                try {
+                    congestionRedisRepository.saveAll(entities.stream()
+                            .map(this::toRedisDto)
+                            .toList());
+                } catch (Exception e) {
+                    log.warn("[CongestionService] DB 폴백 결과 Redis 백필 실패", e);
+                }
+            }
+            return entities.stream().map(this::toResponse).toList();
+        } finally {
+            dbFallbackLock.unlock();
+        }
+    }
+
+    // 백필 전용 변환. areaName은 엔티티에 없어 null — 다음 정상 적재 사이클에서 덮인다.
+    private CongestionRedisDto toRedisDto(Congestion entity) {
+        List<CongestionRedisDto.ForecastDto> forecasts;
+        if (entity.getForecast() == null || entity.getForecast().isBlank()) {
+            forecasts = Collections.emptyList();
+        } else {
+            try {
+                forecasts = objectMapper.readValue(
+                        entity.getForecast(),
+                        new TypeReference<List<CongestionRedisDto.ForecastDto>>() {}
+                );
+            } catch (JsonProcessingException e) {
+                log.warn("[CongestionService] 백필 forecast 파싱 실패 - areaCode={}", entity.getAreaCode());
+                forecasts = Collections.emptyList();
+            }
+        }
+        return new CongestionRedisDto(
+                null,
+                entity.getAreaCode(),
+                entity.getCongestionLevel().getDescription(),
+                entity.getCongestionMessage(),
+                entity.getMinPeopleCount(),
+                entity.getMaxPeopleCount(),
+                entity.getPopulationTime() != null
+                        ? entity.getPopulationTime().format(POPULATION_TIME_FORMATTER)
+                        : null,
+                forecasts
+        );
     }
 
     private CongestionResponse toResponse(CongestionRedisDto dto) {


### PR DESCRIPTION
## Summary
- Promote dev → main: Hikari 풀 고갈 hotfix + AI anomaly 환각 방지
- 운영 영향이 큰 #291 핫픽스가 포함되어 가급적 빠른 배포 권장

## Included
- #292 fix(congestion): findAll DB 폴백 single-flight + Redis 백필 (#291)
  - Redis 미스 시 동시 요청이 DB로 직행해 Hikari 풀(10) 30s 안에 고갈 → 500 폭주 → ReentrantLock 단일 비행 + DB 결과 Redis 백필로 차단
- #289 fix(ai): anomaly 분석 LLM hallucination 방지 (#287)

## Test plan
- [x] dev CI 전체 (build-ai / service-congestion / gateway / map / mobility) 통과
- [ ] main 머지 후 prod 배포에서 `/congestion` 부하 시 Hikari `active < pool size` 확인
- [ ] 동일 시점에 `HikariPool-1 - Connection is not available` 로그 미발생 확인