### PR TITLE
chore(loadtest): k6 ramp-up 부하테스트 도입 + 게이트웨이 rate limit 환경변수화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,6 +225,8 @@ services:
       - LOKI_URL=http://observability:3100/loki/api/v1/push
       - SPRING_DATA_REDIS_HOST=redis
       - SPRING_DATA_REDIS_PASSWORD=${REDIS_PASSWORD:-}
+      - GATEWAY_RATE_REPLENISH=${GATEWAY_RATE_REPLENISH:-10}
+      - GATEWAY_RATE_BURST=${GATEWAY_RATE_BURST:-20}
     depends_on:
       redis:
         condition: service_healthy

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -1,0 +1,101 @@
+# 부하테스트 (Load Test)
+
+게이트웨이를 통한 동기 HTTP 경로의 **회귀 감지용 기준선**을 측정한다.
+관련 이슈: [#333](https://github.com/Dan-burn-go/Backend/issues/333)
+
+> 로컬 단일 머신 측정치는 **상대치(회귀 감지)** 로만 사용한다.
+> SLA 판정·캐파시티 결정은 dev/staging 재측정 후 별도 이슈에서 진행한다.
+
+## 대상 (issue #333)
+
+| 메서드 | 경로 | k6 tag | 부하 특성 |
+|---|---|---|---|
+| GET | `/api/congestion` | `list` | 122개 목록 — 가장 무거움 |
+| GET | `/api/congestion/{areaCode}` | `detail` | 단일 조회 — 캐시 hit 기대 |
+| GET | `/api/congestion/analysis/hourly/{areaCode}?days=7` | `hourly` | 시간별 집계 쿼리 |
+| GET | `/api/congestion/analysis/ranking/busiest?limit=10` | `ranking` | 정렬+집계 |
+
+외부 의존성이 큰 경로(`/api/mobility/route`, `/api/map/*`, `*/ai-report`)와 비동기 service-ai 는 범위에서 제외.
+
+## 사전 준비
+
+1. k6 설치 (macOS): `brew install k6`
+2. 인프라 기동: `docker compose -f docker-compose.local.yml up -d` (MySQL, Redis)
+3. 게이트웨이 + service-congestion 기동
+   ```bash
+   SPRING_PROFILES_ACTIVE=local ./gradlew :service-gateway:bootRun
+   SPRING_PROFILES_ACTIVE=local ./gradlew :service-congestion:bootRun
+   ```
+4. 헬스 확인: `curl http://localhost:8080/api/congestion` 이 200 이고 `data` 배열이 비어있지 않은지 확인.
+
+> 첫 실행 시 `https://jslib.k6.io` 의 summary 라이브러리를 받아오므로 인터넷 연결이 필요하다.
+
+## 실행
+
+**프로젝트 루트에서** 실행한다 (결과가 `load-test/results/` 에 저장됨):
+
+```bash
+# 로컬
+k6 run load-test/k6/ramp-up.js
+
+# 다른 환경 (BASE_URL 덮어쓰기)
+k6 run -e BASE_URL=https://dev.example.com load-test/k6/ramp-up.js
+```
+
+## 시나리오
+
+VU 1 → 50 선형 증가:
+
+```
+stages: [
+  { duration: '30s', target: 5 },  // 워밍업
+  { duration: '5m',  target: 50 }, // 선형 증가
+  { duration: '1m',  target: 0 },  // cooldown
+]
+```
+
+## VU 수준 결정 가이드 (DAU 기준)
+
+| DAU 구간 | 권장 VU | 환경 |
+|---|---|---|
+| **DAU 1만 미만** | **VU 50** (현재 채택) | 로컬 회귀 감지용 베이스라인 |
+| DAU 1만 ~ 10만 | VU 100 ~ 300 | 로컬 또는 dev |
+| DAU 10만 이상 | VU 500+ | dev / staging 필수 |
+
+VU 50 ≈ 150~500 RPS (평균 응답 100~300ms 가정). VU 조정은 `ramp-up.js` 의 `stages` 에서 `target` 값을 바꾼다.
+
+## 임계값 (thresholds)
+
+| 메트릭 | 기준 |
+|---|---|
+| `http_req_failed` | 에러율 < 1% |
+| `http_req_duration` (전체) | p95 < 500ms |
+| `endpoint:list` | p95 < 800ms |
+| `endpoint:detail` | p95 < 300ms |
+| `endpoint:hourly` / `endpoint:ranking` | p95 < 800ms |
+
+기준 초과 시 k6 종료 코드가 0 이 아니다. 첫 측정에서는 이 값들이 **임시 가드레일**이며, 실측 후 기준선에 맞게 조정한다.
+
+## 결과 / 기준선
+
+실행 후 요약은 stdout 과 `load-test/results/summary.json` 에 저장된다.
+측정할 때마다 아래 표를 갱신해 회귀 추적에 사용한다.
+
+| 측정일 | 환경 | 최대 RPS | p95 (list) | p95 (detail) | p95 (hourly) | p95 (ranking) | 에러율 |
+|---|---|---|---|---|---|---|---|
+| 2026-05-28 | local (rate limit 해제) | ~97 | 27.6ms | 8.5ms | 8.8ms | 9.95ms | 0% |
+
+> 2026-05-28 측정: VU 1→50 구간 내내 안정적(37,869 req, checks 100%, interrupted 0). 로컬 단일 머신이라 절대치보다 **회귀 기준선**으로만 사용.
+
+## ⚠️ 게이트웨이 Rate Limiter 주의
+
+게이트웨이는 모든 라우트에 **IP 기반 RequestRateLimiter**(`replenishRate 10, burstCapacity 20`)를 default-filter로 적용한다. KeyResolver가 `getRemoteAddress()` 기반이라 단일 클라이언트(k6)는 **초당 10요청**에서 막혀 대부분 429를 받는다 (X-Forwarded-For 헤더로는 우회 불가).
+
+부하테스트로 **다운스트림 용량**을 보려면 rate limit을 환경변수로 풀어야 한다 (기본값은 운영 설정 그대로 보존):
+
+```bash
+GATEWAY_RATE_REPLENISH=100000 GATEWAY_RATE_BURST=200000 \
+  infisical run --silent -- docker compose up -d --no-deps --force-recreate service-gateway
+```
+
+rate limit을 켠 채로 측정하면 "IP당 10 RPS 보호가 작동한다"는 결과만 나오고 다운스트림 부하는 측정되지 않는다.

--- a/load-test/k6/ramp-up.js
+++ b/load-test/k6/ramp-up.js
@@ -1,0 +1,77 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.1.0/index.js';
+
+// 게이트웨이 기본 주소. dev 등 다른 환경은 BASE_URL 환경변수로 덮어쓴다.
+//   k6 run -e BASE_URL=https://dev.example.com load-test/k6/ramp-up.js
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+
+export const options = {
+  // VU 1 -> 50 선형 증가 (issue #333: 로컬 회귀 감지용 기준선)
+  stages: [
+    { duration: '30s', target: 5 },  // 워밍업
+    { duration: '5m', target: 50 },  // 선형 증가
+    { duration: '1m', target: 0 },   // cooldown
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.01'],                        // 에러율 1% 미만
+    http_req_duration: ['p(95)<500'],                      // 전체 p95 500ms 미만
+    'http_req_duration{endpoint:list}': ['p(95)<800'],     // 122개 목록 — 가장 무거움
+    'http_req_duration{endpoint:detail}': ['p(95)<300'],   // 단일 조회 — 캐시 hit 기대
+    'http_req_duration{endpoint:hourly}': ['p(95)<800'],   // 시간별 집계 쿼리
+    'http_req_duration{endpoint:ranking}': ['p(95)<800'],  // 정렬+집계
+  },
+};
+
+// 실제 areaCode 목록을 시드 추측 없이 런타임에 확보한다.
+export function setup() {
+  const res = http.get(`${BASE_URL}/api/congestion`);
+  if (res.status !== 200) {
+    throw new Error(
+      `setup 실패: GET /api/congestion -> ${res.status}. 게이트웨이/service-congestion 기동 여부를 확인하세요.`,
+    );
+  }
+  const codes = (res.json('data') || []).map((c) => c.areaCode).filter(Boolean);
+  if (codes.length === 0) {
+    throw new Error('areaCode 목록이 비어 있음 — 혼잡도 시드 데이터를 확인하세요.');
+  }
+  console.log(`setup 완료: areaCode ${codes.length}개 로드`);
+  return { areaCodes: codes };
+}
+
+export default function (data) {
+  const areaCode = data.areaCodes[Math.floor(Math.random() * data.areaCodes.length)];
+
+  group('list', () => {
+    const res = http.get(`${BASE_URL}/api/congestion`, { tags: { endpoint: 'list' } });
+    check(res, { 'list status 200': (r) => r.status === 200 });
+  });
+
+  group('detail', () => {
+    const res = http.get(`${BASE_URL}/api/congestion/${areaCode}`, { tags: { endpoint: 'detail' } });
+    check(res, { 'detail status 200': (r) => r.status === 200 });
+  });
+
+  group('hourly', () => {
+    const res = http.get(`${BASE_URL}/api/congestion/analysis/hourly/${areaCode}?days=7`, {
+      tags: { endpoint: 'hourly' },
+    });
+    check(res, { 'hourly status 200': (r) => r.status === 200 });
+  });
+
+  group('ranking', () => {
+    const res = http.get(`${BASE_URL}/api/congestion/analysis/ranking/busiest?limit=10`, {
+      tags: { endpoint: 'ranking' },
+    });
+    check(res, { 'ranking status 200': (r) => r.status === 200 });
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    'load-test/results/summary.json': JSON.stringify(data, null, 2),
+  };
+}

--- a/load-test/results/.gitignore
+++ b/load-test/results/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitkeep
+!.gitignore

--- a/service-gateway/src/main/resources/application.yml
+++ b/service-gateway/src/main/resources/application.yml
@@ -10,8 +10,8 @@ spring:
       default-filters:
         - name: RequestRateLimiter
           args:
-            redis-rate-limiter.replenishRate: 10
-            redis-rate-limiter.burstCapacity: 20
+            redis-rate-limiter.replenishRate: ${GATEWAY_RATE_REPLENISH:10}
+            redis-rate-limiter.burstCapacity: ${GATEWAY_RATE_BURST:20}
             redis-rate-limiter.requestedTokens: 1
             key-resolver: "#{@ipKeyResolver}"
       routes:


### PR DESCRIPTION
## Summary
- k6 ramp-up 부하테스트 스크립트 + 실행 가이드 도입 (issue #333)
- 게이트웨이 RequestRateLimiter 값을 환경변수(`GATEWAY_RATE_REPLENISH`/`GATEWAY_RATE_BURST`) 바인딩으로 변경 — **기본값 10/20 보존**이라 운영 동작은 그대로
- 목적: 배포(prod) 환경 부하테스트 시 Infisical 토글만으로 rate limit을 일시 해제

## 변경
- `load-test/k6/ramp-up.js` — VU 1→50 ramp-up, setup에서 실제 areaCode 추출, 엔드포인트별 tag 측정 (`/api/congestion` 4개 경로)
- `load-test/README.md` — 실행 절차 · DAU별 VU 가이드 · rate limit 주의 · 기준선 표
- `service-gateway/.../application.yml` — rate limit 값 환경변수 바인딩 (기본 10/20)
- `docker-compose.yml` — gateway에 `GATEWAY_RATE_REPLENISH`/`GATEWAY_RATE_BURST` 추가

## 로컬 측정 결과 (기준선)
- VU 1→50, 37,869 req / ~97 RPS / **에러율 0%** / p95 20ms — 안정적, threshold 전부 통과
- 발견: rate limit 켠 채로는 IP당 10 RPS 초과분이 90% 429 → 환경변수로 풀어 다운스트림 기준선 확보

## 머지 후 prod 부하테스트 경로
1. dev 머지 → main promotion → CD가 gateway 이미지 재빌드/배포 (새 application.yml 반영)
2. **Infisical prod 환경**에 `GATEWAY_RATE_REPLENISH=100000`, `GATEWAY_RATE_BURST=200000` 추가 → gateway 재시작 시 rate limit 해제
3. k6 웹 대시보드로 prod 부하테스트:
   ```
   K6_WEB_DASHBOARD=true K6_WEB_DASHBOARD_EXPORT=load-test/results/report.html \
     k6 run -e BASE_URL=https://<prod-domain> load-test/k6/ramp-up.js
   ```
4. 측정 종료 후 Infisical 값 제거 → rate limit 기본값(10/20) 원복

## Test plan
- [x] 로컬 docker-compose에서 ramp-up 1회 성공 (에러율 0%)
- [x] rate limit 환경변수 토글 동작 확인 (50회 연속 호출 200)
- [ ] prod 배포 후 Infisical 토글 → prod 부하테스트 (발표용)