### PR TITLE
chore(congestion,cd): Flyway 도입 + CD 부팅 healthcheck 검증

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,31 @@ jobs:
           echo "DB users ensured. Restarting services..."
           sudo docker restart backend-service-congestion-1 backend-service-map-1 || true
 
+      - name: Wait for service-congestion to be healthy
+        run: |
+          # service-congestion 컨테이너의 네트워크 namespace 공유로 localhost:8082 접근.
+          # 런타임 이미지에 curl 없어도 외부 curlimages/curl 컨테이너로 폴링한다.
+          echo "Polling /actuator/health (timeout 5min)..."
+          success=false
+          for i in $(seq 1 60); do
+            if sudo docker run --rm \
+                 --network container:backend-service-congestion-1 \
+                 curlimages/curl:8.10.1 \
+                 -s --max-time 5 http://localhost:8082/actuator/health 2>/dev/null \
+                 | grep -q '"status":"UP"'; then
+              echo "service-congestion is UP after $((i*5))s."
+              success=true
+              break
+            fi
+            sleep 5
+          done
+          if [ "$success" = false ]; then
+            echo "::error::service-congestion did not become healthy within 5 minutes"
+            echo "==== last 100 lines of service-congestion logs ===="
+            sudo docker logs --tail 100 backend-service-congestion-1 || true
+            exit 1
+          fi
+
       - name: Start Portainer (if not running)
         run: |
           cd ~/Backend

--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -9,8 +9,13 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+    locations: classpath:db/migration
   data:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}

--- a/service-congestion/src/main/resources/db/migration/V1__init.sql
+++ b/service-congestion/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,2 @@
+-- Flyway baseline marker. baseline-on-migrate=true 로 prod 기존 스키마는 이 버전으로 표시되고 실행되지 않는다.
+-- 이후 모든 스키마 변경은 V2__... 부터 순차 추가한다.


### PR DESCRIPTION
## Summary
오늘 사고(인덱스 부재 → 좀비 누적 → 데드락 → 부팅 hang)의 **재발 방지 안전망 2종** 추가.

1. **Flyway 도입(service-congestion만)** + `ddl-auto: validate`
   - 부팅 시점 자동 ALTER로 인한 metadata lock 데드락 차단
   - 앞으로 스키마 변경은 사람이 통제 가능한 시점에 V2__... 마이그레이션으로
2. **CD 부팅 healthcheck 검증**
   - 부팅 실패가 `deploy success`로 가려지던 사각지대 차단

## Changes

### Flyway (service-congestion만)
- `build.gradle`: `flyway-core` + `flyway-mysql` 의존성 추가
- `application.yml`:
  - `spring.flyway.baseline-on-migrate=true` + `baseline-version=1`
  - `spring.jpa.hibernate.ddl-auto: update` → `validate`
- `resources/db/migration/V1__init.sql`: 빈 baseline marker (주석만)
- **동작**:
  - 첫 부팅 시 Flyway가 `flyway_schema_history` 테이블 생성 + baseline=1 기록
  - V1은 실행되지 않음 (이미 prod에 존재하는 스키마를 V1로 간주)
  - 이후 변경은 V2__add_xxx.sql 형태로 추가하면 Flyway가 순차 적용

### CD healthcheck (.github/workflows/cd.yml)
- 새 step `Wait for service-congestion to be healthy` 추가 (DB users 설정 직후, Portainer 시작 전)
- `--network container:backend-service-congestion-1` 트릭으로 `curlimages/curl` 컨테이너가 service-congestion의 네트워크 namespace에 진입 → `localhost:8082/actuator/health` 폴링
- 5s × 60회 = 5분 timeout, UP 응답 받으면 즉시 통과
- timeout 시 `::error::` + 마지막 100줄 로그 출력 후 deploy 실패 처리

## Risks
- `ddl-auto: validate`가 스키마 ↔ 엔티티 드리프트 발견 시 부팅 실패할 수 있음. 그동안 `update`로 운영해온 정합 상태라 가능성은 낮으나, **만약 실패하면 새 healthcheck가 즉시 잡아 deploy 실패로 알람** → 안전장치 동작 확인 기회.
- service-map 등 다른 모듈은 이번 PR 범위 밖. 동일 패턴 후속 PR로 확산 예정.

## Test plan
- [x] `./gradlew :service-congestion:build` 통과 (테스트 포함)
- [ ] 배포 후 로그에서 `Flyway Community Edition ... by Redgate` + `Schema baseline successful` 또는 `Successfully applied 0 migrations` 확인
- [ ] DB에 `flyway_schema_history` 테이블 생성 + `version=1, success=1` 행 확인
- [ ] healthcheck step 통과 + 평소대로 스케줄러 수집 5분 주기 회전
- [ ] 부팅 실패 시 healthcheck timeout으로 deploy 실패하는지 (가능하면 의도적 fail로 1회 검증)

## Follow-ups (별도 PR)
- service-map / service-mobility 동일 패턴 확산
- `ddl-auto: validate` 안정화 후 `none`으로 한 단계 더 보수화 검토
- healthcheck를 다른 서비스(service-map, service-gateway 등)로 확장