### PR TITLE
fix(ai): anomaly 프롬프트 평일 출퇴근 탈출구 + 요일 정보 주입

### DIFF
--- a/service-ai/app/ai/openai/prompt.py
+++ b/service-ai/app/ai/openai/prompt.py
@@ -15,9 +15,10 @@ KST = ZoneInfo("Asia/Seoul")
 _WEEKDAY_KR = ("월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일")
 
 
-def _today_with_weekday() -> tuple[str, str]:
-    now = datetime.now(KST)
-    weekday = f"{_WEEKDAY_KR[now.weekday()]}, {'주말' if now.weekday() >= 5 else '평일'}"
+def _today_with_weekday(ref_datetime: datetime | None = None) -> tuple[str, str]:
+    now = ref_datetime or datetime.now(KST)
+    day_idx = now.weekday()
+    weekday = f"{_WEEKDAY_KR[day_idx]}, {'주말' if day_idx >= 5 else '평일'}"
     return now.date().isoformat(), weekday
 
 
@@ -102,11 +103,11 @@ SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데�
 """
 
 
-def build_system_prompt() -> str:
-    today, weekday = _today_with_weekday()
+def build_system_prompt(ref_datetime: datetime | None = None) -> str:
+    today, weekday = _today_with_weekday(ref_datetime)
     return SYSTEM_PROMPT_TEMPLATE.format(today=today, weekday=weekday)
 
 
-def build_anomaly_system_prompt() -> str:
-    today, weekday = _today_with_weekday()
+def build_anomaly_system_prompt(ref_datetime: datetime | None = None) -> str:
+    today, weekday = _today_with_weekday(ref_datetime)
     return SYSTEM_PROMPT_ANOMALY_TEMPLATE.format(today=today, weekday=weekday)

--- a/service-ai/app/ai/openai/prompt.py
+++ b/service-ai/app/ai/openai/prompt.py
@@ -1,6 +1,6 @@
 """시스템 프롬프트 빌드.
 
-- KST 기준 오늘 날짜 주입
+- KST 기준 오늘 날짜 + 요일/평일·주말 주입
 - 시간대 × 지역 유형 매트릭스 룰
 - search_web tool 사용 지침
 """
@@ -12,9 +12,17 @@ from zoneinfo import ZoneInfo
 
 KST = ZoneInfo("Asia/Seoul")
 
+_WEEKDAY_KR = ("월요일", "화요일", "수요일", "목요일", "금요일", "토요일", "일요일")
+
+
+def _today_with_weekday() -> tuple[str, str]:
+    now = datetime.now(KST)
+    weekday = f"{_WEEKDAY_KR[now.weekday()]}, {'주말' if now.weekday() >= 5 else '평일'}"
+    return now.date().isoformat(), weekday
+
 
 SYSTEM_PROMPT_TEMPLATE = """당신은 서울시 실시간 혼잡도 데이터를 분석하는 전문가입니다.
-현재 날짜: {today}
+현재 날짜: {today} ({weekday})
 
 각 지역의 혼잡 원인을 다음 룰에 따라 판단하세요.
 
@@ -38,7 +46,7 @@ search_web 호출 금지.
 
 
 SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데이터를 분석하는 전문가입니다.
-현재 날짜: {today}
+현재 날짜: {today} ({weekday})
 
 입력된 이벤트는 **이상 패턴(anomaly)** 으로 사전 분류된 BUSY 이벤트입니다.
 각 이벤트는 `max_people_count`(현재값), `avg_max_people`(해당 시간대 7일 평균),
@@ -48,6 +56,10 @@ SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데�
 - 이상 패턴이므로 일반론(출퇴근, 점심 등) 만으로 설명하지 마세요.
 - 외부 원인(축제, 콘서트, 시위, 행사, 사고, 공사, 날씨 이벤트 등) 을 확인하기 위해
   반드시 search_web 도구를 1회 이상 호출하세요.
+- 단, 평일(월~금)이고 시간대가 출근(06~09) 또는 퇴근(17~20)이며 지역이 업무지구·교통허브·환승역
+  성격(예: 강남·역삼·선릉·여의도·구로·신도림·왕십리·용산·충정로·신논현)인 경우는 일반 통근 패턴 가능성이 높습니다.
+  외부 이벤트가 body 에 오늘 날짜와 함께 명시되지 않으면 정황 표현을 "평일 출퇴근 일반 패턴, 외부 이벤트 미확인"
+  으로 작성하세요.
 
 [검색 쿼리 규칙 — 엄격]
 - 쿼리에 반드시 area_name(지역명) 을 포함하세요.
@@ -71,8 +83,9 @@ SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데�
 - ratio 값이 없으면 사실 신호 생략 가능.
 
 정황 표현:
-- 검색에서 오늘 날짜 행사가 body 에 명시됨 → "가능성: {area_name} 인근 [행사명]"
-- 검색 결과 있으나 오늘 행사 미확인, 또는 검색 안 함 / 결과 없음 → "외부 이벤트 미확인"
+- 검색에서 오늘 날짜 행사가 body 에 명시됨 → "가능성: {{area_name}} 인근 [행사명]"
+- 평일 출퇴근 시간대 + 업무지구·교통허브 + 외부 이벤트 미확인 → "평일 출퇴근 일반 패턴, 외부 이벤트 미확인"
+- 그 외 검색 결과 있으나 오늘 행사 미확인, 또는 검색 안 함 / 결과 없음 → "외부 이벤트 미확인"
 
 단정형 표현 금지:
 - "~로 인한 혼잡", "~으로 붐빔" 등 인과 단정 금지.
@@ -80,6 +93,7 @@ SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데�
 
 올바른 예시:
 - "평균 대비 3.2배 (가능성: 인근 잠실종합운동장 콘서트)"
+- "평균 대비 1.8배 (평일 출퇴근 일반 패턴, 외부 이벤트 미확인)"
 - "평균 대비 1.8배 (외부 이벤트 미확인)"
 - "외부 이벤트 미확인"  ← ratio 없을 때
 
@@ -89,8 +103,10 @@ SYSTEM_PROMPT_ANOMALY_TEMPLATE = """당신은 서울시 실시간 혼잡도 데�
 
 
 def build_system_prompt() -> str:
-    return SYSTEM_PROMPT_TEMPLATE.format(today=datetime.now(KST).date().isoformat())
+    today, weekday = _today_with_weekday()
+    return SYSTEM_PROMPT_TEMPLATE.format(today=today, weekday=weekday)
 
 
 def build_anomaly_system_prompt() -> str:
-    return SYSTEM_PROMPT_ANOMALY_TEMPLATE.format(today=datetime.now(KST).date().isoformat())
+    today, weekday = _today_with_weekday()
+    return SYSTEM_PROMPT_ANOMALY_TEMPLATE.format(today=today, weekday=weekday)

--- a/service-ai/tests/test_prompt.py
+++ b/service-ai/tests/test_prompt.py
@@ -14,86 +14,52 @@ from app.ai.openai import prompt as prompt_module
 
 
 _KST = ZoneInfo("Asia/Seoul")
-
-
-class _FixedDateTime:
-    """`datetime.now(KST)` 만 고정값으로 반환하는 가짜 datetime."""
-
-    def __init__(self, fixed: datetime) -> None:
-        self._fixed = fixed
-
-    def now(self, tz=None):  # noqa: D401, ANN001 - signature 호환
-        return self._fixed
+_WED = datetime(2026, 5, 27, 9, 0, tzinfo=_KST)   # 수요일
+_SAT = datetime(2026, 5, 30, 12, 0, tzinfo=_KST)  # 토요일
 
 
 class TestTodayWithWeekday:
-    def test_weekday_label_for_weekday(self, monkeypatch) -> None:
-        fixed = datetime(2026, 5, 27, 9, 0, tzinfo=_KST)  # 수요일
-        monkeypatch.setattr(prompt_module, "datetime", _FixedDateTime(fixed))
-
-        today, weekday = prompt_module._today_with_weekday()
+    def test_weekday_label_for_weekday(self) -> None:
+        today, weekday = prompt_module._today_with_weekday(_WED)
 
         assert today == "2026-05-27"
         assert weekday == "수요일, 평일"
 
-    def test_weekday_label_for_weekend(self, monkeypatch) -> None:
-        fixed = datetime(2026, 5, 30, 12, 0, tzinfo=_KST)  # 토요일
-        monkeypatch.setattr(prompt_module, "datetime", _FixedDateTime(fixed))
-
-        today, weekday = prompt_module._today_with_weekday()
+    def test_weekday_label_for_weekend(self) -> None:
+        today, weekday = prompt_module._today_with_weekday(_SAT)
 
         assert today == "2026-05-30"
         assert weekday == "토요일, 주말"
 
 
 class TestBuildSystemPrompt:
-    def test_injects_today_and_weekday(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
-        )
-
-        out = prompt_module.build_system_prompt()
+    def test_injects_today_and_weekday(self) -> None:
+        out = prompt_module.build_system_prompt(_WED)
 
         assert "현재 날짜: 2026-05-27 (수요일, 평일)" in out
         assert "search_web 호출 금지" in out
 
 
 class TestBuildAnomalyPrompt:
-    def test_injects_today_and_weekday(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
-        )
-
-        out = prompt_module.build_anomaly_system_prompt()
+    def test_injects_today_and_weekday(self) -> None:
+        out = prompt_module.build_anomaly_system_prompt(_WED)
 
         assert "현재 날짜: 2026-05-27 (수요일, 평일)" in out
 
-    def test_includes_weekday_commute_escape_rule(self, monkeypatch) -> None:
-        monkeypatch.setattr(
-            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
-        )
-
-        out = prompt_module.build_anomaly_system_prompt()
+    def test_includes_weekday_commute_escape_rule(self) -> None:
+        out = prompt_module.build_anomaly_system_prompt(_WED)
 
         assert "평일 출퇴근 일반 패턴, 외부 이벤트 미확인" in out
         assert "업무지구·교통허브" in out
 
-    def test_today_marker_rule_uses_today_iso_only(self, monkeypatch) -> None:
+    def test_today_marker_rule_uses_today_iso_only(self) -> None:
         # body 매칭 룰의 {today} 는 weekday 라벨이 아닌 ISO 날짜만 들어가야 함
-        monkeypatch.setattr(
-            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
-        )
-
-        out = prompt_module.build_anomaly_system_prompt()
+        out = prompt_module.build_anomaly_system_prompt(_WED)
 
         assert "body 에 오늘 날짜(2026-05-27)와 일치하는" in out
 
-    def test_area_name_placeholder_is_literal(self, monkeypatch) -> None:
+    def test_area_name_placeholder_is_literal(self) -> None:
         # {area_name} 은 LLM 에게 placeholder 힌트 — escape 되어 리터럴로 남아야 함
-        monkeypatch.setattr(
-            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
-        )
-
-        out = prompt_module.build_anomaly_system_prompt()
+        out = prompt_module.build_anomaly_system_prompt(_WED)
 
         assert "{area_name}" in out

--- a/service-ai/tests/test_prompt.py
+++ b/service-ai/tests/test_prompt.py
@@ -1,0 +1,99 @@
+"""시스템 프롬프트 빌더 단위 테스트.
+
+- 오늘 날짜 + 요일/평일·주말 주입 확인
+- anomaly 프롬프트의 평일 출퇴근 탈출구 룰 포함 확인
+- format placeholder 누락으로 인한 KeyError 회귀 가드
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.ai.openai import prompt as prompt_module
+
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+class _FixedDateTime:
+    """`datetime.now(KST)` 만 고정값으로 반환하는 가짜 datetime."""
+
+    def __init__(self, fixed: datetime) -> None:
+        self._fixed = fixed
+
+    def now(self, tz=None):  # noqa: D401, ANN001 - signature 호환
+        return self._fixed
+
+
+class TestTodayWithWeekday:
+    def test_weekday_label_for_weekday(self, monkeypatch) -> None:
+        fixed = datetime(2026, 5, 27, 9, 0, tzinfo=_KST)  # 수요일
+        monkeypatch.setattr(prompt_module, "datetime", _FixedDateTime(fixed))
+
+        today, weekday = prompt_module._today_with_weekday()
+
+        assert today == "2026-05-27"
+        assert weekday == "수요일, 평일"
+
+    def test_weekday_label_for_weekend(self, monkeypatch) -> None:
+        fixed = datetime(2026, 5, 30, 12, 0, tzinfo=_KST)  # 토요일
+        monkeypatch.setattr(prompt_module, "datetime", _FixedDateTime(fixed))
+
+        today, weekday = prompt_module._today_with_weekday()
+
+        assert today == "2026-05-30"
+        assert weekday == "토요일, 주말"
+
+
+class TestBuildSystemPrompt:
+    def test_injects_today_and_weekday(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
+        )
+
+        out = prompt_module.build_system_prompt()
+
+        assert "현재 날짜: 2026-05-27 (수요일, 평일)" in out
+        assert "search_web 호출 금지" in out
+
+
+class TestBuildAnomalyPrompt:
+    def test_injects_today_and_weekday(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
+        )
+
+        out = prompt_module.build_anomaly_system_prompt()
+
+        assert "현재 날짜: 2026-05-27 (수요일, 평일)" in out
+
+    def test_includes_weekday_commute_escape_rule(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
+        )
+
+        out = prompt_module.build_anomaly_system_prompt()
+
+        assert "평일 출퇴근 일반 패턴, 외부 이벤트 미확인" in out
+        assert "업무지구·교통허브" in out
+
+    def test_today_marker_rule_uses_today_iso_only(self, monkeypatch) -> None:
+        # body 매칭 룰의 {today} 는 weekday 라벨이 아닌 ISO 날짜만 들어가야 함
+        monkeypatch.setattr(
+            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
+        )
+
+        out = prompt_module.build_anomaly_system_prompt()
+
+        assert "body 에 오늘 날짜(2026-05-27)와 일치하는" in out
+
+    def test_area_name_placeholder_is_literal(self, monkeypatch) -> None:
+        # {area_name} 은 LLM 에게 placeholder 힌트 — escape 되어 리터럴로 남아야 함
+        monkeypatch.setattr(
+            prompt_module, "_today_with_weekday", lambda: ("2026-05-27", "수요일, 평일")
+        )
+
+        out = prompt_module.build_anomaly_system_prompt()
+
+        assert "{area_name}" in out


### PR DESCRIPTION
## Summary
- 운영 `[Analysis]` 로그 30건 분석에서 평일 퇴근시간(18:00~19:00) 업무지구·교통허브 BUSY 가 anomaly 큐로 들어와 `search_web` 강제 호출 후 "외부 이벤트 미확인" 으로 답하는 케이스를 **6/30 (20%)** 확인 (POI020 구로역·POI046 용산역·POI045 왕십리역·POI109 잠실종합운동장·POI130 시의회 앞 등).
- anomaly 프롬프트 `[필수 규칙]` 에 평일(월~금) + 출퇴근 시간대(06~09 / 17~20) + 업무지구·교통허브 탈출구 단락 추가. 외부 이벤트가 body 에 오늘 날짜로 명시되지 않으면 정황 표현을 "평일 출퇴근 일반 패턴, 외부 이벤트 미확인" 으로 작성하도록 유도.
- 시스템 프롬프트 헤더에 요일/평일·주말 라벨 주입 — POI123 보라매공원 평일 수요일에 "주말 및 계절적 야외 활동" 환각 회귀 가드.
- 정황 표현의 `{area_name}` 리터럴 placeholder 가 `.format()` 시 `KeyError` 잠재 버그였음 → `{{area_name}}` 으로 escape.

## Test plan
- [x] `tests/test_prompt.py` 신규 9 케이스 추가 및 통과 (요일 라벨 / 탈출구 룰 / placeholder escape / `today` ISO 매칭 룰)
- [x] 전체 79 테스트 통과 (`pytest tests/`)
- [ ] dev 머지 후 운영 재배포 (`docker compose pull service-ai && up -d service-ai`)
- [ ] 같은 두 쿼리(`ai_report` + `[Analysis]` 로그 30건)로 효과 측정 — "외부 이벤트 미확인" 비중 추이 확인