### PR TITLE
fix(congestion): docker-compose 에 VAPID 환경변수 매핑 추가 (#298)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,9 @@ services:
       - SPRING_RABBITMQ_PORT=5672
       - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USER:-guest}
       - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASS:-guest}
+      - VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY:-}
+      - VAPID_PRIVATE_KEY=${VAPID_PRIVATE_KEY:-}
+      - VAPID_SUBJECT=${VAPID_SUBJECT:-}
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## 문제
prod 배포 후 service-congestion 컨테이너 부팅 시:
```
[WebPushSender] VAPID 키 미설정 - 알림 전송 불가. publicKey=(blank), privateKey=(blank)
```

## 원인
docker compose는 host env 를 컨테이너로 자동 전달하지 않음. \`environment:\` 블록에 명시적으로 매핑돼야 함.
Infisical 로 host 에는 VAPID 3종 secret 이 정상 주입되지만 (\`infisical run -- printenv\` 로 확인됨), \`docker-compose.yml\`의 service-congestion 블록에 VAPID 매핑이 누락되어 컨테이너에는 빈 값 전달.

## 수정
\`docker-compose.yml\`의 service-congestion \`environment:\` 블록에 3줄 추가:
\`\`\`yaml
- VAPID_PUBLIC_KEY=\${VAPID_PUBLIC_KEY:-}
- VAPID_PRIVATE_KEY=\${VAPID_PRIVATE_KEY:-}
- VAPID_SUBJECT=\${VAPID_SUBJECT:-}
\`\`\`

## 검증
- [x] 다른 서비스 환경변수 매핑 패턴(\`SPRING_DATA_REDIS_PASSWORD\`, \`SEOUL_API_KEY\` 등)과 동일
- [ ] dev → main 머지 → CD 자동 배포 → \`/actuator/health\` webPush UP 확인
- [ ] \`docker exec backend-service-congestion-1 env | grep VAPID\` 결과 3종 모두 보이는지 확인

## 부수 액션 (사용자)
Infisical prod 환경에서 \`VAPID_SUBJECT\` 값을 \`kim138762@dankook.ac.kr\` → \`mailto:kim138762@dankook.ac.kr\` 로 수정 (RFC 8292 VAPID JWT \`sub\` claim 형식 요구사항).