### PR TITLE
fix(ai): search_web 날짜 토큰 정규식 보강 — ISO/슬래시/점 포맷 (#330)

### DIFF
--- a/service-ai/app/ai/mcp/server.py
+++ b/service-ai/app/ai/mcp/server.py
@@ -26,7 +26,10 @@ SEARCH_MAX_ATTEMPTS = 2
 SEARCH_RETRY_BACKOFF_SECONDS = 0.5
 
 # DDG News 결과를 0건으로 만드는 날짜 토큰 패턴
-_DATE_TOKEN_RE = re.compile(r"\d{4}|\d+\s*월|\d+\s*일")
+# ISO/슬래시/점 구분자 전체 우선 매칭 → 짧은 형태 → 한국식 단위 순서로 처리
+_DATE_TOKEN_RE = re.compile(
+    r"\d{4}[-./]\d{1,2}[-./]\d{1,2}|\d{1,2}[-./]\d{1,2}|\d{4}\s*년?|\d+\s*월|\d+\s*일"
+)
 
 
 def _sanitize_query(query: str) -> str:

--- a/service-ai/tests/test_mcp_server_sanitize.py
+++ b/service-ai/tests/test_mcp_server_sanitize.py
@@ -1,0 +1,41 @@
+"""search_web query sanitize 회귀 방지 테스트.
+
+- ISO/슬래시/점/한국식 날짜 토큰 제거
+- 토큰 없는 쿼리는 변형 없음
+- sanitize 결과가 빈 문자열이면 원본 반환
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.mcp.server import _sanitize_query
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # ISO 전체 포맷
+        ("홍대 2026-05-26 콘서트", "홍대 콘서트"),
+        ("강남 2026.05.26 시위", "강남 시위"),
+        ("잠실 2026/05/26 행사", "잠실 행사"),
+        # 짧은 형태 (월/일만)
+        ("잠실 05/26 행사", "잠실 행사"),
+        ("성수 05-26 팝업", "성수 팝업"),
+        ("여의도 05.26 축제", "여의도 축제"),
+        # 한국식 단위
+        ("홍대 5월 26일 콘서트", "홍대 콘서트"),
+        ("강남 2026년 행사", "강남 행사"),
+        # 토큰 없음 — 변형 없음
+        ("홍대 콘서트", "홍대 콘서트"),
+        ("잠실 야구 경기", "잠실 야구 경기"),
+    ],
+)
+def test_sanitize_strips_date_tokens(raw: str, expected: str) -> None:
+    assert _sanitize_query(raw) == expected
+
+
+def test_sanitize_empty_after_strip_falls_back_to_original() -> None:
+    """결과가 빈 문자열이 되면 원본 query 그대로 사용."""
+    raw = "2026-05-26"
+    assert _sanitize_query(raw) == raw


### PR DESCRIPTION
Closes #330

## Summary
- \`_DATE_TOKEN_RE\` 를 보강해 ISO/슬래시/점 구분자 날짜를 완전히 제거
- 회귀 방지 테스트 \`tests/test_mcp_server_sanitize.py\` 신규

## 배경
#327 에서 도입한 \`\d{4}|\d+\s*월|\d+\s*일\` 가 ISO/슬래시/점 포맷을 부분/미매칭으로 처리:
| 입력 | 이전 | 이후 |
|---|---|---|
| \`"홍대 2026-05-26 콘서트"\` | \`"홍대 -05-26 콘서트"\` | \`"홍대 콘서트"\` |
| \`"잠실 05/26 행사"\` | \`"잠실 05/26 행사"\` (그대로) | \`"잠실 행사"\` |
| \`"강남 2026.05.26 시위"\` | \`"강남 .05.26 시위"\` | \`"강남 시위"\` |

## Test plan
- [x] sanitize 단위 테스트 11 passed (ISO/짧은 포맷/한국식/토큰 없음/빈 결과 fallback)
- [x] 전체 service-ai 단위 테스트 72 passed