### PR TITLE
fix(ai): 빈 LLM 응답 가드 + 파싱 실패 시 content preview 로깅

### DIFF
--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -286,13 +286,23 @@ class OpenAIAnalyzer(AIAnalyzer):
         tool_results: list[dict[str, Any]] | None = None,
     ) -> list[AnalysisResult]:
         """LLM 최종 응답 → AnalysisResult 리스트 + 구조화 로그."""
+        if not content.strip():
+            logger.warning(
+                "[OpenAI] 빈 LLM 응답 - 분석 결과 0건으로 처리 (events=%d, tool_called=%s)",
+                len(events), tool_called,
+            )
+            return []
+
         match = re.search(r'```(?:json)?\s*(.*?)```', content, re.DOTALL)
         if match:
             content = match.group(1)
         try:
             parsed = json.loads(content.strip())
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error("[OpenAI] 응답 파싱 실패 - %s", e)
+            logger.error(
+                "[OpenAI] 응답 파싱 실패 - %s | content_len=%d, preview=%r",
+                e, len(content), content[:200],
+            )
             raise
 
         if isinstance(parsed, list):


### PR DESCRIPTION
## 문제
prod 로그에 반복적으로 발생:
\`\`\`
[OpenAI] 응답 파싱 실패 - Expecting value: line 1 column 1 (char 0)
\`\`\`

## 원인
\`_parse_results()\`에서 LLM 이 빈 content 를 반환하면 \`json.loads("")\` 가 \`JSONDecodeError\` 폭주. 원본 content 를 로깅하지 않아 재발 시 원인 추적 불가.

가능한 빈 응답 시나리오:
- \`finish_reason=content_filter | length\` 로 잘림
- tool_calls 만 반환 후 hop 2에서 최종 텍스트 비음
- 배치 윈도우에 분석 대상 없을 때 모델이 빈 출력

## 수정
\`service-ai/app/ai/openai/client.py\` \`_parse_results()\`:

1. **빈 content 가드**: 예외 던지지 않고 빈 결과 반환
   \`\`\`python
   if not content.strip():
       logger.warning("[OpenAI] 빈 LLM 응답 - 분석 결과 0건으로 처리 ...")
       return []
   \`\`\`

2. **파싱 실패 시 진단 정보 추가** (재발 시 원인 식별 가능)
   \`\`\`python
   logger.error("[OpenAI] 응답 파싱 실패 - %s | content_len=%d, preview=%r", e, len(content), content[:200])
   \`\`\`

## Test plan
- [x] Python syntax check 통과 (\`python3 -m py_compile\`)
- [ ] 배포 후 \`[OpenAI] 응답 파싱 실패\` 로그 빈도 감소 또는 \`preview=...\` 패턴으로 원인 식별 가능

## Scope
- service-ai 영역 단독, 다른 서비스 무관
- \`_parse_results\`의 다른 분기는 그대로