### PR TITLE
chore(release): dev → main promotion (Flyway 도입 + CD healthcheck)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,31 @@ jobs:
           echo "DB users ensured. Restarting services..."
           sudo docker restart backend-service-congestion-1 backend-service-map-1 || true
 
+      - name: Wait for service-congestion to be healthy
+        run: |
+          # service-congestion 컨테이너의 네트워크 namespace 공유로 localhost:8082 접근.
+          # 런타임 이미지에 curl 없어도 외부 curlimages/curl 컨테이너로 폴링한다.
+          echo "Polling /actuator/health (timeout 5min)..."
+          success=false
+          for i in $(seq 1 60); do
+            if sudo docker run --rm \
+                 --network container:backend-service-congestion-1 \
+                 curlimages/curl:8.10.1 \
+                 -s --max-time 5 http://localhost:8082/actuator/health 2>/dev/null \
+                 | grep -q '"status":"UP"'; then
+              echo "service-congestion is UP after $((i*5))s."
+              success=true
+              break
+            fi
+            sleep 5
+          done
+          if [ "$success" = false ]; then
+            echo "::error::service-congestion did not become healthy within 5 minutes"
+            echo "==== last 100 lines of service-congestion logs ===="
+            sudo docker logs --tail 100 backend-service-congestion-1 || true
+            exit 1
+          fi
+
       - name: Start Portainer (if not running)
         run: |
           cd ~/Backend

--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -9,8 +9,13 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+    locations: classpath:db/migration
   data:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}

--- a/service-congestion/src/main/resources/db/migration/V1__init.sql
+++ b/service-congestion/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,2 @@
+-- Flyway baseline marker. baseline-on-migrate=true 로 prod 기존 스키마는 이 버전으로 표시되고 실행되지 않는다.
+-- 이후 모든 스키마 변경은 V2__... 부터 순차 추가한다.


### PR DESCRIPTION
## Summary
- Promote #296 to main: 오늘 사고 회고 기반 운영 안정성 안전망 2종
- Flyway로 부팅 시점 자동 ALTER 차단 + CD가 부팅 실패를 즉시 감지

## Included
- #296 chore(congestion,cd): Flyway 도입(service-congestion) + CD 부팅 healthcheck 검증
  - `flyway-core`/`flyway-mysql` + `baseline-on-migrate=true` (V1은 빈 baseline marker)
  - `ddl-auto: update` → `validate`
  - CD에 `/actuator/health` polling step 추가 (5분 timeout)

## Operational notes
- 첫 부팅 시 Flyway가 `flyway_schema_history` 테이블 생성 + baseline=1 기록
- `ddl-auto: validate`가 스키마 ↔ 엔티티 드리프트 발견 시 부팅 실패 가능 (가능성 낮음)
- 만약 부팅 실패하면 새 healthcheck가 즉시 잡아 deploy 실패 + 마지막 100줄 로그 출력 → 빠른 진단 가능

## Test plan
- [x] dev CI 전체 (build-ai / service-congestion / gateway / map / mobility) 통과
- [ ] main 머지 후 첫 배포에서:
  - Flyway 로그 `Schema baseline successful` 확인
  - DB `SHOW TABLES`에 `flyway_schema_history` 존재 + `version=1, success=1` 행
  - CD step "Wait for service-congestion to be healthy"가 5분 안에 통과
  - 스케줄러 평소대로 5분 주기 회전