### PR TITLE
chore: promote dev → main (AI 빈 응답 파싱 가드 #311)

### DIFF
--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -286,13 +286,23 @@ class OpenAIAnalyzer(AIAnalyzer):
         tool_results: list[dict[str, Any]] | None = None,
     ) -> list[AnalysisResult]:
         """LLM 최종 응답 → AnalysisResult 리스트 + 구조화 로그."""
+        if not content.strip():
+            logger.warning(
+                "[OpenAI] 빈 LLM 응답 - 분석 결과 0건으로 처리 (events=%d, tool_called=%s)",
+                len(events), tool_called,
+            )
+            return []
+
         match = re.search(r'```(?:json)?\s*(.*?)```', content, re.DOTALL)
         if match:
             content = match.group(1)
         try:
             parsed = json.loads(content.strip())
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error("[OpenAI] 응답 파싱 실패 - %s", e)
+            logger.error(
+                "[OpenAI] 응답 파싱 실패 - %s | content_len=%d, preview=%r",
+                e, len(content), content[:200],
+            )
             raise
 
         if isinstance(parsed, list):


### PR DESCRIPTION
## Summary
dev → main promotion (service-ai 안정화 fix).

- **fix(ai): 빈 LLM 응답 가드 + 파싱 실패 시 content preview 로깅** — #311 머지본
  - 빈 content 시 \`json.loads("")\` 폭주 방지 (warn + 분석 결과 0건 처리)
  - 진짜 파싱 실패는 \`content_len + preview\` 로깅 추가

## Test plan
- [x] Python syntax check 통과
- [ ] 배포 후 \`[OpenAI] 응답 파싱 실패 - Expecting value: line 1 column 1 (char 0)\` 로그 사라짐
- [ ] 빈 응답 발생 시 \`[OpenAI] 빈 LLM 응답 - 분석 결과 0건\` WARN 로그로 정상 처리됨

## Scope
- service-ai 단독