### PR TITLE
chore(release): dev → main promotion (congestion 인덱스 hotfix)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/domain/Congestion.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/domain/Congestion.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Column;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +17,13 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(
+        name = "congestion",
+        indexes = {
+                @Index(name = "idx_congestion_area_code_created_at", columnList = "area_code, created_at"),
+                @Index(name = "idx_congestion_created_at", columnList = "created_at")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Congestion extends BaseEntity {


### PR DESCRIPTION
## Summary
- Promote #294 to main: `congestion` 테이블 풀스캔으로 인한 스케줄러 자기참조 데드락 hotfix
- 운영에서 스케줄러가 첫 호출에서 hang하며 Redis 적재가 영원히 안 되는 현상 차단

## Included
- #294 fix(congestion): congestion 테이블 (area_code, created_at) 복합 인덱스 추가
  - `idx_congestion_area_code_created_at`: corr-subquery 풀스캔 → 인덱스 lookup, ms 단위로 변환
  - `idx_congestion_created_at`: cleanup range scan 가속
  - Hibernate `ddl-auto: update`가 부팅 시 `ALTER TABLE ADD INDEX` 자동 적용

## Operational notes
- 부팅 시 ALTER 적용 중 짧은 메타데이터 락 가능 (22만 row 기준 수~수십 초 예상)
- 적용 후 확인:
  - `SHOW INDEX FROM congestion` 두 인덱스 존재
  - `"[CongestionScheduler] 혼잡도 데이터 수집 완료"` 로그가 5분 주기로 출력
  - `SHOW PROCESSLIST`에 5초+ executing 쿼리 없음

## Test plan
- [x] dev CI 전체 (build-ai / service-congestion / gateway / map / mobility) 통과
- [ ] main 머지 후 prod 배포에서 인덱스 생성 + 스케줄러 정상 회전 확인