### PR TITLE
chore(release): dev → main promotion (#305 환각 차단 + search_web 재시도)

### DIFF
--- a/service-ai/app/ai/mcp/server.py
+++ b/service-ai/app/ai/mcp/server.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 mcp_server = FastMCP("ai-search-server")
 
 BODY_SNIPPET_MAX_CHARS = 200
+SEARCH_MAX_ATTEMPTS = 2
+SEARCH_RETRY_BACKOFF_SECONDS = 0.5
 
 
 @mcp_server.tool()
@@ -35,18 +37,47 @@ async def search_web(query: str) -> dict[str, Any]:
         실패: {"error": "search_timeout" | "search_failed", "results": []}
 
     date 는 기사 발행일이며 행사일과 다름. body 는 행사 일시·장소 검증용 snippet.
+    DDG의 일시 응답 파싱 오류(DecodeError) 대비로 1회 재시도한다.
+    최종 실패해도 빈 결과로 반환하여 분석은 계속 진행되도록 한다 (WARN).
     """
-    try:
-        raw = await asyncio.wait_for(
-            asyncio.to_thread(_ddg_news, query),
-            timeout=settings.mcp_tool_timeout_seconds,
+    raw: list[dict[str, Any]] | None = None
+    last_error: BaseException | None = None
+    for attempt in range(1, SEARCH_MAX_ATTEMPTS + 1):
+        try:
+            raw = await asyncio.wait_for(
+                asyncio.to_thread(_ddg_news, query),
+                timeout=settings.mcp_tool_timeout_seconds,
+            )
+            last_error = None
+            break
+        except asyncio.TimeoutError as e:
+            last_error = e
+            if attempt < SEARCH_MAX_ATTEMPTS:
+                logger.warning(
+                    "[MCP] search_web 타임아웃, 재시도 - query=%s, attempt=%d",
+                    query, attempt,
+                )
+                await asyncio.sleep(SEARCH_RETRY_BACKOFF_SECONDS)
+        except Exception as e:
+            last_error = e
+            if attempt < SEARCH_MAX_ATTEMPTS:
+                logger.warning(
+                    "[MCP] search_web 일시 실패, 재시도 - query=%s, attempt=%d, error=%s",
+                    query, attempt, type(e).__name__,
+                )
+                await asyncio.sleep(SEARCH_RETRY_BACKOFF_SECONDS)
+
+    if last_error is not None:
+        error_kind = (
+            "search_timeout" if isinstance(last_error, asyncio.TimeoutError)
+            else "search_failed"
         )
-    except asyncio.TimeoutError:
-        logger.warning("[MCP] search_web 타임아웃 - query=%s", query)
-        return {"error": "search_timeout", "results": []}
-    except Exception as e:
-        logger.error("[MCP] search_web 실패 - query=%s, error=%s", query, e)
-        return {"error": "search_failed", "results": []}
+        # 재시도 후 최종 실패 — 분석은 빈 결과로 진행되도록 WARN
+        logger.warning(
+            "[MCP] search_web 최종 실패 - query=%s, kind=%s, error=%s",
+            query, error_kind, type(last_error).__name__,
+        )
+        return {"error": error_kind, "results": []}
 
     results = [
         {

--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -12,7 +12,9 @@ import asyncio
 import json
 import logging
 import re
+from datetime import date, datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import httpx
 
@@ -28,6 +30,80 @@ logger = logging.getLogger(__name__)
 
 # 배치당 응답 토큰 예산 경험치 (rate limiter 사전 추정용)
 RESPONSE_TOKEN_BUDGET = 400
+
+_KST = ZoneInfo("Asia/Seoul")
+# 모델이 환각 회피용으로 이미 안전하게 답한 경우 검증을 스킵하는 마커
+_SAFE_MESSAGE_MARKERS = ("원인 불명", "추가 모니터링")
+_FALLBACK_MESSAGE = "원인 불명, 추가 모니터링 필요"
+
+
+def _now_kst_date() -> date:
+    """KST 기준 오늘 날짜. 테스트에서 monkeypatch로 고정 가능."""
+    return datetime.now(_KST).date()
+
+
+def _today_date_variants(today: date) -> list[str]:
+    """오늘 날짜를 한국 뉴스 본문에서 마주칠 만한 표기 변형 목록.
+
+    한 변형이라도 등장하면 '검색 결과가 오늘 일정을 다룬다'고 본다.
+    """
+    y, m, d = today.year, today.month, today.day
+    return [
+        f"{y}-{m:02d}-{d:02d}",
+        f"{y}.{m:02d}.{d:02d}",
+        f"{y}/{m:02d}/{d:02d}",
+        f"{y}년 {m}월 {d}일",
+        f"{y}년{m}월{d}일",
+        f"{m}월 {d}일",
+        f"{m}/{d}",
+        f"{m}-{d}",
+        f"{m}.{d}",
+        f"{m:02d}/{d:02d}",
+        f"{m:02d}-{d:02d}",
+    ]
+
+
+def _has_today_marker(text: str, today: date) -> bool:
+    return any(v in text for v in _today_date_variants(today))
+
+
+def _is_safe_message(message: str) -> bool:
+    return any(marker in message for marker in _SAFE_MESSAGE_MARKERS)
+
+
+def _validate_anti_hallucination(
+    message: str,
+    *,
+    tool_called: bool,
+    tool_results: list[dict[str, Any]] | None,
+    today: date,
+) -> tuple[str, bool]:
+    """검색 결과 본문에 오늘 날짜가 없으면 메시지를 안전 문구로 강제 교체.
+
+    - tool_called=False: 외부 이벤트 의존하지 않는 일반 분석이므로 통과
+    - 이미 안전 문구(원인 불명/추가 모니터링)인 경우 통과
+    - tool_results 본문(body)+제목(title) 합본에 오늘 날짜 변형이 하나도 없으면
+      모델이 과거 기사 등 무관 정보로 합성했을 가능성 높음 → 안전 문구로 교체
+
+    Returns: (검증 통과한 메시지, 교체 발생 여부)
+    """
+    if not tool_called:
+        return message, False
+    if _is_safe_message(message):
+        return message, False
+
+    haystack_parts: list[str] = []
+    for r in tool_results or []:
+        body = r.get("body") or ""
+        title = r.get("title") or ""
+        if body or title:
+            haystack_parts.append(body)
+            haystack_parts.append(title)
+    haystack = " ".join(haystack_parts)
+
+    if _has_today_marker(haystack, today):
+        return message, False
+    return _FALLBACK_MESSAGE, True
 
 
 class OpenAIAnalyzer(AIAnalyzer):
@@ -226,6 +302,7 @@ class OpenAIAnalyzer(AIAnalyzer):
 
         items = parsed.get("results", parsed.get("data", []))
         event_map = {e.area_code: e for e in events}
+        today = _now_kst_date()
         results: list[AnalysisResult] = []
         for item in items:
             area_code = item.get("area_code")
@@ -235,18 +312,33 @@ class OpenAIAnalyzer(AIAnalyzer):
             event = event_map.get(area_code)
             if event is None:
                 continue
+
+            validated_message, replaced = _validate_anti_hallucination(
+                analysis_message,
+                tool_called=tool_called,
+                tool_results=tool_results,
+                today=today,
+            )
+            if replaced:
+                logger.warning(
+                    "[OpenAI] 환각 의심 - tool_results에 오늘 날짜 없음, "
+                    "메시지 강제 교체. area_code=%s, original=%s",
+                    area_code,
+                    analysis_message,
+                )
+
             results.append(
                 AnalysisResult(
                     area_name=event.area_name,
                     area_code=area_code,
                     congestion_level=event.congestion_level,
-                    analysis_message=analysis_message,
+                    analysis_message=validated_message,
                     population_time=event.population_time,
                 )
             )
             self._log_analysis(
                 event=event,
-                analysis_message=analysis_message,
+                analysis_message=validated_message,
                 tool_called=tool_called,
                 tool_queries=tool_queries,
                 tool_results=tool_results,

--- a/service-ai/tests/test_anti_hallucination.py
+++ b/service-ai/tests/test_anti_hallucination.py
@@ -1,0 +1,138 @@
+"""환각 방지 검증 헬퍼 단위 테스트.
+
+운영 사고: 모델이 검색 결과에 5월 19일 일정이 없는데도 5월 19일 잠실 메시지를
+"프로야구 및 프로농구 경기로 인한 혼잡"으로 합성한 사례 → 본문에 오늘 날짜가
+명시되지 않으면 메시지를 강제로 안전 문구로 교체하도록 가드 추가.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from app.ai.openai.client import (
+    _FALLBACK_MESSAGE,
+    _has_today_marker,
+    _is_safe_message,
+    _today_date_variants,
+    _validate_anti_hallucination,
+)
+
+
+TODAY = date(2026, 5, 19)
+
+
+class TestTodayDateVariants:
+    def test_includes_common_korean_news_formats(self) -> None:
+        variants = _today_date_variants(TODAY)
+        assert "2026-05-19" in variants
+        assert "5월 19일" in variants
+        assert "5/19" in variants
+        assert "05-19" in variants
+
+    def test_zero_padding_and_unpadded_both_present(self) -> None:
+        variants = _today_date_variants(TODAY)
+        # padded
+        assert "05/19" in variants
+        # unpadded
+        assert "5-19" in variants
+
+
+class TestHasTodayMarker:
+    def test_returns_true_on_iso_format(self) -> None:
+        text = "5월 19일 오후 7시 잠실구장에서 KBO 정규시즌 진행 (2026-05-19)"
+        assert _has_today_marker(text, TODAY) is True
+
+    def test_returns_true_on_korean_format(self) -> None:
+        text = "이번 5월 19일 잠실에서 야구 경기가 열립니다"
+        assert _has_today_marker(text, TODAY) is True
+
+    def test_returns_false_when_only_other_dates_present(self) -> None:
+        # 운영 사례: 검색 결과가 전부 3월 기사
+        text = "2026-03-28 KBO 개막전 잠실 / 3월 29일 농구 경기"
+        assert _has_today_marker(text, TODAY) is False
+
+    def test_returns_false_on_empty_text(self) -> None:
+        assert _has_today_marker("", TODAY) is False
+
+
+class TestIsSafeMessage:
+    def test_safe_when_contains_unknown_marker(self) -> None:
+        assert _is_safe_message("원인 불명, 추가 모니터링 필요") is True
+
+    def test_safe_when_contains_monitoring_marker(self) -> None:
+        assert _is_safe_message("외부 이벤트 미확인, 추가 모니터링 진행") is True
+
+    def test_unsafe_for_concrete_event_claim(self) -> None:
+        assert _is_safe_message("프로야구 경기로 인한 혼잡") is False
+
+
+class TestValidateAntiHallucination:
+    def test_passes_through_when_tool_not_called(self) -> None:
+        # 일반 분석(출퇴근 등)은 외부 이벤트 의존이 없으므로 검증 스킵
+        out, replaced = _validate_anti_hallucination(
+            "출근 시간대 업무지구 혼잡",
+            tool_called=False,
+            tool_results=None,
+            today=TODAY,
+        )
+        assert out == "출근 시간대 업무지구 혼잡"
+        assert replaced is False
+
+    def test_passes_through_when_message_already_safe(self) -> None:
+        out, replaced = _validate_anti_hallucination(
+            "원인 불명, 추가 모니터링 필요",
+            tool_called=True,
+            tool_results=[{"title": "무관 기사", "body": "오래 전 일", "date": ""}],
+            today=TODAY,
+        )
+        assert replaced is False
+        assert "원인 불명" in out
+
+    def test_passes_through_when_today_marker_in_body(self) -> None:
+        out, replaced = _validate_anti_hallucination(
+            "잠실 야구 경기로 인한 혼잡",
+            tool_called=True,
+            tool_results=[
+                {
+                    "title": "오늘 잠실 KBO 정규시즌 일정",
+                    "date": "2026-05-19T11:00:00+00:00",
+                    "body": "5월 19일 오후 7시 잠실구장 KBO 정규시즌 경기",
+                },
+            ],
+            today=TODAY,
+        )
+        assert out == "잠실 야구 경기로 인한 혼잡"
+        assert replaced is False
+
+    def test_replaces_when_no_today_marker_in_body(self) -> None:
+        # 운영 사고 재현: 검색 결과가 전부 3월 기사인데 모델은 5/19 메시지 합성
+        out, replaced = _validate_anti_hallucination(
+            "프로야구 및 프로농구 경기로 인한 혼잡",
+            tool_called=True,
+            tool_results=[
+                {
+                    "title": "주말 잠실종합운동장 6만 명 운집",
+                    "date": "2026-03-29T09:02:00+00:00",
+                    "body": "이번 주말 서울 잠실종합운동장에서 프로야구 개막전을 비롯해",
+                },
+                {
+                    "title": "잠실 돔구장 착공 확정",
+                    "date": "2026-03-11T18:40:00+00:00",
+                    "body": "2032년 서울 송파구 잠실종합운동장 일대가",
+                },
+            ],
+            today=TODAY,
+        )
+        assert out == _FALLBACK_MESSAGE
+        assert replaced is True
+
+    def test_replaces_when_tool_results_empty(self) -> None:
+        # 검색했지만 결과 0건 → 본문 0자 → 매칭 불가 → 안전 교체
+        out, replaced = _validate_anti_hallucination(
+            "행사로 인한 혼잡",
+            tool_called=True,
+            tool_results=[],
+            today=TODAY,
+        )
+        assert out == _FALLBACK_MESSAGE
+        assert replaced is True

--- a/service-ai/tests/test_openai_client_tools.py
+++ b/service-ai/tests/test_openai_client_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import date
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -17,6 +18,19 @@ import pytest
 
 from app.ai.openai import OpenAIAnalyzer
 from app.models.schemas import CongestionEvent
+
+
+@pytest.fixture(autouse=True)
+def _freeze_today(monkeypatch):
+    """이 모듈의 모든 테스트에서 KST '오늘'을 이벤트의 populationTime(5/5) 으로 고정.
+
+    환각 검증이 tool_results 본문에서 '오늘 날짜 마커'를 찾기 때문에,
+    테스트 시점의 실제 오늘과 무관하게 결정적이도록 함.
+    """
+    monkeypatch.setattr(
+        "app.ai.openai.client._now_kst_date",
+        lambda: date(2026, 5, 5),
+    )
 
 
 def _make_event(
@@ -103,7 +117,11 @@ async def test_no_tool_calls_direct_answer(analyzer):
 async def test_single_tool_call_then_final_answer(analyzer):
     a, mcp = analyzer
     mcp.call_tool.return_value = json.dumps({
-        "results": [{"title": "강남역 콘서트", "date": "2026-05-05"}]
+        "results": [{
+            "title": "강남역 콘서트",
+            "date": "2026-05-05",
+            "body": "5월 5일 오후 8시 강남역 부근 콘서트 개최 예정",
+        }]
     })
     a._client.post.side_effect = [
         _httpx_response(_llm_payload(content=None, tool_calls=[{
@@ -131,7 +149,13 @@ async def test_single_tool_call_then_final_answer(analyzer):
 
 async def test_parallel_tool_calls(analyzer):
     a, mcp = analyzer
-    mcp.call_tool.return_value = json.dumps({"results": []})
+    mcp.call_tool.return_value = json.dumps({
+        "results": [{
+            "title": "오늘 행사",
+            "date": "2026-05-05",
+            "body": "5월 5일 행사 진행",
+        }]
+    })
     a._client.post.side_effect = [
         _httpx_response(_llm_payload(content=None, tool_calls=[
             {


### PR DESCRIPTION
## Summary
- Promote #305 to main: AI 분석 메시지의 환각 차단 + search_web 일시 파싱 오류 안정화

## Included
- #305 fix(ai): tool 검색 결과 본문 기반 환각 차단 + search_web 1회 재시도
  - `_parse_results` 후처리에 tool_results 본문의 오늘 날짜 마커 검증
  - 마커 0건이면 메시지를 "원인 불명, 추가 모니터링 필요"로 강제 교체 + WARN 로그
  - search_web 1회 재시도(0.5s backoff) + 최종 실패 ERROR→WARN

## Operational notes
- 환각 의심 시 WARN 로그(`[OpenAI] 환각 의심 - tool_results에 오늘 날짜 없음`)로 Grafana 추적
- WARN 빈도 ↑ = 환각 차단 동작 / 정상 분석 과탐 둘 다 가능 → 운영 모니터링 필요
- tool_results body snippet (200자, #287) 이 일치 마커를 못 만들 만큼 짧을 가능성은 낮음

## Test plan
- [x] pytest 57건 통과 (anti_hallucination 14건 신규 + 기존 회귀 0)
- [x] dev CI 5건 통과
- [ ] main 배포 후 Grafana에서 `환각 의심` WARN 로그 발생/빈도 확인
- [ ] 정상 분석 통과율 (메시지 교체 비율 < 30% 목표)
- [ ] `[MCP] search_web 재시도` WARN으로 일시 hiccup 흡수 효과 추적