### PR TITLE
fix(congestion): AI 리포트 경로 /api/congestion/{areaCode}/ai-report 로 정렬 (#321)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/controller/AireportController.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/controller/AireportController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "AI 리포트", description = "AI 리포트 조회 API")
 @RestController
-@RequestMapping("/api/aireport")
+@RequestMapping("/api/congestion")
 @RequiredArgsConstructor
 public class AireportController {
 
@@ -26,7 +26,7 @@ public class AireportController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 장소의 AI 리포트 데이터 없음")
     })
-    @GetMapping("/{areaCode}")
+    @GetMapping("/{areaCode}/ai-report")
     public ApiResponse<AireportApiResponse> getLatestAiReport(
             @Parameter(description = "장소 코드 (예: POI001)", example = "POI001")
             @PathVariable String areaCode) {

--- a/service-congestion/src/test/java/com/danburn/congestion/controller/AireportControllerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/controller/AireportControllerTest.java
@@ -31,14 +31,14 @@ class AireportControllerTest {
     private AiService aiService;
 
     @Test
-    @DisplayName("GET /api/aireport/{areaCode} → 조회 성공")
+    @DisplayName("GET /api/congestion/{areaCode}/ai-report → 조회 성공")
     void getLatestAiReport_success() throws Exception {
         AireportApiResponse response = new AireportApiResponse(
                 "POI001", "광화문·덕수궁", "주말 나들이 인파로 인한 혼잡", "2026-04-01 14:00"
         );
         given(aiService.getLatestAiReport("POI001")).willReturn(response);
 
-        mockMvc.perform(get("/api/aireport/POI001"))
+        mockMvc.perform(get("/api/congestion/POI001/ai-report"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.areaCode").value("POI001"))
@@ -48,12 +48,12 @@ class AireportControllerTest {
     }
 
     @Test
-    @DisplayName("GET /api/aireport/{areaCode} → 404 에러 응답")
+    @DisplayName("GET /api/congestion/{areaCode}/ai-report → 404 에러 응답")
     void getLatestAiReport_notFound() throws Exception {
         given(aiService.getLatestAiReport("POI999"))
                 .willThrow(new GlobalException(404, "AI 리포트 데이터가 없습니다. areaCode: POI999"));
 
-        mockMvc.perform(get("/api/aireport/POI999"))
+        mockMvc.perform(get("/api/congestion/POI999/ai-report"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("AI 리포트 데이터가 없습니다. areaCode: POI999"));


### PR DESCRIPTION
## Summary
- 프론트가 AI 분석 결과를 못 받던 문제 수정 (#321)
- 컨트롤러 경로 `/api/aireport/{areaCode}` → `/api/congestion/{areaCode}/ai-report` 로 이동
- 게이트웨이 라우팅(`/api/congestion/**`) 및 `service-ai/CLAUDE.md` 설계 문서와 일치
- 게이트웨이 yaml 수정 불필요 (기존 prefix 가 커버)

## Test plan
- [x] `./gradlew :service-congestion:test --tests AireportControllerTest` → BUILD SUCCESSFUL
- [ ] 게이트웨이 경유 통합 호출 확인 (`GET /api/congestion/POI001/ai-report`)
- [ ] 프론트엔드 호출 경로 동기화 안내

Closes #321