### PR TITLE
fix(ai): gpt-oss-120b 레이트리밋 정합 — RPM 버킷 + 429 지수 백오프

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,7 +197,7 @@ services:
       - AI_PROVIDER=${AI_PROVIDER:-openai}
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.cerebras.ai/v1}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_MODEL=${OPENAI_MODEL:-qwen-3-235b-a22b-instruct-2507}
+      - OPENAI_MODEL=${OPENAI_MODEL:-zai-glm-4.7}
       - OTLP_TRACES_URL=http://observability:4318/v1/traces
       - LOKI_URL=http://observability:3100/loki/api/v1/push
     depends_on:

--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -18,6 +18,7 @@ from zoneinfo import ZoneInfo
 
 import httpx
 
+from app.ai.errors import RetriableError
 from app.ai.interface import AIAnalyzer
 from app.ai.mcp.client import MCPClient
 from app.ai.openai.errors import _classify_429
@@ -122,6 +123,7 @@ class OpenAIAnalyzer(AIAnalyzer):
             timeout=httpx.Timeout(60.0, read=300.0),
         )
         self._rate_limiter = RateLimiter(
+            rpm_limit=settings.rpm_limit,
             tpm_limit=settings.tpm_limit,
             tpd_limit=settings.tpd_limit,
         )
@@ -215,6 +217,51 @@ class OpenAIAnalyzer(AIAnalyzer):
         )
 
     async def _call_llm(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        *,
+        tool_choice: str | None = None,
+    ) -> dict[str, Any]:
+        """429 지수 백오프 재시도 래퍼.
+
+        - RetriableError: 대기 후 재시도. 대기 = max(base*2**(n-1), retry_after), 상한 max_delay
+        - 재시도 한도 소진 시 RetriableError 전파 → 상위(batch)에서 DLQ
+        - NonRetriableError: 재시도 없이 즉시 전파 → DLQ
+        - 각 재시도는 acquire 를 다시 거치므로 RPM 버킷이 추가로 throttle
+        """
+        attempt = 1
+        while True:
+            try:
+                return await self._call_llm_once(
+                    messages, tools, tool_choice=tool_choice
+                )
+            except RetriableError as e:
+                if attempt >= settings.llm_retry_max_attempts:
+                    logger.error(
+                        "[OpenAI] 429 재시도 한도 소진 (%d/%d) → DLQ 전파 - %s",
+                        attempt,
+                        settings.llm_retry_max_attempts,
+                        e,
+                    )
+                    raise
+                delay = min(
+                    settings.llm_retry_base_delay * (2 ** (attempt - 1)),
+                    settings.llm_retry_max_delay,
+                )
+                delay = max(delay, e.retry_after)
+                logger.warning(
+                    "[OpenAI] 429 재시도 %d/%d - %.1f초 대기 (retry_after=%.1f, code=%s)",
+                    attempt,
+                    settings.llm_retry_max_attempts,
+                    delay,
+                    e.retry_after,
+                    e.error_code,
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
+
+    async def _call_llm_once(
         self,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None,

--- a/service-ai/app/ai/rate_limiter.py
+++ b/service-ai/app/ai/rate_limiter.py
@@ -1,14 +1,15 @@
-"""토큰 예산 기반 Rate Limiter.
+"""요청수 + 토큰 예산 기반 Rate Limiter.
 
-- Cerebras Free Tier (qwen-3-235b-a22b-instruct-2507, 2026-04 확인)
-  · TPM 60,000 / TPH 1,000,000 / TPD 1,000,000
-  · RPM 30 / RPH 900 / RPD 14,400
-- 기존 RPM 기반 구현 한계: 배치 크기 증가 시 TPM 쉽게 초과 (구조적 결함)
-- 개선: TPM + TPD 이중 leaky bucket 으로 토큰 단위 강제
+- gpt-oss-120b (Cerebras, 2026-05 확인)
+  · RPM 5 / TPM 30,000 / TPH 1,000,000 / TPD 1,000,000
+- RPM 5(=12초당 1회)가 바인딩 제약 → 토큰만으로는 요청수 초과를 못 막음
+- 설계: RPM + TPM + TPD 삼중 leaky bucket 으로 요청수·토큰 동시 강제
+  · TPH 는 총량(1M)이 TPD 와 같아 별도 버킷 불필요 (TPD 버킷이 커버)
 
 API
-- await limiter.acquire(estimated_tokens): 두 버킷 여유 확보까지 대기
-- limiter.record_actual(actual, estimated): 응답 수신 후 실제 사용량 보정
+- await limiter.acquire(estimated_tokens): 세 버킷 여유 확보까지 대기 (요청 1건 + 토큰)
+- limiter.record_actual(actual, estimated): 응답 수신 후 실제 토큰 사용량 보정
+  · RPM 은 환불하지 않음 — 실패(429) 요청도 서버 RPM 카운터에 잡히므로
 """
 
 from __future__ import annotations
@@ -80,30 +81,33 @@ class _TokenBucket:
 
 
 class RateLimiter:
-    """TPM + TPD 이중 버킷 Rate Limiter."""
+    """RPM + TPM + TPD 삼중 버킷 Rate Limiter."""
 
-    def __init__(self, tpm_limit: int, tpd_limit: int) -> None:
+    def __init__(self, *, rpm_limit: int, tpm_limit: int, tpd_limit: int) -> None:
+        self._rpm = _TokenBucket(rpm_limit, 60.0, "RPM")
         self._tpm = _TokenBucket(tpm_limit, 60.0, "TPM")
         self._tpd = _TokenBucket(tpd_limit, 24 * 60 * 60.0, "TPD")
         self._lock = asyncio.Lock()
 
     async def acquire(self, estimated_tokens: int) -> None:
-        """두 버킷 모두 estimated_tokens 여유 확보까지 대기."""
-        if estimated_tokens <= 0:
-            return
+        """세 버킷(요청 1건 + estimated_tokens) 모두 여유 확보까지 대기."""
+        estimated_tokens = max(0, estimated_tokens)
         while True:
             async with self._lock:
+                wait_rpm = self._rpm.wait_time(1)
                 wait_tpm = self._tpm.wait_time(estimated_tokens)
                 wait_tpd = self._tpd.wait_time(estimated_tokens)
-                wait = max(wait_tpm, wait_tpd)
+                wait = max(wait_rpm, wait_tpm, wait_tpd)
                 if wait <= 0:
+                    self._rpm.consume(1)
                     self._tpm.consume(estimated_tokens)
                     self._tpd.consume(estimated_tokens)
                     return
             logger.info(
-                "[RateLimiter] 토큰 예산 대기 %.1f초 (est=%d, tpm_wait=%.1f, tpd_wait=%.1f)",
+                "[RateLimiter] 예산 대기 %.1f초 (est=%d, rpm_wait=%.1f, tpm_wait=%.1f, tpd_wait=%.1f)",
                 wait,
                 estimated_tokens,
+                wait_rpm,
                 wait_tpm,
                 wait_tpd,
             )

--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -6,7 +6,7 @@ class Settings(BaseSettings):
     ai_provider: str = "stub"  # "stub" | "openai"
     openai_base_url: str = "https://api.cerebras.ai/v1"
     openai_api_key: str = ""
-    openai_model: str = "qwen-3-235b-a22b-instruct-2507"
+    openai_model: str = "gpt-oss-120b"
 
     # ── MCP Tool Calling ──
     mcp_max_tool_hops: int = 1
@@ -14,14 +14,22 @@ class Settings(BaseSettings):
     mcp_search_max_results: int = 5
     mcp_search_region: str = "kr-kr"
 
-    # ── Rate Limit (토큰 예산 기반) ──
-    # - Cerebras Free Tier: TPM 60,000 / TPD 1,000,000
-    # - 운영 여유 마진 적용
-    tpm_limit: int = 50_000
+    # ── Rate Limit (요청수 + 토큰 예산 기반) ──
+    # - gpt-oss-120b: RPM 5 / TPM 30,000 / TPH 1,000,000 / TPD 1,000,000
+    # - 운영 여유 마진 적용 (RPM 은 재시도 요청까지 포함 → 1건 여유)
+    # - TPH 별도 버킷 미운용: 총량(1M)이 TPD 와 동일 → TPD 버킷이 그대로 커버
+    rpm_limit: int = 4
+    tpm_limit: int = 25_000
     tpd_limit: int = 900_000
     tpd_soft_limit_ratio: float = 0.8
-    # 레거시 호환용 (구 RPM 기반 설정)
-    rate_limit_rpm: int = 25
+
+    # ── LLM 429 재시도 (지수 백오프) ──
+    # - 최초 호출 포함 총 시도 횟수. 소진 시 RetriableError 전파 → DLQ
+    # - 대기 = max(base * 2**(n-1), retry_after), 상한 max_delay
+    # - RPM 슬롯(12초) 정렬: 6 → 12 → 24초 (인라인 총 ≤42초), 상한 60초=한 분 윈도우
+    llm_retry_max_attempts: int = 4
+    llm_retry_base_delay: float = 6.0
+    llm_retry_max_delay: float = 60.0
 
     # ── RabbitMQ ──
     rabbitmq_url: str  # amqp://{user}:{pass}@{host}:{port}/
@@ -31,13 +39,13 @@ class Settings(BaseSettings):
     # ── RabbitMQ DLX / DLQ ──
     # - DLX: direct, durable
     # - DLQ: TTL 24h, max-length 10,000
-    # - 재처리 워커: 10분 주기, 사이클당 최대 50건
+    # - 재처리 워커: 10분 주기, 사이클당 최대 5건 (RPM 5 한도 내 — 라이브 트래픽과 공유)
     dlq_dlx_name: str = "ai.congestion.dlx"
     rabbitmq_dlq_name: str = "ai.congestion.dlq"
     dlq_message_ttl_ms: int = 86_400_000  # 24h
     dlq_max_length: int = 10_000
     dlq_reprocess_interval_seconds: int = 600  # 10분
-    dlq_reprocess_batch_max: int = 50
+    dlq_reprocess_batch_max: int = 5
     message_max_attempt: int = 3
 
     # ── Batch ──

--- a/service-ai/tests/test_openai_client_retry.py
+++ b/service-ai/tests/test_openai_client_retry.py
@@ -1,0 +1,98 @@
+"""OpenAIAnalyzer._call_llm — 429 지수 백오프 재시도 테스트.
+
+- _call_llm_once 를 AsyncMock 으로 교체해 429/성공 시퀀스 시뮬레이션
+- asyncio.sleep 가로채 실제 대기 없이 백오프 지연값만 검증
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.ai.errors import NonRetriableError, RetriableError
+from app.ai.openai import OpenAIAnalyzer
+from app.config import settings
+
+
+class _FakeMCP:
+    def __init__(self) -> None:
+        self.list_tools = AsyncMock(return_value=[])
+        self.call_tool = AsyncMock()
+
+
+@pytest.fixture
+def analyzer():
+    return OpenAIAnalyzer(_FakeMCP())
+
+
+@pytest.fixture
+def captured_sleeps(monkeypatch):
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr("app.ai.openai.client.asyncio.sleep", fake_sleep)
+    return sleeps
+
+
+@pytest.mark.asyncio
+async def test_retries_on_retriable_then_succeeds(analyzer, captured_sleeps):
+    analyzer._call_llm_once = AsyncMock(side_effect=[
+        RetriableError("token_quota_exceeded", "tpm", retry_after=1.0),
+        RetriableError("unknown_429", "again", retry_after=1.0),
+        {"content": "ok"},
+    ])
+
+    msg = await analyzer._call_llm([{"role": "user", "content": "x"}], None)
+
+    assert msg == {"content": "ok"}
+    assert analyzer._call_llm_once.await_count == 3
+    # 지수 증가: base*2**0=2, base*2**1=4 (retry_after=1 보다 큼)
+    assert captured_sleeps == [
+        pytest.approx(settings.llm_retry_base_delay),
+        pytest.approx(settings.llm_retry_base_delay * 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_after_floor_overrides_short_backoff(analyzer, captured_sleeps):
+    # retry_after 가 지수 지연보다 크면 그 값을 따른다
+    big = settings.llm_retry_base_delay + 50.0
+    analyzer._call_llm_once = AsyncMock(side_effect=[
+        RetriableError("token_quota_exceeded", "tpm", retry_after=big),
+        {"content": "ok"},
+    ])
+
+    await analyzer._call_llm([{"role": "user", "content": "x"}], None)
+
+    # max_delay 상한 적용 후 retry_after floor 비교
+    expected = max(min(settings.llm_retry_base_delay, settings.llm_retry_max_delay), big)
+    assert captured_sleeps == [pytest.approx(expected)]
+
+
+@pytest.mark.asyncio
+async def test_non_retriable_is_not_retried(analyzer, captured_sleeps):
+    analyzer._call_llm_once = AsyncMock(
+        side_effect=NonRetriableError("queue_exceeded", "full")
+    )
+
+    with pytest.raises(NonRetriableError):
+        await analyzer._call_llm([{"role": "user", "content": "x"}], None)
+
+    assert analyzer._call_llm_once.await_count == 1
+    assert captured_sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_exhausts_retries_then_raises(analyzer, captured_sleeps):
+    analyzer._call_llm_once = AsyncMock(
+        side_effect=RetriableError("unknown_429", "always", retry_after=0.0)
+    )
+
+    with pytest.raises(RetriableError):
+        await analyzer._call_llm([{"role": "user", "content": "x"}], None)
+
+    assert analyzer._call_llm_once.await_count == settings.llm_retry_max_attempts
+    assert len(captured_sleeps) == settings.llm_retry_max_attempts - 1

--- a/service-ai/tests/test_rate_limiter_soft.py
+++ b/service-ai/tests/test_rate_limiter_soft.py
@@ -8,13 +8,13 @@ from app.ai.rate_limiter import RateLimiter
 
 
 def test_tpd_used_ratio_initial_is_zero():
-    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1000, tpd_limit=10_000)
     assert limiter.tpd_used_ratio() == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
 async def test_tpd_used_ratio_after_acquire():
-    limiter = RateLimiter(tpm_limit=1_000_000, tpd_limit=10_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1_000_000, tpd_limit=10_000)
     await limiter.acquire(2_000)
     # 2000 / 10000 = 0.2
     assert limiter.tpd_used_ratio() == pytest.approx(0.2, abs=0.01)
@@ -23,7 +23,7 @@ async def test_tpd_used_ratio_after_acquire():
 @pytest.mark.asyncio
 async def test_tpd_used_ratio_crosses_soft_limit():
     """soft limit 80% 임계 동작 검증."""
-    limiter = RateLimiter(tpm_limit=1_000_000, tpd_limit=1_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1_000_000, tpd_limit=1_000)
     soft_limit = 0.8
 
     # 70% 사용 → 임계 미만
@@ -37,7 +37,7 @@ async def test_tpd_used_ratio_crosses_soft_limit():
 
 def test_tpd_used_ratio_clamped_to_zero_when_overrefunded():
     """over-refund(잔여 > capacity)는 음수 사용률 대신 0.0 으로 클램프."""
-    limiter = RateLimiter(tpm_limit=1000, tpd_limit=1000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1000, tpd_limit=1000)
     # capacity 초과 환불해도 ratio 는 0 미만으로 안 떨어짐
     limiter._tpd._available = 2000.0
     assert limiter.tpd_used_ratio() == 0.0

--- a/service-ai/tests/test_rate_limiter_tokens.py
+++ b/service-ai/tests/test_rate_limiter_tokens.py
@@ -11,14 +11,14 @@ from app.ai.rate_limiter import RateLimiter, _TokenBucket, estimate_prompt_token
 
 @pytest.mark.asyncio
 async def test_acquire_fast_path_under_budget():
-    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1000, tpd_limit=10_000)
     # 여유 충분 → 즉시 반환
     await asyncio.wait_for(limiter.acquire(100), timeout=0.5)
 
 
 @pytest.mark.asyncio
 async def test_acquire_blocks_when_tpm_exhausted(monkeypatch):
-    limiter = RateLimiter(tpm_limit=100, tpd_limit=1_000_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=100, tpd_limit=1_000_000)
     # 전체 예산 소진
     await limiter.acquire(100)
 
@@ -43,7 +43,7 @@ async def test_acquire_blocks_when_tpm_exhausted(monkeypatch):
 
 
 def test_record_actual_adjusts_consumed_amount():
-    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1000, tpd_limit=10_000)
     limiter._tpm._available = 1000.0
     limiter._tpd._available = 10_000.0
 
@@ -57,7 +57,7 @@ def test_record_actual_adjusts_consumed_amount():
 
 
 def test_record_actual_refunds_when_overestimated():
-    limiter = RateLimiter(tpm_limit=1000, tpd_limit=10_000)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1000, tpd_limit=10_000)
     limiter._tpm._available = 1000.0
     limiter._tpd._available = 10_000.0
     limiter._tpm.consume(300)
@@ -71,7 +71,7 @@ def test_record_actual_refunds_when_overestimated():
 @pytest.mark.asyncio
 async def test_acquire_blocks_when_tpd_exhausted(monkeypatch):
     """TPD 소진 시 TPM 여유 있어도 대기 필요."""
-    limiter = RateLimiter(tpm_limit=1_000_000, tpd_limit=100)
+    limiter = RateLimiter(rpm_limit=10**9, tpm_limit=1_000_000, tpd_limit=100)
     await limiter.acquire(100)
 
     sleep_calls: list[float] = []
@@ -86,6 +86,37 @@ async def test_acquire_blocks_when_tpd_exhausted(monkeypatch):
     monkeypatch.setattr("app.ai.rate_limiter.asyncio.sleep", fake_sleep)
     await asyncio.wait_for(limiter.acquire(50), timeout=1.0)
     assert sleep_calls and sleep_calls[0] > 0
+
+
+@pytest.mark.asyncio
+async def test_acquire_blocks_when_rpm_exhausted(monkeypatch):
+    """토큰 여유가 충분해도 RPM 소진 시 대기 필요 (요청수 강제)."""
+    limiter = RateLimiter(rpm_limit=2, tpm_limit=1_000_000, tpd_limit=1_000_000)
+    # 작은 토큰이라 TPM/TPD 는 넉넉 → RPM 버킷만 소진
+    await limiter.acquire(10)
+    await limiter.acquire(10)  # 2/2 → RPM 버킷 비움
+
+    sleep_calls: list[float] = []
+    original_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        limiter._rpm._available = 2.0  # 무한 루프 방지 → RPM 충전
+        await original_sleep(0)
+
+    monkeypatch.setattr("app.ai.rate_limiter.asyncio.sleep", fake_sleep)
+    await asyncio.wait_for(limiter.acquire(10), timeout=1.0)
+    assert sleep_calls and sleep_calls[0] > 0
+
+
+def test_record_actual_does_not_refund_rpm():
+    """실패 보정(record_actual)은 토큰만 환불, RPM 은 유지 (서버 카운터 반영)."""
+    limiter = RateLimiter(rpm_limit=5, tpm_limit=1000, tpd_limit=10_000)
+    limiter._rpm.consume(1)
+    before = limiter._rpm._available
+    # 429 실패 경로: actual=0, estimated=400 → 토큰 전액 환불
+    limiter.record_actual(actual_tokens=0, estimated_tokens=400)
+    assert limiter._rpm._available == pytest.approx(before, abs=0.01)
 
 
 def test_token_bucket_wait_time_calculation():


### PR DESCRIPTION
## 배경
모델을 **gpt-oss-120b** 로 교체 (RPM 5 / TPM 30K / TPH 1M / TPD 1M). 기존 백오프·레이트리밋은 Cerebras qwen(TPM 60K / RPM 30) 기준이라 새 한도에 부적합.

## 핵심 문제
RateLimiter에 **요청수(RPM) 제한 자체가 없었음** — 토큰이 남아도 RPM 5를 초과해 429 발생. RPM이 새 한도의 바인딩 제약.

## 변경
- **RPM 버킷 추가**: RPM/TPM/TPD 삼중 leaky bucket. 12초당 1회 사전 throttle. 실패(429) 요청도 서버 RPM에 잡히므로 RPM은 환불 안 함.
- **한도 재조정**: `tpm_limit` 50K→25K, `rpm_limit` 4, 모델 기본값 `gpt-oss-120b`, 미사용 `rate_limit_rpm` 제거. (TPH는 총량이 TPD와 동일 1M이라 별도 버킷 불필요)
- **429 인라인 지수 백오프**: `6 → 12 → 24초`(총 4회), 상한 60초, 대기=`max(사다리, retry_after)`. 소진 시 DLQ 전파, NonRetriable은 즉시 DLQ. RPM 슬롯(12초)·분 윈도우(60초)에 정렬.
- **DLQ 재처리 배치** 50→5 (RPM 한도를 라이브 트래픽과 공유).
- **docker-compose 폴백 모델** `zai-glm-4.7` (런타임은 Infisical=gpt-oss-120b).

## 테스트
- 유닛 85개 통과 (RPM 버킷 차단/환불, 429 지수 백오프 재시도/non-retriable/소진 신규)

## Test plan
- [ ] 배포 후 gpt-oss-120b 실호출 1건으로 모델 ID 수락 + 429 헤더 동작 확인