### PR TITLE
chore: promote dev → main (혼잡도 하강 알림 #298)

### DIFF
--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':service-common')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -17,6 +18,10 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
     runtimeOnly 'net.ttddyy.observation:datasource-micrometer-spring-boot:1.0.6'
+
+    implementation 'nl.martijndwars:web-push:5.1.1'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/service-congestion/src/main/java/com/danburn/congestion/CongestionApplication.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/CongestionApplication.java
@@ -1,12 +1,15 @@
 package com.danburn.congestion;
 
+import com.danburn.congestion.notification.config.VapidProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @EnableAsync
+@EnableConfigurationProperties(VapidProperties.class)
 @SpringBootApplication(scanBasePackages = {"com.danburn.congestion", "com.danburn.common"})
 public class CongestionApplication {
 

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/config/NotificationAsyncConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/config/NotificationAsyncConfig.java
@@ -1,0 +1,22 @@
+package com.danburn.congestion.notification.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class NotificationAsyncConfig {
+
+    @Bean("notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("notif-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/config/VapidProperties.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/config/VapidProperties.java
@@ -1,0 +1,10 @@
+package com.danburn.congestion.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("vapid")
+public record VapidProperties(
+        String publicKey,
+        String privateKey,
+        String subject
+) {}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/controller/NotificationController.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/controller/NotificationController.java
@@ -1,0 +1,57 @@
+package com.danburn.congestion.notification.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.congestion.notification.config.VapidProperties;
+import com.danburn.congestion.notification.dto.SubscribeRequest;
+import com.danburn.congestion.notification.dto.SubscribeResult;
+import com.danburn.congestion.notification.dto.UnsubscribeRequest;
+import com.danburn.congestion.notification.dto.VapidKeyResponse;
+import com.danburn.congestion.notification.service.SubscriptionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final SubscriptionService subscriptionService;
+    private final VapidProperties vapidProperties;
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<ApiResponse<SubscribeResult>> subscribe(@RequestBody @Valid SubscribeRequest request) {
+        SubscribeResult result = subscriptionService.subscribe(request);
+
+        if ("SUBSCRIBED".equals(result.status())) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(result));
+        }
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @PostMapping("/unsubscribe")
+    public ResponseEntity<ApiResponse<Void>> unsubscribe(@Valid @RequestBody UnsubscribeRequest req) {
+        subscriptionService.unsubscribe(req.endpoint(), req.areaCode());
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @GetMapping("/vapid-public-key")
+    public ResponseEntity<ApiResponse<VapidKeyResponse>> getVapidPublicKey() {
+        if (vapidProperties.publicKey() == null || vapidProperties.publicKey().isBlank()) {
+            ApiResponse<VapidKeyResponse> errorBody = new ApiResponse<>(503, "VAPID 키가 설정되지 않았습니다", null);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .header(HttpHeaders.RETRY_AFTER, "3600")
+                    .body(errorBody);
+        }
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CACHE_CONTROL, "public, max-age=86400")
+                .body(ApiResponse.ok(new VapidKeyResponse(vapidProperties.publicKey())));
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/controller/NotificationExceptionHandler.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/controller/NotificationExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.danburn.congestion.notification.controller;
+
+import com.danburn.common.response.ApiResponse;
+import com.danburn.congestion.notification.exception.AlreadyNotBusyException;
+import com.danburn.congestion.notification.exception.AreaNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class NotificationExceptionHandler {
+
+    @ExceptionHandler(AreaNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAreaNotFound(AreaNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error(HttpStatus.NOT_FOUND.value(), "존재하지 않는 장소예요"));
+    }
+
+    @ExceptionHandler(AlreadyNotBusyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAlreadyNotBusy(AlreadyNotBusyException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT.value(), "이미 한가한 지역이에요. 지금 바로 방문하기 좋아요!"));
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/domain/NotificationSubscription.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/domain/NotificationSubscription.java
@@ -1,0 +1,81 @@
+package com.danburn.congestion.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "notification_subscription",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_subscription_endpoint_area", columnNames = {"endpoint", "area_code"})
+        },
+        indexes = {
+                @Index(name = "idx_subscription_area_expires", columnList = "area_code, expires_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationSubscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "endpoint", nullable = false, length = 700)
+    private String endpoint;
+
+    @Column(name = "p256dh_key", nullable = false, length = 200)
+    private String p256dhKey;
+
+    @Column(name = "auth_key", nullable = false, length = 100)
+    private String authKey;
+
+    @Column(name = "area_code", nullable = false, length = 20)
+    private String areaCode;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Builder
+    private NotificationSubscription(
+            String endpoint,
+            String p256dhKey,
+            String authKey,
+            String areaCode,
+            Instant expiresAt,
+            Instant createdAt) {
+        this.endpoint = endpoint;
+        this.p256dhKey = p256dhKey;
+        this.authKey = authKey;
+        this.areaCode = areaCode;
+        this.expiresAt = expiresAt;
+        this.createdAt = createdAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+
+    public void renewExpiresAt(Instant newExpiresAt) {
+        this.expiresAt = newExpiresAt;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/dto/SubscribeRequest.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/dto/SubscribeRequest.java
@@ -1,0 +1,18 @@
+package com.danburn.congestion.notification.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SubscribeRequest(
+        @NotBlank @Size(max = 700) @Pattern(regexp = "^https://.+") String endpoint,
+        @NotNull @Valid Keys keys,
+        @NotBlank @Size(max = 20) String areaCode
+) {
+    public record Keys(
+            @NotBlank String p256dh,
+            @NotBlank String auth
+    ) {}
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/dto/SubscribeResponse.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/dto/SubscribeResponse.java
@@ -1,0 +1,8 @@
+package com.danburn.congestion.notification.dto;
+
+import java.time.Instant;
+
+public record SubscribeResponse(
+        String status,
+        Instant expiresAt
+) {}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/dto/SubscribeResult.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/dto/SubscribeResult.java
@@ -1,0 +1,5 @@
+package com.danburn.congestion.notification.dto;
+
+import java.time.Instant;
+
+public record SubscribeResult(String status, Instant expiresAt) {}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/dto/UnsubscribeRequest.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/dto/UnsubscribeRequest.java
@@ -1,0 +1,9 @@
+package com.danburn.congestion.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UnsubscribeRequest(
+        @NotBlank @Size(max = 700) String endpoint,
+        @NotBlank @Size(max = 20) String areaCode
+) {}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/dto/VapidKeyResponse.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/dto/VapidKeyResponse.java
@@ -1,0 +1,5 @@
+package com.danburn.congestion.notification.dto;
+
+public record VapidKeyResponse(
+        String publicKey
+) {}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/exception/AlreadyNotBusyException.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/exception/AlreadyNotBusyException.java
@@ -1,0 +1,17 @@
+package com.danburn.congestion.notification.exception;
+
+import com.danburn.congestion.domain.CongestionLevel;
+
+public class AlreadyNotBusyException extends RuntimeException {
+
+    private final CongestionLevel currentLevel;
+
+    public AlreadyNotBusyException(CongestionLevel currentLevel) {
+        super("이미 한가한 지역: " + currentLevel.name());
+        this.currentLevel = currentLevel;
+    }
+
+    public CongestionLevel getCurrentLevel() {
+        return currentLevel;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/exception/AreaNotFoundException.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/exception/AreaNotFoundException.java
@@ -1,0 +1,15 @@
+package com.danburn.congestion.notification.exception;
+
+public class AreaNotFoundException extends RuntimeException {
+
+    private final String areaCode;
+
+    public AreaNotFoundException(String areaCode) {
+        super("존재하지 않는 장소: " + areaCode);
+        this.areaCode = areaCode;
+    }
+
+    public String getAreaCode() {
+        return areaCode;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/health/WebPushHealthIndicator.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/health/WebPushHealthIndicator.java
@@ -1,0 +1,24 @@
+package com.danburn.congestion.notification.health;
+
+import com.danburn.congestion.notification.service.WebPushSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WebPushHealthIndicator implements HealthIndicator {
+
+    private final WebPushSender webPushSender;
+
+    @Override
+    public Health health() {
+        if (!webPushSender.isConfigured()) {
+            return Health.down()
+                    .withDetail("reason", "VAPID keys not configured")
+                    .build();
+        }
+        return Health.up().build();
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/repository/NotificationFiredMarkerRepository.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/repository/NotificationFiredMarkerRepository.java
@@ -1,0 +1,25 @@
+package com.danburn.congestion.notification.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationFiredMarkerRepository {
+
+    private static final String KEY_PREFIX = "notif:fired:";
+    private static final Duration MARKER_TTL = Duration.ofSeconds(30);
+
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    public void markFired(String areaCode) {
+        stringRedisTemplate.opsForValue().set(KEY_PREFIX + areaCode, "1", MARKER_TTL);
+    }
+
+    public boolean isRecentlyFired(String areaCode) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(KEY_PREFIX + areaCode));
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/repository/NotificationSubscriptionRepository.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/repository/NotificationSubscriptionRepository.java
@@ -1,0 +1,25 @@
+package com.danburn.congestion.notification.repository;
+
+import com.danburn.congestion.notification.domain.NotificationSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationSubscriptionRepository extends JpaRepository<NotificationSubscription, Long> {
+
+    Optional<NotificationSubscription> findByEndpointAndAreaCode(String endpoint, String areaCode);
+
+    List<NotificationSubscription> findByAreaCodeAndExpiresAtAfter(String areaCode, Instant now);
+
+    @Modifying
+    @Transactional
+    void deleteByEndpointAndAreaCode(String endpoint, String areaCode);
+
+    @Modifying
+    @Transactional
+    int deleteByExpiresAtBefore(Instant now);
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/scheduler/ExpiredSubscriptionCleanup.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/scheduler/ExpiredSubscriptionCleanup.java
@@ -1,0 +1,28 @@
+package com.danburn.congestion.notification.scheduler;
+
+import com.danburn.congestion.notification.repository.NotificationSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExpiredSubscriptionCleanup {
+
+    private final NotificationSubscriptionRepository repository;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void cleanupExpiredSubscriptions() {
+        log.info("[ExpiredSubscriptionCleanup] 만료된 구독 정리 시작");
+        try {
+            int deleted = repository.deleteByExpiresAtBefore(Instant.now());
+            log.info("[ExpiredSubscriptionCleanup] 만료된 구독 정리 완료 - {}건 삭제", deleted);
+        } catch (Exception e) {
+            log.error("[ExpiredSubscriptionCleanup] 만료된 구독 정리 실패 - {}", e.getMessage(), e);
+        }
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/service/SubscriptionService.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/service/SubscriptionService.java
@@ -1,0 +1,132 @@
+package com.danburn.congestion.notification.service;
+
+import com.danburn.congestion.domain.CongestionLevel;
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.notification.domain.NotificationSubscription;
+import com.danburn.congestion.notification.dto.SubscribeRequest;
+import com.danburn.congestion.notification.dto.SubscribeResult;
+import com.danburn.congestion.notification.exception.AlreadyNotBusyException;
+import com.danburn.congestion.notification.exception.AreaNotFoundException;
+import com.danburn.congestion.notification.repository.NotificationFiredMarkerRepository;
+import com.danburn.congestion.notification.repository.NotificationSubscriptionRepository;
+import com.danburn.congestion.repository.CongestionRedisRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+    private static final Duration TTL = Duration.ofHours(12);
+
+    private final NotificationSubscriptionRepository repository;
+    private final CongestionRedisRepository congestionRedisRepository;
+    private final WebPushSender webPushSender;
+    private final ObjectMapper objectMapper;
+    private final NotificationFiredMarkerRepository firedMarkerRepository;
+
+    @Transactional
+    public SubscribeResult subscribe(SubscribeRequest req) {
+        CongestionRedisDto congestionData = congestionRedisRepository.findByAreaCode(req.areaCode())
+                .orElseThrow(() -> new AreaNotFoundException(req.areaCode()));
+
+        CongestionLevel level = CongestionLevel.fromDescription(congestionData.congestionLevel());
+        if (level != CongestionLevel.BUSY) {
+            throw new AlreadyNotBusyException(level);
+        }
+
+        if (firedMarkerRepository.isRecentlyFired(req.areaCode())) {
+            throw new AlreadyNotBusyException(level);
+        }
+
+        Instant now = Instant.now();
+        Instant expiresAt = now.plus(TTL);
+
+        Optional<NotificationSubscription> existing =
+                repository.findByEndpointAndAreaCode(req.endpoint(), req.areaCode());
+
+        if (existing.isPresent()) {
+            NotificationSubscription sub = existing.get();
+            sub.renewExpiresAt(expiresAt);
+            repository.save(sub);
+            log.info("[SubscriptionService] 구독 갱신 - areaCode={}, endpoint={}", req.areaCode(), req.endpoint());
+            return new SubscribeResult("RENEWED", expiresAt);
+        }
+
+        NotificationSubscription sub = NotificationSubscription.builder()
+                .endpoint(req.endpoint())
+                .p256dhKey(req.keys().p256dh())
+                .authKey(req.keys().auth())
+                .areaCode(req.areaCode())
+                .expiresAt(expiresAt)
+                .build();
+        try {
+            NotificationSubscription saved = repository.save(sub);
+            log.info("[SubscriptionService] 새 구독 등록 - areaCode={}, endpoint={}", req.areaCode(), req.endpoint());
+            return new SubscribeResult("SUBSCRIBED", saved.getExpiresAt());
+        } catch (DataIntegrityViolationException e) {
+            return repository.findByEndpointAndAreaCode(req.endpoint(), req.areaCode())
+                    .map(found -> {
+                        found.renewExpiresAt(expiresAt);
+                        repository.save(found);
+                        log.info("[SubscriptionService] 구독 충돌 후 갱신 - areaCode={}, endpoint={}", req.areaCode(), req.endpoint());
+                        return new SubscribeResult("RENEWED", found.getExpiresAt());
+                    })
+                    .orElseThrow(() -> e);
+        }
+    }
+
+    @Transactional
+    public void unsubscribe(String endpoint, String areaCode) {
+        repository.deleteByEndpointAndAreaCode(endpoint, areaCode);
+        log.info("[SubscriptionService] 구독 취소 - areaCode={}, endpoint={}", areaCode, endpoint);
+    }
+
+    @Async("notificationExecutor")
+    public void notifyAndCleanup(String areaCode, String areaName) {
+        firedMarkerRepository.markFired(areaCode);
+
+        List<NotificationSubscription> subscriptions =
+                repository.findByAreaCodeAndExpiresAtAfter(areaCode, Instant.now());
+
+        log.info("[SubscriptionService] 알림 전송 시작 - areaCode={}, 구독자 수={}", areaCode, subscriptions.size());
+
+        for (NotificationSubscription sub : subscriptions) {
+            try {
+                String payload = buildPayload(areaName, areaCode);
+                WebPushSender.SendResult result = webPushSender.send(sub, payload);
+
+                if (result == WebPushSender.SendResult.SUCCESS || result == WebPushSender.SendResult.DEAD) {
+                    repository.deleteByEndpointAndAreaCode(sub.getEndpoint(), sub.getAreaCode());
+                    log.info("[SubscriptionService] 알림 전송 후 구독 삭제 - result={}, endpoint={}", result, sub.getEndpoint());
+                } else {
+                    log.info("[SubscriptionService] 알림 재시도 예정 - endpoint={}", sub.getEndpoint());
+                }
+            } catch (Exception e) {
+                log.warn("[SubscriptionService] 알림 전송 실패 - endpoint={}, error={}", sub.getEndpoint(), e.getMessage());
+            }
+        }
+    }
+
+    private String buildPayload(String areaName, String areaCode) throws JsonProcessingException {
+        Map<String, String> payload = Map.of(
+                "title", areaName + "이(가) 한가해졌어요!",
+                "body", "지금 방문하기 좋은 시간이에요",
+                "url", "/places/" + areaCode
+        );
+        return objectMapper.writeValueAsString(payload);
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/notification/service/WebPushSender.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/notification/service/WebPushSender.java
@@ -1,0 +1,87 @@
+package com.danburn.congestion.notification.service;
+
+import com.danburn.congestion.notification.config.VapidProperties;
+import com.danburn.congestion.notification.domain.NotificationSubscription;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import nl.martijndwars.webpush.Subscription;
+import org.apache.http.HttpResponse;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.stereotype.Component;
+
+import java.security.Security;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebPushSender {
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public enum SendResult {
+        SUCCESS, DEAD, RETRY
+    }
+
+    private final VapidProperties vapidProperties;
+    private PushService pushService;
+    private boolean configured = false;
+
+    public boolean isConfigured() {
+        return configured;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (vapidProperties.publicKey() == null || vapidProperties.publicKey().isBlank()
+                || vapidProperties.privateKey() == null || vapidProperties.privateKey().isBlank()) {
+            log.error("[WebPushSender] VAPID 키 미설정 - 알림 전송 불가. publicKey={}, privateKey={}",
+                    vapidProperties.publicKey() == null ? "null" : "(blank)",
+                    vapidProperties.privateKey() == null ? "null" : "(blank)");
+            return;
+        }
+        try {
+            pushService = new PushService(
+                    vapidProperties.publicKey(),
+                    vapidProperties.privateKey(),
+                    vapidProperties.subject()
+            );
+            configured = true;
+        } catch (Exception e) {
+            log.error("[WebPushSender] PushService 초기화 실패 - VAPID 키 미설정 상태일 수 있음: {}", e.getMessage());
+        }
+    }
+
+    public SendResult send(NotificationSubscription sub, String payload) {
+        if (pushService == null) {
+            log.warn("[WebPushSender] PushService 미초기화 - 알림 전송 건너뜀: endpoint={}", sub.getEndpoint());
+            return SendResult.RETRY;
+        }
+        try {
+            Subscription subscription = new Subscription(
+                    sub.getEndpoint(),
+                    new Subscription.Keys(sub.getP256dhKey(), sub.getAuthKey())
+            );
+            Notification notification = new Notification(subscription, payload);
+            HttpResponse response = pushService.send(notification);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode == 201) {
+                return SendResult.SUCCESS;
+            } else if (statusCode == 404 || statusCode == 410) {
+                log.info("[WebPushSender] 만료된 구독 감지 - status={}, endpoint={}", statusCode, sub.getEndpoint());
+                return SendResult.DEAD;
+            } else {
+                log.warn("[WebPushSender] 알림 전송 실패 - status={}, endpoint={}", statusCode, sub.getEndpoint());
+                return SendResult.RETRY;
+            }
+        } catch (Exception e) {
+            log.warn("[WebPushSender] 알림 전송 중 예외 발생 - endpoint={}, error={}", sub.getEndpoint(), e.getMessage());
+            return SendResult.RETRY;
+        }
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/scheduler/CongestionScheduler.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/scheduler/CongestionScheduler.java
@@ -7,6 +7,7 @@ import com.danburn.congestion.event.CongestionAnomalyEvent;
 import com.danburn.congestion.event.CongestionBusyEvent;
 import com.danburn.congestion.event.CongestionEventPublisher;
 import com.danburn.congestion.infra.SeoulApiClient;
+import com.danburn.congestion.notification.service.SubscriptionService;
 import com.danburn.congestion.service.AnomalyDetector;
 import com.danburn.congestion.service.CongestionService;
 import com.danburn.congestion.service.CongestionStateTracker;
@@ -31,6 +32,7 @@ public class CongestionScheduler {
     private final CongestionStateTracker stateTracker;
     private final AnomalyDetector anomalyDetector;
     private final CongestionEventPublisher eventPublisher;
+    private final SubscriptionService subscriptionService;
 
     @Scheduled(
             fixedRateString = "${congestion.scheduler.interval}",
@@ -99,6 +101,17 @@ public class CongestionScheduler {
                 ));
             } catch (Exception e) {
                 log.warn("[CongestionScheduler] 이벤트 발행 실패 - areaCode={}, reason={}",
+                        areaCode, e.getMessage());
+            }
+        }
+
+        List<String> relaxedAreaCodes = stateTracker.filterAreaCodesForRelaxedNotification(dtos);
+        for (String areaCode : relaxedAreaCodes) {
+            try {
+                CongestionRedisDto dto = dtoMap.get(areaCode);
+                subscriptionService.notifyAndCleanup(areaCode, dto.areaName());
+            } catch (Exception e) {
+                log.warn("[CongestionScheduler] 하강 알림 디스패치 실패 - areaCode={}, reason={}",
                         areaCode, e.getMessage());
             }
         }

--- a/service-congestion/src/main/java/com/danburn/congestion/service/CongestionStateTracker.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/CongestionStateTracker.java
@@ -51,6 +51,40 @@ public class CongestionStateTracker {
         return result;
     }
 
+    /**
+     * BUSY → non-BUSY 하강 엣지가 발생한 areaCode 목록을 반환한다.
+     * 알림 발송 대상 식별 용도.
+     */
+    public List<String> filterAreaCodesForRelaxedNotification(List<CongestionRedisDto> dtos) {
+        List<String> nonBusyAreaCodes = dtos.stream()
+                .filter(dto -> {
+                    if (dto.congestionLevel() == null) return false;
+                    try {
+                        return CongestionLevel.fromDescription(dto.congestionLevel()) != CongestionLevel.BUSY;
+                    } catch (IllegalArgumentException e) {
+                        return false;
+                    }
+                })
+                .map(CongestionRedisDto::areaCode)
+                .toList();
+
+        if (nonBusyAreaCodes.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, CongestionLevel> previousLevels = getPreviousLevels(nonBusyAreaCodes);
+
+        List<String> result = new ArrayList<>();
+        for (String areaCode : nonBusyAreaCodes) {
+            CongestionLevel previous = previousLevels.get(areaCode);
+            if (previous == CongestionLevel.BUSY) {
+                log.info("[StateTracker] 하강 엣지 감지 - areaCode={}, BUSY → non-BUSY", areaCode);
+                result.add(areaCode);
+            }
+        }
+        return result;
+    }
+
     private Map<String, CongestionLevel> getPreviousLevels(List<String> areaCodes) {
         Map<String, CongestionLevel> result = new HashMap<>();
         List<String> missingCodes = new ArrayList<>();

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -11,6 +11,10 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
   flyway:
     enabled: true
     baseline-on-migrate: true
@@ -68,6 +72,11 @@ logging:
 seoul:
   api:
     key: ${SEOUL_API_KEY:}
+
+vapid:
+  public-key: ${VAPID_PUBLIC_KEY:}
+  private-key: ${VAPID_PRIVATE_KEY:}
+  subject: ${VAPID_SUBJECT:mailto:ce19f003@gmail.com}
 
 congestion:
   scheduler:

--- a/service-congestion/src/main/resources/db/migration/V2__add_notification_subscription.sql
+++ b/service-congestion/src/main/resources/db/migration/V2__add_notification_subscription.sql
@@ -1,0 +1,12 @@
+CREATE TABLE notification_subscription (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    endpoint VARCHAR(700) NOT NULL,
+    p256dh_key VARCHAR(200) NOT NULL,
+    auth_key VARCHAR(100) NOT NULL,
+    area_code VARCHAR(20) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_subscription_endpoint_area (endpoint, area_code),
+    KEY idx_subscription_area_expires (area_code, expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;

--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -20,6 +20,18 @@ spring:
           uri: ${CONGESTION_SERVICE_URL:http://localhost:8082}
           predicates:
             - Path=/api/congestion/**
+        # 알림 서비스
+        - id: notification-route
+          uri: ${CONGESTION_SERVICE_URL:http://localhost:8082}
+          predicates:
+            - Path=/api/v1/notifications/**
+          filters:
+            - name: RequestRateLimiter
+              args:
+                redis-rate-limiter.replenishRate: 2
+                redis-rate-limiter.burstCapacity: 5
+                redis-rate-limiter.requestedTokens: 1
+                key-resolver: "#{@ipKeyResolver}"
         # 지도 & 대체지 추천 서비스
         - id: map-route
           uri: ${MAP_SERVICE_URL:http://localhost:8083}


### PR DESCRIPTION
## Summary
dev → main promotion. 본 PR로 포함되는 변경은 1건.

- **feat(congestion): 혼잡도 하강 알림(Web Push) 구현 (#298)** — #307 머지본
  - BUSY → BUSY 아닌 상태 하강 엣지 시 익명 Web Push 1회 발송
  - `(endpoint, area_code)` 12시간 one-shot 구독, Flyway V2
  - VAPID 헬스체크, Gateway rate limit, race window 마커, ApiResponse 통일, Instant

## 배포 전 사전 작업
- [ ] Infisical **prod** 환경에 VAPID 키 3종 등록 (`VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`)
  - 미등록 시 부팅은 되지만 `/actuator/health`에 webPush DOWN으로 노출되고 발송 불가

## Test plan
- [x] 로컬 도커 (MySQL/Redis/RabbitMQ) + bootRun 통합 검증 완료 (#307 본문 참고)
- [ ] 배포 후 `/actuator/health` webPush UP 확인
- [ ] 배포 후 `/api/v1/notifications/vapid-public-key` 200 응답 확인
- [ ] 프론트 Service Worker 연동 E2E (별도)