### PR TITLE
chore: promote dev → main (VAPID compose env 매핑 핫픽스 #298)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,9 @@ services:
       - SPRING_RABBITMQ_PORT=5672
       - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USER:-guest}
       - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASS:-guest}
+      - VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY:-}
+      - VAPID_PRIVATE_KEY=${VAPID_PRIVATE_KEY:-}
+      - VAPID_SUBJECT=${VAPID_SUBJECT:-}
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary
dev → main promotion (#298 운영 안정화 핫픽스).

- **fix(congestion): docker-compose 에 VAPID 환경변수 매핑 추가 (#298)** — #309 머지본
  - prod 컨테이너에 VAPID 키가 \`(blank)\`으로 전달되어 WebPushSender 초기화 실패하던 문제 해결
  - \`docker-compose.yml\`의 service-congestion \`environment:\` 블록에 VAPID 3종 명시적 매핑 추가

## 배포 후 검증
- [ ] CD 자동 배포 완료
- [ ] \`docker exec backend-service-congestion-1 env | grep VAPID\` → 3종 값 존재
- [ ] \`/actuator/health\` → webPush UP
- [ ] \`/api/v1/notifications/vapid-public-key\` → 200 + base64url 87자

## 사용자 액션 (이미 안내됨)
- Infisical prod 환경 \`VAPID_SUBJECT\` 값 → \`mailto:kim138762@dankook.ac.kr\` (mailto: prefix 추가)