### PR TITLE
fix(congestion): congestion 테이블 (area_code, created_at) 복합 인덱스 추가

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/domain/Congestion.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/domain/Congestion.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Column;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +17,13 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(
+        name = "congestion",
+        indexes = {
+                @Index(name = "idx_congestion_area_code_created_at", columnList = "area_code, created_at"),
+                @Index(name = "idx_congestion_created_at", columnList = "created_at")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Congestion extends BaseEntity {


### PR DESCRIPTION
## Summary
- `congestion` 테이블에 PK 외 인덱스가 없어 `findLatestPerLocation` / `findLatestByAreaCodes`의 correlated subquery가 22만 row × subquery 풀스캔으로 단일 쿼리도 수십 분 hang
- 캐시 미스 한 번 → DB 폴백 → 풀스캔 누적 → 디스크 I/O 포화 → 좀비 쿼리 눈덩이 → 스케줄러 적재 경로(`checkAndPublishBusyEvents` → `findLatestByAreaCodes`)도 같은 늪에 빠져 **Redis가 영원히 비는 자기참조 데드락**이 prod에서 관측됨

## Diagnosis evidence
- `SHOW INDEX FROM congestion`: PRIMARY만 존재
- `SHOW PROCESSLIST`: 동일 풀스캔 쿼리 20+ 개가 5,000+ 초 동안 executing
- `SHOW ENGINE INNODB STATUS`: `55,551 reads/sec`, 누적 `5.2B OS file reads` — 디스크 풀스캔
- jstack: `scheduling-1` 938s 동안 `NativeProtocol.readMessage` (MySQL 응답 대기)
- 우선 응급 처치는 mysql/service-congestion 컨테이너 재시작으로 좀비 쿼리 정리 완료

## Change
```java
@Table(
    name = "congestion",
    indexes = {
        @Index(name = "idx_congestion_area_code_created_at", columnList = "area_code, created_at"),
        @Index(name = "idx_congestion_created_at", columnList = "created_at")
    }
)
```
- `idx_congestion_area_code_created_at`: 두 corr-subquery 쿼리 커버, ms 단위로 변환
- `idx_congestion_created_at`: `deleteByCreatedAtBefore` (cleanup 스케줄러) range scan 가속

## Effect
- 부팅 시 Hibernate `ddl-auto: update`가 자동으로 `ALTER TABLE ADD INDEX` 실행 (22만 row 기준 수~수십 초)
- 이후 단일 쿼리 ms 단위 → 풀스캔 / 좀비 누적 / 자기참조 데드락 모두 해결
- #285 prefix 변경, #291 single-flight + 백필과 함께 운영 안정성 회복

## Test plan
- [x] `./gradlew :service-congestion:build` 통과
- [ ] 배포 후 `SHOW INDEX FROM congestion`로 두 인덱스 생성 확인
- [ ] 스케줄러 "수집 완료" 로그 정상 출력 확인 (5분 주기)
- [ ] `SHOW PROCESSLIST`에 5초 이상 executing 쿼리 없음 확인