### PR TITLE
feat:  대중교통 경로 Mock API 구현

### DIFF
--- a/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
+++ b/service-map/src/main/java/com/danburn/map/controller/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.danburn.common.exception.GlobalException;
 import com.danburn.common.response.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,14 +27,14 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse("잘못된 입력값입니다.");
         log.warn("ConstraintViolationException: {}", message);
-        return ResponseEntity.status(400)
-                .body(ApiResponse.error(400, message));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("Unhandled exception", e);
-        return ResponseEntity.status(500)
-                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/service-mobility/src/main/java/com/danburn/mobility/controller/GlobalExceptionHandler.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/controller/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.danburn.mobility.controller;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.common.response.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGlobalException(GlobalException e) {
+        log.error("GlobalException: status={}, message={}", e.getStatus(), e.getMessage());
+        return ResponseEntity.status(e.getStatus())
+                .body(ApiResponse.error(e.getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .map(v -> v.getPropertyPath().toString().replaceAll(".*\\.", "") + ": " + v.getMessage())
+                .findFirst()
+                .orElse("잘못된 입력값입니다.");
+        log.warn("ConstraintViolationException: {}", message);
+        return ResponseEntity.status(400)
+                .body(ApiResponse.error(400, message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+        return ResponseEntity.status(500)
+                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/service-mobility/src/main/java/com/danburn/mobility/controller/GlobalExceptionHandler.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/controller/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.danburn.common.exception.GlobalException;
 import com.danburn.common.response.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,14 +27,14 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .orElse("잘못된 입력값입니다.");
         log.warn("ConstraintViolationException: {}", message);
-        return ResponseEntity.status(400)
-                .body(ApiResponse.error(400, message));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error(HttpStatus.BAD_REQUEST.value(), message));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("Unhandled exception", e);
-        return ResponseEntity.status(500)
-                .body(ApiResponse.error(500, "서버 내부 오류가 발생했습니다."));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."));
     }
 }

--- a/service-mobility/src/main/java/com/danburn/mobility/controller/MockOdsayController.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/controller/MockOdsayController.java
@@ -1,0 +1,239 @@
+package com.danburn.mobility.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.mobility.dto.response.TransitRouteResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "대중교통 경로", description = "대중교통 경로 조회 API")
+@RestController
+@RequestMapping("/api/mobility")
+public class MockOdsayController {
+
+    @Operation(
+            summary = "대중교통 경로 조회",
+            description = """
+                    출발지/도착지 좌표 기준 대중교통 경로를 조회합니다.
+
+                    **subPath.trafficType별 응답 필드 안내**
+
+                    | 필드 | WALK | BUS | SUBWAY |
+                    |------|------|-----|--------|
+                    | intervalTime | 생략 | 배차 간격(분) | 배차 간격(분) |
+                    | way | 생략 | 생략 | 진행 방면 |
+                    | lane | 생략 | 버스 노선 목록 | 지하철 노선 목록 |
+                    | stations | 생략 | 경유 정류장 목록 | 경유 역 목록 |
+
+                    **lane 필드별 응답 안내**
+
+                    | 필드 | BUS | SUBWAY |
+                    |------|-----|--------|
+                    | busNo | 버스 번호 | 생략 |
+                    | type | 버스 종류 코드 | 생략 |
+                    | name | 생략 | 지하철 노선명 |
+                    | subwayCode | 생략 | 지하철 노선 코드 |
+                    """
+    )
+    @GetMapping("/route")
+    public ApiResponse<TransitRouteResponse> getRoute(
+            @Parameter(description = "출발지 경도", example = "127.1272127") @RequestParam double originLng,
+            @Parameter(description = "출발지 위도", example = "37.3213399") @RequestParam double originLat,
+            @Parameter(description = "도착지 경도", example = "127.02800140627488") @RequestParam double destLng,
+            @Parameter(description = "도착지 위도", example = "37.49808633653005") @RequestParam double destLat
+    ) {
+        TransitRouteResponse.Path path1 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(59, 3200, 1, 0, "단국대정문", "신분당선강남역"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 51, 25, null,
+                                List.of(new TransitRouteResponse.Lane(null, "1101", 4, null)),
+                                List.of(
+                                        "단국대정문", "대지고등학교.전내교차로", "꽃메마을1단지",
+                                        "꽃메마을.새에덴교회", "꽃메마을.현대홈타운3단지", "중앙공원",
+                                        "보정동행정복지센터", "보정동카페거리.죽현마을", "죽전초중고교.대현초교",
+                                        "농수산물센터", "오리역", "하얀마을.구미도서관",
+                                        "까치마을.건영빌라.2001아울렛", "미금역.청솔마을.2001아울렛",
+                                        "청솔주공6단지", "상록마을", "아데나펠리스", "정자역",
+                                        "두산위브제니스", "느티마을.경남빌라", "롯데백화점.수내역",
+                                        "분당구청입구.수내교", "신백현초등학교", "백현육교",
+                                        "판교역.낙생육교.현대백화점", "판교TG", "금토JC", "서울진입",
+                                        "청계산입구역", "양재IC", "서초IC", "KCC사옥",
+                                        "신논현역.유화빌딩", "강남역.지오다노", "강남역10번출구", "신분당선강남역"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null)
+                )
+        );
+
+        TransitRouteResponse.Path path2 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(50, 2850, 1, 2, "단국대.인문관", "강남"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 2, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 15, 5, null,
+                                List.of(new TransitRouteResponse.Lane(null, "24", 3, null)),
+                                List.of(
+                                        "단국대.인문관", "단국대정문", "대지고등학교.전내교차로",
+                                        "꽃메마을1단지", "꽃메마을.새에덴교회", "꽃메마을.현대홈타운3단지",
+                                        "중앙공원", "보정동행정복지센터", "보정동카페거리.죽현마을",
+                                        "죽전역.신세계사우스시티"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 1, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 8, 8, "정자",
+                                List.of(new TransitRouteResponse.Lane("수도권 수인.분당선", null, null, 116)),
+                                List.of("죽전", "오리", "미금", "정자")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 15, 8, "강남",
+                                List.of(new TransitRouteResponse.Lane("수도권 신분당선", null, null, 109)),
+                                List.of("정자", "판교", "청계산입구", "양재시민의숲", "양재", "강남")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null)
+                )
+        );
+
+        TransitRouteResponse.Path path3 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(52, 3350, 1, 1, "단국대정문", "강남"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 24, 11, null,
+                                List.of(new TransitRouteResponse.Lane(null, "39-1", 3, null)),
+                                List.of(
+                                        "단국대정문", "단국대학교.죽전야외음악당.성현마을2단지", "대림아파트후문",
+                                        "힐스테이트.현대1차", "건영캐스빌정문", "건영캐스빌후문",
+                                        "새터마을.죽전힐스테이트후문", "새터마을.죽전힐스테이트정문", "새터마을",
+                                        "죽전교차로", "대지중학교", "죽전1동행정복지센터.홈타운입구",
+                                        "인현마을", "현암마을", "죽전초중고교.대현초교",
+                                        "벽산아파트.우리은행(마을)", "오리역.하나로마트(마을)", "미금역.청솔마을.2001아울렛"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 17, 8, "강남",
+                                List.of(new TransitRouteResponse.Lane("수도권 신분당선", null, null, 109)),
+                                List.of("미금", "정자", "판교", "청계산입구", "양재시민의숲", "양재", "강남")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null)
+                )
+        );
+
+        TransitRouteResponse.Path path4 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(40, 4750, 1, 1, "단국대정문", "강남"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 16, 15, null,
+                                List.of(new TransitRouteResponse.Lane(null, "8100", 6, null)),
+                                List.of("단국대정문", "꽃메마을.새에덴교회", "보정동행정복지센터", "오리역", "미금역.청솔마을.2001아울렛", "정자역")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 2, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 15, 8, "강남",
+                                List.of(new TransitRouteResponse.Lane("수도권 신분당선", null, null, 109)),
+                                List.of("정자", "판교", "청계산입구", "양재시민의숲", "양재", "강남")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null)
+                )
+        );
+
+        TransitRouteResponse.Path path5 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(53, 2850, 1, 2, "단국대학교.죽전야외음악당.성현마을2단지", "강남"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 7, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 13, 15, null,
+                                List.of(new TransitRouteResponse.Lane(null, "40", 3, null)),
+                                List.of(
+                                        "단국대학교.죽전야외음악당.성현마을2단지", "대지고등학교.전내교차로",
+                                        "꽃메마을1단지", "꽃메마을.새에덴교회", "꽃메마을.현대홈타운3단지",
+                                        "중앙공원", "보정동행정복지센터", "보정동카페거리.죽현마을",
+                                        "죽전역.신세계사우스시티"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 1, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 8, 8, "정자",
+                                List.of(new TransitRouteResponse.Lane("수도권 수인.분당선", null, null, 116)),
+                                List.of("죽전", "오리", "미금", "정자")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 15, 8, "강남",
+                                List.of(new TransitRouteResponse.Lane("수도권 신분당선", null, null, 109)),
+                                List.of("정자", "판교", "청계산입구", "양재시민의숲", "양재", "강남")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null)
+                )
+        );
+
+        TransitRouteResponse.Path path6 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(55, 3350, 1, 1, "대지고등학교.전내교차로", "강남"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 7, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 24, 11, null,
+                                List.of(new TransitRouteResponse.Lane(null, "25(단국대학교.미금역)", 3, null)),
+                                List.of(
+                                        "대지고등학교.전내교차로", "꽃메마을1단지", "꽃메마을.새에덴교회",
+                                        "꽃메마을.현대홈타운3단지", "중앙공원", "꽃메마을현대4차4단지",
+                                        "도담마을5.6.7단지", "한양수자인", "대일초등학교", "대일초교후문",
+                                        "대지초교.금강플라자", "한신.길훈아파트", "죽전동성2차아파트",
+                                        "동성1차아파트.죽전패션타운.서울예스병원", "죽전초중고교.대현초교",
+                                        "벽산아파트.우리은행(마을)", "오리역.하나로마트(마을)", "미금역.청솔마을.2001아울렛"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "SUBWAY", 17, 8, "강남",
+                                List.of(new TransitRouteResponse.Lane("수도권 신분당선", null, null, 109)),
+                                List.of("미금", "정자", "판교", "청계산입구", "양재시민의숲", "양재", "강남")
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null)
+                )
+        );
+
+        TransitRouteResponse.Path path7 = new TransitRouteResponse.Path(
+                new TransitRouteResponse.Info(71, 3450, 2, 0, "단국대.치과병원", "신분당선강남역"),
+                List.of(
+                        new TransitRouteResponse.SubPath("WALK", 3, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 22, 15, null,
+                                List.of(new TransitRouteResponse.Lane(null, "8100", 6, null)),
+                                List.of(
+                                        "단국대.치과병원", "단국대정문", "꽃메마을.새에덴교회",
+                                        "보정동행정복지센터", "오리역", "미금역.청솔마을.2001아울렛",
+                                        "정자역", "분당구청입구.수내교", "판교역.낙생육교.현대백화점"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 9, null, null, null, null),
+                        new TransitRouteResponse.SubPath(
+                                "BUS", 33, 12, null,
+                                List.of(new TransitRouteResponse.Lane(null, "1151", 4, null)),
+                                List.of(
+                                        "성남역.백현마을2단지", "백현마을1단지", "판교역.낙생육교.현대백화점",
+                                        "판교TG", "금토JC", "서울진입", "청계산입구역",
+                                        "양재IC", "서초IC", "KCC사옥", "지하철2호선강남역",
+                                        "강남역.지오다노", "강남역10번출구", "신분당선강남역"
+                                )
+                        ),
+                        new TransitRouteResponse.SubPath("WALK", 4, null, null, null, null)
+                )
+        );
+
+        return ApiResponse.ok(new TransitRouteResponse(
+                List.of(path1, path2, path3, path4, path5, path6, path7)
+        ));
+    }
+}

--- a/service-mobility/src/main/java/com/danburn/mobility/controller/MockOdsayController.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/controller/MockOdsayController.java
@@ -23,7 +23,7 @@ public class MockOdsayController {
 
     @Operation(
             summary = "대중교통 경로 조회",
-            description = "출발지/도착지 좌표 기준 대중교통 경로를 조회합니다."
+            description = "!! 현재 Mock Data !! 출발지/도착지 좌표 기준 대중교통 경로를 조회합니다."
     )
     @GetMapping("/route")
     public ApiResponse<TransitRouteResponse> getRoute(

--- a/service-mobility/src/main/java/com/danburn/mobility/controller/MockOdsayController.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/controller/MockOdsayController.java
@@ -5,6 +5,9 @@ import com.danburn.mobility.dto.response.TransitRouteResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,40 +16,21 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @Tag(name = "대중교통 경로", description = "대중교통 경로 조회 API")
+@Validated
 @RestController
 @RequestMapping("/api/mobility")
 public class MockOdsayController {
 
     @Operation(
             summary = "대중교통 경로 조회",
-            description = """
-                    출발지/도착지 좌표 기준 대중교통 경로를 조회합니다.
-
-                    **subPath.trafficType별 응답 필드 안내**
-
-                    | 필드 | WALK | BUS | SUBWAY |
-                    |------|------|-----|--------|
-                    | intervalTime | 생략 | 배차 간격(분) | 배차 간격(분) |
-                    | way | 생략 | 생략 | 진행 방면 |
-                    | lane | 생략 | 버스 노선 목록 | 지하철 노선 목록 |
-                    | stations | 생략 | 경유 정류장 목록 | 경유 역 목록 |
-
-                    **lane 필드별 응답 안내**
-
-                    | 필드 | BUS | SUBWAY |
-                    |------|-----|--------|
-                    | busNo | 버스 번호 | 생략 |
-                    | type | 버스 종류 코드 | 생략 |
-                    | name | 생략 | 지하철 노선명 |
-                    | subwayCode | 생략 | 지하철 노선 코드 |
-                    """
+            description = "출발지/도착지 좌표 기준 대중교통 경로를 조회합니다."
     )
     @GetMapping("/route")
     public ApiResponse<TransitRouteResponse> getRoute(
-            @Parameter(description = "출발지 경도", example = "127.1272127") @RequestParam double originLng,
-            @Parameter(description = "출발지 위도", example = "37.3213399") @RequestParam double originLat,
-            @Parameter(description = "도착지 경도", example = "127.02800140627488") @RequestParam double destLng,
-            @Parameter(description = "도착지 위도", example = "37.49808633653005") @RequestParam double destLat
+            @Parameter(description = "출발지 경도", example = "127.1272127") @DecimalMin("-180.0") @DecimalMax("180.0") @RequestParam double originLng,
+            @Parameter(description = "출발지 위도", example = "37.3213399") @DecimalMin("-90.0") @DecimalMax("90.0") @RequestParam double originLat,
+            @Parameter(description = "도착지 경도", example = "127.02800140627488") @DecimalMin("-180.0") @DecimalMax("180.0") @RequestParam double destLng,
+            @Parameter(description = "도착지 위도", example = "37.49808633653005") @DecimalMin("-90.0") @DecimalMax("90.0") @RequestParam double destLat
     ) {
         TransitRouteResponse.Path path1 = new TransitRouteResponse.Path(
                 new TransitRouteResponse.Info(59, 3200, 1, 0, "단국대정문", "신분당선강남역"),

--- a/service-mobility/src/main/java/com/danburn/mobility/dto/request/OdsayApiRequest.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/dto/request/OdsayApiRequest.java
@@ -1,0 +1,8 @@
+package com.danburn.mobility.dto.request;
+
+public record OdsayApiRequest(
+        double originLng,
+        double originLat,
+        double destLng,
+        double destLat
+) {}

--- a/service-mobility/src/main/java/com/danburn/mobility/dto/response/OdsayApiResponse.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/dto/response/OdsayApiResponse.java
@@ -1,0 +1,68 @@
+package com.danburn.mobility.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Schema(description = "ODsay 대중교통 경로 응답")
+public record OdsayApiResponse(Result result) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "경로 검색 결과")
+    public record Result(
+            @Schema(description = "검색 타입(0: 광역버스, 시내버스, 지하철, 도보 1: KTX, GTX, SRT, 시외버스)") int searchType,
+            @Schema(description = "경로 옵션 목록") List<Path> path
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "하나의 경로 옵션")
+    public record Path(
+            @Schema(description = "경로 전체 요약 정보") Info info,
+            @Schema(description = "구간 목록 (도보/버스/지하철 순서로 구성)") List<SubPath> subPath
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "경로 전체 요약 정보")
+    public record Info(
+            @Schema(description = "총 소요 시간 (분)") int totalTime,
+            @Schema(description = "총 요금 (원)") int payment,
+            @Schema(description = "버스 환승 횟수") int busTransitCount,
+            @Schema(description = "지하철 환승 횟수") int subwayTransitCount,
+            @Schema(description = "첫 출발 정류장/역명") String firstStartStation,
+            @Schema(description = "최종 도착 정류장/역명") String lastEndStation
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "이동 구간 정보. trafficType에 따라 null 필드가 다름")
+    public record SubPath(
+            @Schema(description = "이동 수단 유형 (1=지하철, 2=버스, 3=도보)") int trafficType,
+            @Schema(description = "구간 소요 시간 (분)") int sectionTime,
+            @Schema(description = "배차 간격 (분). WALK이면 null") Integer intervalTime,
+            @Schema(description = "지하철 진행 방면. BUS/WALK이면 null") String way,
+            @Schema(description = "탑승 가능 노선 목록. WALK이면 null") List<Lane> lane,
+            @Schema(description = "경유 정류장/역 목록. WALK이면 null") PassStopList passStopList
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "경유 정류장/역 목록")
+    public record PassStopList(
+            @Schema(description = "정류장/역 목록") List<Station> stations
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "정류장/역 정보")
+    public record Station(
+            @Schema(description = "정류장/역 이름") String stationName
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "노선 정보. BUS/SUBWAY에 따라 null 필드가 다름")
+    public record Lane(
+            @Schema(description = "지하철 노선명. BUS이면 null") String name,
+            @Schema(description = "버스 번호. SUBWAY이면 null") String busNo,
+            @Schema(description = "버스 종류 코드. SUBWAY이면 null") Integer type,
+            @Schema(description = "지하철 노선 코드. BUS이면 null") Integer subwayCode
+    ) {}
+}

--- a/service-mobility/src/main/java/com/danburn/mobility/dto/response/TransitRouteResponse.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/dto/response/TransitRouteResponse.java
@@ -1,0 +1,48 @@
+package com.danburn.mobility.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "대중교통 경로 응답")
+public record TransitRouteResponse(
+        @Schema(description = "경로 옵션 목록") List<Path> paths
+) {
+
+    @Schema(description = "하나의 경로 옵션")
+    public record Path(
+            @Schema(description = "경로 전체 요약 정보") Info info,
+            @Schema(description = "구간 목록") List<SubPath> subPaths
+    ) {}
+
+    @Schema(description = "경로 전체 요약 정보")
+    public record Info(
+            @Schema(description = "총 소요 시간 (분)") int totalTime,
+            @Schema(description = "총 요금 (원)") int payment,
+            @Schema(description = "버스 환승 횟수") int busTransitCount,
+            @Schema(description = "지하철 환승 횟수") int subwayTransitCount,
+            @Schema(description = "첫 출발 정류장/역명") String firstStartStation,
+            @Schema(description = "최종 도착 정류장/역명") String lastEndStation
+    ) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "이동 구간 정보. WALK이면 null 필드 생략됨")
+    public record SubPath(
+            @Schema(description = "이동 수단 (WALK / BUS / SUBWAY)") String trafficType,
+            @Schema(description = "구간 소요 시간 (분)") int sectionTime,
+            @Schema(description = "배차 간격 (분). WALK이면 생략") Integer intervalTime,
+            @Schema(description = "지하철 진행 방면. BUS/WALK이면 생략") String way,
+            @Schema(description = "탑승 가능 노선 목록. WALK이면 생략") List<Lane> lane,
+            @Schema(description = "경유 정류장/역 이름 목록. WALK이면 생략") List<String> stations
+    ) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "노선 정보. BUS/SUBWAY에 따라 null 필드 생략됨")
+    public record Lane(
+            @Schema(description = "지하철 노선명. BUS이면 생략") String name,
+            @Schema(description = "버스 번호. SUBWAY이면 생략") String busNo,
+            @Schema(description = "버스 종류 코드. SUBWAY이면 생략") Integer type,
+            @Schema(description = "지하철 노선 코드. BUS이면 생략") Integer subwayCode
+    ) {}
+}


### PR DESCRIPTION
작업 내용
- [x] `OdsayApiResponse` ODsay 원본 역직렬화용 Raw DTO 설계
- [x] `TransitRouteResponse` 프론트 응답 DTO 분리
- [x] `result` 래퍼 제거, `paths` 직접 반환
- [x] `trafficType` String 변환 (WALK / BUS / SUBWAY)
- [x] `PassStopList { List<Station> }` → `List<String> stations` 평탄화
- [x] `@JsonInclude(NON_NULL)` 적용 (WALK 구간 null 필드 자동 생략)
- [x] `MockOdsayController` 실제 ODsay 응답 기반 7개 경로 Mock 데이터 구현
- [x] Swagger `@Schema`, `@Operation` 문서화
- [x] 좌표 파라미터 유효성 검증 추가 (`@DecimalMin` / `@DecimalMax`)
- [x] `GlobalExceptionHandler` 추가


추후 구현 사항
  
- [ ] 실제 ODsay API 연동 시 `OdsayApiClient` (infra), `OdsayService` (변환 로직),
  `OdsayController` 구현 예정