### PR TITLE
test: 5개 서비스 미커버 영역 단위 테스트 추가

### DIFF
--- a/service-ai/tests/test_ai_factory.py
+++ b/service-ai/tests/test_ai_factory.py
@@ -1,0 +1,32 @@
+"""app.ai.factory — create_analyzer() 분기 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.factory import create_analyzer
+from app.ai.stub import StubAnalyzer
+
+
+class TestCreateAnalyzer:
+    def test_stub_provider_returns_stub_analyzer(self, monkeypatch):
+        monkeypatch.setattr("app.ai.factory.settings.ai_provider", "stub")
+        analyzer = create_analyzer()
+        assert isinstance(analyzer, StubAnalyzer)
+
+    def test_stub_provider_ignores_mcp_client(self, monkeypatch):
+        monkeypatch.setattr("app.ai.factory.settings.ai_provider", "stub")
+        # mcp_client 전달해도 StubAnalyzer 반환
+        analyzer = create_analyzer(mcp_client=object())  # type: ignore[arg-type]
+        assert isinstance(analyzer, StubAnalyzer)
+
+    def test_openai_provider_without_mcp_client_raises(self, monkeypatch):
+        monkeypatch.setattr("app.ai.factory.settings.ai_provider", "openai")
+        with pytest.raises(RuntimeError, match="mcp_client"):
+            create_analyzer(mcp_client=None)
+
+    def test_unknown_provider_falls_back_to_stub(self, monkeypatch):
+        """기타 provider 값 → else 분기 → StubAnalyzer."""
+        monkeypatch.setattr("app.ai.factory.settings.ai_provider", "unknown")
+        analyzer = create_analyzer()
+        assert isinstance(analyzer, StubAnalyzer)

--- a/service-ai/tests/test_ai_stub.py
+++ b/service-ai/tests/test_ai_stub.py
@@ -1,0 +1,63 @@
+"""app.ai.stub — StubAnalyzer 동작 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.stub import StubAnalyzer
+from app.models.schemas import CongestionEvent
+
+
+def _event(code: str = "A", level: str = "BUSY") -> CongestionEvent:
+    return CongestionEvent(
+        area_name=f"지역-{code}",
+        area_code=code,
+        congestion_level=level,
+        max_people_count=100,
+        population_time="2026-05-28 12:00",
+    )
+
+
+class TestStubAnalyzer:
+    @pytest.mark.asyncio
+    async def test_normal_mode_returns_results_for_all_events(self):
+        analyzer = StubAnalyzer()
+        events = [_event("A"), _event("B"), _event("C")]
+        results = await analyzer.analyze(events)
+        assert len(results) == 3
+
+    @pytest.mark.asyncio
+    async def test_result_fields_match_event(self):
+        analyzer = StubAnalyzer()
+        e = _event("X", level="VERY_BUSY")
+        results = await analyzer.analyze([e])
+        r = results[0]
+        assert r.area_name == e.area_name
+        assert r.area_code == e.area_code
+        assert r.congestion_level == e.congestion_level
+        assert r.population_time == e.population_time
+
+    @pytest.mark.asyncio
+    async def test_normal_mode_message_contains_stub_tag(self):
+        analyzer = StubAnalyzer()
+        results = await analyzer.analyze([_event("A")])
+        assert "[Stub]" in results[0].analysis_message
+        assert "Stub-Anomaly" not in results[0].analysis_message
+
+    @pytest.mark.asyncio
+    async def test_anomaly_mode_message_contains_stub_anomaly_tag(self):
+        analyzer = StubAnalyzer()
+        results = await analyzer.analyze([_event("A")], mode="anomaly")
+        assert "[Stub-Anomaly]" in results[0].analysis_message
+
+    @pytest.mark.asyncio
+    async def test_empty_events_returns_empty_list(self):
+        analyzer = StubAnalyzer()
+        results = await analyzer.analyze([])
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_close_does_not_raise(self):
+        """AIAnalyzer.close() 기본 구현 — 예외 없음."""
+        analyzer = StubAnalyzer()
+        await analyzer.close()  # should not raise

--- a/service-ai/tests/test_config.py
+++ b/service-ai/tests/test_config.py
@@ -1,0 +1,61 @@
+"""app.config — Settings 기본값 및 환경변수 주입 테스트."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.config import Settings
+
+
+class TestSettingsDefaults:
+    def test_default_ai_provider(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.ai_provider == "stub"
+
+    def test_default_rabbitmq_queue(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.rabbitmq_queue == "ai.congestion.analysis"
+
+    def test_default_dlq_name(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.rabbitmq_dlq_name == "ai.congestion.dlq"
+
+    def test_default_dlx_name(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.dlq_dlx_name == "ai.congestion.dlx"
+
+    def test_default_batch_window(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.batch_window_seconds == pytest.approx(5.0)
+
+    def test_default_rpm_limit(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.rpm_limit == 4
+
+    def test_rabbitmq_url_required(self):
+        """rabbitmq_url 없이 Settings() → ValidationError."""
+        from pydantic import ValidationError
+
+        # 환경변수가 없는 격리 상태로 확인
+        env_backup = os.environ.pop("RABBITMQ_URL", None)
+        try:
+            with pytest.raises((ValidationError, Exception)):
+                Settings()
+        finally:
+            if env_backup is not None:
+                os.environ["RABBITMQ_URL"] = env_backup
+
+    def test_override_via_constructor(self):
+        s = Settings(rabbitmq_url="amqp://localhost/", ai_provider="openai", rpm_limit=2)
+        assert s.ai_provider == "openai"
+        assert s.rpm_limit == 2
+
+    def test_dlq_message_ttl_ms_default(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.dlq_message_ttl_ms == 86_400_000
+
+    def test_dlq_max_length_default(self):
+        s = Settings(rabbitmq_url="amqp://localhost/")
+        assert s.dlq_max_length == 10_000

--- a/service-ai/tests/test_consumer.py
+++ b/service-ai/tests/test_consumer.py
@@ -1,0 +1,106 @@
+"""app.rabbitmq.consumer — RabbitMQConsumer._on_message() 파싱 로직 테스트.
+
+실제 RabbitMQ 연결 없이 _on_message() 의 파싱/nack 분기만 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.rabbitmq.consumer import RabbitMQConsumer
+
+
+class FakeMessage:
+    """AbstractIncomingMessage 최소 더미."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.body = payload
+        self.nacked = False
+        self.nack_requeue: bool | None = None
+
+    async def nack(self, requeue: bool = True) -> None:
+        self.nacked = True
+        self.nack_requeue = requeue
+
+
+class FakeBatchProcessor:
+    def __init__(self) -> None:
+        self.added: list = []
+
+    async def add(self, event, message) -> None:
+        self.added.append((event, message))
+
+
+def _make_consumer() -> tuple[RabbitMQConsumer, FakeBatchProcessor]:
+    bp = FakeBatchProcessor()
+    consumer = RabbitMQConsumer(batch_processor=bp)  # type: ignore[arg-type]
+    return consumer, bp
+
+
+def _valid_body(**overrides) -> bytes:
+    data = {
+        "areaName": "강남",
+        "areaCode": "POI001",
+        "congestionLevel": "BUSY",
+        "maxPeopleCount": 200,
+        "populationTime": "2026-05-28 09:00",
+    }
+    data.update(overrides)
+    return json.dumps(data).encode()
+
+
+class TestOnMessage:
+    @pytest.mark.asyncio
+    async def test_valid_message_forwarded_to_batch(self):
+        consumer, bp = _make_consumer()
+        msg = FakeMessage(_valid_body())
+        await consumer._on_message(msg)
+        assert len(bp.added) == 1
+        event, forwarded_msg = bp.added[0]
+        assert event.area_code == "POI001"
+        assert forwarded_msg is msg
+        assert not msg.nacked
+
+    @pytest.mark.asyncio
+    async def test_optional_fields_parsed(self):
+        consumer, bp = _make_consumer()
+        msg = FakeMessage(_valid_body(avgMaxPeople=150.0, ratio=1.33))
+        await consumer._on_message(msg)
+        event, _ = bp.added[0]
+        assert event.avg_max_people == 150.0
+        assert event.ratio == pytest.approx(1.33)
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_nacks_to_dlq(self):
+        consumer, bp = _make_consumer()
+        msg = FakeMessage(b"not-json")
+        await consumer._on_message(msg)
+        assert msg.nacked is True
+        assert msg.nack_requeue is False
+        assert len(bp.added) == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_required_field_nacks_to_dlq(self):
+        consumer, bp = _make_consumer()
+        # maxPeopleCount 누락
+        bad = {
+            "areaName": "홍대",
+            "areaCode": "POI002",
+            "congestionLevel": "NORMAL",
+            "populationTime": "2026-05-28 12:00",
+        }
+        msg = FakeMessage(json.dumps(bad).encode())
+        await consumer._on_message(msg)
+        assert msg.nacked is True
+        assert msg.nack_requeue is False
+        assert len(bp.added) == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_running_false(self):
+        consumer, _ = _make_consumer()
+        consumer._running = True
+        # _channel/_connection 없어도 stop() 가 안전하게 완료
+        await consumer.stop()
+        assert consumer._running is False

--- a/service-ai/tests/test_mcp_client.py
+++ b/service-ai/tests/test_mcp_client.py
@@ -1,0 +1,116 @@
+"""app.ai.mcp.client — MCPClient 상태 및 예외 경로 테스트.
+
+실제 MCP 서버 연결(create_connected_server_and_client_session)은 mock으로 대체한다.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.ai.mcp.client import MCPClient
+
+
+def _make_fake_tool(name: str, description: str = "desc") -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    tool.inputSchema = {"type": "object", "properties": {}}
+    return tool
+
+
+class TestMCPClientNotStarted:
+    @pytest.mark.asyncio
+    async def test_list_tools_raises_when_not_started(self):
+        client = MCPClient()
+        with pytest.raises(RuntimeError, match="시작되지 않았습니다"):
+            await client.list_tools()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_raises_when_not_started(self):
+        client = MCPClient()
+        with pytest.raises(RuntimeError, match="시작되지 않았습니다"):
+            await client.call_tool("search_web", {})
+
+    @pytest.mark.asyncio
+    async def test_stop_safe_when_not_started(self):
+        client = MCPClient()
+        await client.stop()  # should not raise
+
+
+class TestMCPClientStarted:
+    def _fake_session(self, tools=None, call_result_text="ok"):
+        """list_tools / call_tool 을 흉내내는 가짜 ClientSession."""
+        session = AsyncMock()
+        tool_list = MagicMock()
+        tool_list.tools = tools or []
+        session.list_tools.return_value = tool_list
+
+        call_result = MagicMock()
+        content_item = MagicMock()
+        content_item.text = call_result_text
+        call_result.content = [content_item]
+        session.call_tool.return_value = call_result
+        return session
+
+    @asynccontextmanager
+    async def _patched_start(self, client: MCPClient, session):
+        """create_connected_server_and_client_session 을 patch하여 start() 실행."""
+        fake_ctx = AsyncMock()
+        fake_ctx.__aenter__ = AsyncMock(return_value=session)
+        fake_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.ai.mcp.client.create_connected_server_and_client_session",
+            return_value=fake_ctx,
+        ):
+            await client.start()
+            yield
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self):
+        """이미 시작된 클라이언트에 start() 재호출 → 예외 없음."""
+        client = MCPClient()
+        session = self._fake_session()
+        async with self._patched_start(client, session):
+            await client.start()  # 두 번째 호출 → early return
+            assert client._session is session  # 세션 변경 없음
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_openai_format(self):
+        client = MCPClient()
+        tools = [_make_fake_tool("search_web"), _make_fake_tool("get_weather")]
+        session = self._fake_session(tools=tools)
+        async with self._patched_start(client, session):
+            result = await client.list_tools()
+        assert len(result) == 2
+        assert result[0]["type"] == "function"
+        assert result[0]["function"]["name"] == "search_web"
+        assert result[1]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_call_tool_returns_text_content(self):
+        client = MCPClient()
+        session = self._fake_session(call_result_text="검색 결과입니다")
+        async with self._patched_start(client, session):
+            result = await client.call_tool("search_web", {"query": "강남 혼잡"})
+        assert "검색 결과입니다" in result
+
+    @pytest.mark.asyncio
+    async def test_call_tool_empty_content_returns_json_fallback(self):
+        client = MCPClient()
+        session = AsyncMock()
+        tool_list = MagicMock()
+        tool_list.tools = []
+        session.list_tools.return_value = tool_list
+        call_result = MagicMock()
+        # content 없음 (text attribute 없는 항목)
+        item = MagicMock(spec=[])  # no 'text' attribute
+        call_result.content = [item]
+        session.call_tool.return_value = call_result
+
+        async with self._patched_start(client, session):
+            result = await client.call_tool("search_web", {})
+        assert result == '{"results": []}'

--- a/service-ai/tests/test_publisher.py
+++ b/service-ai/tests/test_publisher.py
@@ -1,0 +1,86 @@
+"""app.rabbitmq.publisher — RabbitMQPublisher.publish_all() 로직 테스트.
+
+실제 RabbitMQ 연결 없이 exchange.publish 호출을 mock으로 검증한다.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.schemas import AnalysisResult
+from app.rabbitmq.publisher import REPORT_ROUTING_KEY, RabbitMQPublisher
+
+
+def _result(code: str = "A") -> AnalysisResult:
+    return AnalysisResult(
+        area_name=f"지역-{code}",
+        area_code=code,
+        congestion_level="BUSY",
+        analysis_message="분석 결과",
+        population_time="2026-05-28 12:00",
+    )
+
+
+class TestPublishAll:
+    @pytest.mark.asyncio
+    async def test_empty_list_does_not_call_exchange(self):
+        publisher = RabbitMQPublisher()
+        mock_exchange = AsyncMock()
+        publisher._exchange = mock_exchange
+        await publisher.publish_all([])
+        mock_exchange.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_result_published_with_correct_routing_key(self):
+        publisher = RabbitMQPublisher()
+        mock_exchange = AsyncMock()
+        publisher._exchange = mock_exchange
+
+        await publisher.publish_all([_result("X")])
+
+        mock_exchange.publish.assert_called_once()
+        _, kwargs = mock_exchange.publish.call_args
+        assert kwargs.get("routing_key") == REPORT_ROUTING_KEY
+
+    @pytest.mark.asyncio
+    async def test_multiple_results_each_published(self):
+        publisher = RabbitMQPublisher()
+        mock_exchange = AsyncMock()
+        publisher._exchange = mock_exchange
+
+        results = [_result("A"), _result("B"), _result("C")]
+        await publisher.publish_all(results)
+
+        assert mock_exchange.publish.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_message_body_contains_correct_fields(self):
+        publisher = RabbitMQPublisher()
+        published_messages: list = []
+
+        async def capture_publish(message, *, routing_key):
+            published_messages.append(message)
+
+        mock_exchange = MagicMock()
+        mock_exchange.publish = capture_publish
+        publisher._exchange = mock_exchange
+
+        r = _result("Z")
+        await publisher.publish_all([r])
+
+        assert len(published_messages) == 1
+        body = json.loads(published_messages[0].body.decode())
+        assert body["areaCode"] == "Z"
+        assert body["areaName"] == r.area_name
+        assert body["congestionLevel"] == r.congestion_level
+        assert body["analysisMessage"] == r.analysis_message
+        assert body["populationTime"] == r.population_time
+
+    @pytest.mark.asyncio
+    async def test_close_safe_when_not_connected(self):
+        publisher = RabbitMQPublisher()
+        # _channel/_connection 모두 None인 상태에서 close() 안전 완료
+        await publisher.close()

--- a/service-ai/tests/test_schemas.py
+++ b/service-ai/tests/test_schemas.py
@@ -1,0 +1,78 @@
+"""app.models.schemas — Pydantic 모델 유효성 검증 테스트."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.schemas import AnalysisResult, CongestionEvent
+
+
+class TestCongestionEvent:
+    def test_required_fields_ok(self):
+        e = CongestionEvent(
+            area_name="강남",
+            area_code="POI001",
+            congestion_level="BUSY",
+            max_people_count=200,
+            population_time="2026-05-28 09:00",
+        )
+        assert e.area_code == "POI001"
+        assert e.avg_max_people is None
+        assert e.ratio is None
+
+    def test_optional_fields_accepted(self):
+        e = CongestionEvent(
+            area_name="홍대",
+            area_code="POI002",
+            congestion_level="NORMAL",
+            max_people_count=50,
+            population_time="2026-05-28 12:00",
+            avg_max_people=120.5,
+            ratio=0.42,
+        )
+        assert e.avg_max_people == 120.5
+        assert e.ratio == pytest.approx(0.42)
+
+    def test_missing_required_field_raises(self):
+        with pytest.raises(ValidationError):
+            CongestionEvent(  # type: ignore[call-arg]
+                area_name="X",
+                area_code="Y",
+                congestion_level="BUSY",
+                # max_people_count 누락
+                population_time="2026-05-28 00:00",
+            )
+
+    def test_wrong_type_for_max_people_count_raises(self):
+        with pytest.raises(ValidationError):
+            CongestionEvent(
+                area_name="X",
+                area_code="Y",
+                congestion_level="BUSY",
+                max_people_count="not-an-int",  # type: ignore[arg-type]
+                population_time="2026-05-28 00:00",
+            )
+
+
+class TestAnalysisResult:
+    def test_all_fields_ok(self):
+        r = AnalysisResult(
+            area_name="잠실",
+            area_code="POI003",
+            congestion_level="VERY_BUSY",
+            analysis_message="혼잡 원인 분석 결과입니다.",
+            population_time="2026-05-28 18:00",
+        )
+        assert r.area_name == "잠실"
+        assert r.analysis_message == "혼잡 원인 분석 결과입니다."
+
+    def test_missing_field_raises(self):
+        with pytest.raises(ValidationError):
+            AnalysisResult(  # type: ignore[call-arg]
+                area_name="X",
+                area_code="Y",
+                congestion_level="BUSY",
+                # analysis_message 누락
+                population_time="2026-05-28 00:00",
+            )

--- a/service-common/build.gradle
+++ b/service-common/build.gradle
@@ -11,4 +11,9 @@ dependencies {
     // Distributed Tracing (Micrometer → OpenTelemetry → OTLP)
     api 'io.micrometer:micrometer-tracing-bridge-otel'
     api 'io.opentelemetry:opentelemetry-exporter-otlp'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/service-common/src/test/java/com/danburn/common/exception/GlobalExceptionTest.java
+++ b/service-common/src/test/java/com/danburn/common/exception/GlobalExceptionTest.java
@@ -1,0 +1,51 @@
+package com.danburn.common.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GlobalException")
+class GlobalExceptionTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Constructor {
+
+        @Test
+        @DisplayName("status와 message가 올바르게 저장됨")
+        void status_message_저장() {
+            GlobalException ex = new GlobalException(404, "리소스를 찾을 수 없음");
+
+            assertThat(ex.getStatus()).isEqualTo(404);
+            assertThat(ex.getMessage()).isEqualTo("리소스를 찾을 수 없음");
+        }
+
+        @Test
+        @DisplayName("RuntimeException 상속 확인")
+        void RuntimeException_상속() {
+            GlobalException ex = new GlobalException(500, "서버 오류");
+
+            assertThat(ex).isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        @DisplayName("400 상태코드 케이스")
+        void status_400() {
+            GlobalException ex = new GlobalException(400, "잘못된 요청");
+
+            assertThat(ex.getStatus()).isEqualTo(400);
+            assertThat(ex.getMessage()).isEqualTo("잘못된 요청");
+        }
+
+        @Test
+        @DisplayName("403 상태코드 케이스")
+        void status_403() {
+            GlobalException ex = new GlobalException(403, "접근 권한 없음");
+
+            assertThat(ex.getStatus()).isEqualTo(403);
+            assertThat(ex.getMessage()).isEqualTo("접근 권한 없음");
+        }
+    }
+}

--- a/service-common/src/test/java/com/danburn/common/response/ApiResponseTest.java
+++ b/service-common/src/test/java/com/danburn/common/response/ApiResponseTest.java
@@ -1,0 +1,74 @@
+package com.danburn.common.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ApiResponse")
+class ApiResponseTest {
+
+    @Nested
+    @DisplayName("ok() 팩토리 메서드")
+    class Ok {
+
+        @Test
+        @DisplayName("status 200, message OK, data 반환")
+        void ok_반환값_검증() {
+            ApiResponse<String> response = ApiResponse.ok("hello");
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getMessage()).isEqualTo("OK");
+            assertThat(response.getData()).isEqualTo("hello");
+        }
+
+        @Test
+        @DisplayName("data가 null이어도 정상 생성")
+        void ok_data_null() {
+            ApiResponse<String> response = ApiResponse.ok(null);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getData()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("created() 팩토리 메서드")
+    class Created {
+
+        @Test
+        @DisplayName("status 201, message Created, data 반환")
+        void created_반환값_검증() {
+            ApiResponse<Integer> response = ApiResponse.created(42);
+
+            assertThat(response.getStatus()).isEqualTo(201);
+            assertThat(response.getMessage()).isEqualTo("Created");
+            assertThat(response.getData()).isEqualTo(42);
+        }
+    }
+
+    @Nested
+    @DisplayName("error() 팩토리 메서드")
+    class Error {
+
+        @Test
+        @DisplayName("지정한 status와 message 반환, data는 null")
+        void error_반환값_검증() {
+            ApiResponse<Void> response = ApiResponse.error(400, "잘못된 요청");
+
+            assertThat(response.getStatus()).isEqualTo(400);
+            assertThat(response.getMessage()).isEqualTo("잘못된 요청");
+            assertThat(response.getData()).isNull();
+        }
+
+        @Test
+        @DisplayName("500 서버 오류 케이스")
+        void error_서버_오류() {
+            ApiResponse<Void> response = ApiResponse.error(500, "Internal Server Error");
+
+            assertThat(response.getStatus()).isEqualTo(500);
+            assertThat(response.getMessage()).isEqualTo("Internal Server Error");
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/event/AiReportEventConsumerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/event/AiReportEventConsumerTest.java
@@ -1,0 +1,76 @@
+package com.danburn.congestion.event;
+
+import com.danburn.congestion.repository.AiReportRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class AiReportEventConsumerTest {
+
+    @Mock
+    private AiReportRepository aiReportRepository;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private AiReportEventConsumer consumer;
+
+    private AiReportEvent event() {
+        return new AiReportEvent(
+                "명동", "POI001", "붐빔", "분석 결과 메시지", "2026-04-01 14:00"
+        );
+    }
+
+    @Nested
+    @DisplayName("handleAiReport")
+    class HandleAiReport {
+
+        @Test
+        @DisplayName("신규 삽입(inserted=1) → Redis 캐싱")
+        void insertedAndCached() {
+            given(aiReportRepository.insertIfAbsent(any(), any(), any(), any(), any())).willReturn(1);
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+
+            consumer.handleAiReport(event());
+
+            then(aiReportRepository).should().insertIfAbsent(
+                    eq("명동"), eq("POI001"), eq("붐빔"), eq("분석 결과 메시지"), eq("2026-04-01 14:00")
+            );
+            then(valueOps).should().set(eq("ai-report:POI001"), anyString(), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("중복 메시지(inserted=0) → Redis 캐싱 안 함")
+        void duplicateIgnored() {
+            given(aiReportRepository.insertIfAbsent(any(), any(), any(), any(), any())).willReturn(0);
+
+            consumer.handleAiReport(event());
+
+            then(stringRedisTemplate).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/event/CongestionEventPublisherTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/event/CongestionEventPublisherTest.java
@@ -1,0 +1,65 @@
+package com.danburn.congestion.event;
+
+import com.danburn.congestion.config.rabbitmq.RabbitMqConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionEventPublisherTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private CongestionEventPublisher publisher;
+
+    @Nested
+    @DisplayName("publishBusyEvent")
+    class PublishBusyEvent {
+
+        @Test
+        @DisplayName("BUSY 이벤트 → 올바른 exchange/routingKey로 발행")
+        void publishBusy() {
+            CongestionBusyEvent event = new CongestionBusyEvent(
+                    "명동", "POI001", "붐빔", 34000, "2026-04-01 14:00"
+            );
+
+            publisher.publishBusyEvent(event);
+
+            then(rabbitTemplate).should().convertAndSend(
+                    RabbitMqConfig.EXCHANGE_NAME,
+                    RabbitMqConfig.BUSY_ROUTING_KEY,
+                    event
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("publishAnomalyEvent")
+    class PublishAnomalyEvent {
+
+        @Test
+        @DisplayName("ANOMALY 이벤트 → 올바른 exchange/routingKey로 발행")
+        void publishAnomaly() {
+            CongestionAnomalyEvent event = new CongestionAnomalyEvent(
+                    "명동", "POI001", "붐빔", 34000, 20000.0, 1.7, "2026-04-01 14:00"
+            );
+
+            publisher.publishAnomalyEvent(event);
+
+            then(rabbitTemplate).should().convertAndSend(
+                    RabbitMqConfig.EXCHANGE_NAME,
+                    RabbitMqConfig.ANOMALY_ROUTING_KEY,
+                    event
+            );
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/infra/SeoulAreaTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/infra/SeoulAreaTest.java
@@ -1,0 +1,58 @@
+package com.danburn.congestion.infra;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SeoulAreaTest {
+
+    @Nested
+    @DisplayName("getCode / getName")
+    class GetCodeName {
+
+        @Test
+        @DisplayName("각 enum 상수의 code·name 접근 가능")
+        void codeAndName() {
+            assertThat(SeoulArea.POI001.getCode()).isEqualTo("POI001");
+            assertThat(SeoulArea.POI001.getName()).isEqualTo("강남 MICE 관광특구");
+        }
+
+        @Test
+        @DisplayName("code와 enum name이 일치")
+        void codeMatchesEnumName() {
+            for (SeoulArea area : SeoulArea.values()) {
+                assertThat(area.getCode()).isEqualTo(area.name());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("all()")
+    class All {
+
+        @Test
+        @DisplayName("all() 목록이 비어있지 않음")
+        void allNotEmpty() {
+            List<SeoulArea> all = SeoulArea.all();
+            assertThat(all).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("all() 크기가 values() 크기와 동일")
+        void allSizeMatchesValues() {
+            assertThat(SeoulArea.all()).hasSize(SeoulArea.values().length);
+        }
+
+        @Test
+        @DisplayName("all()에 중복 없음")
+        void noDuplicates() {
+            List<SeoulArea> all = SeoulArea.all();
+            long distinct = all.stream().map(SeoulArea::getCode).distinct().count();
+            assertThat(distinct).isEqualTo(all.size());
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/notification/controller/NotificationControllerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,197 @@
+package com.danburn.congestion.notification.controller;
+
+import com.danburn.congestion.notification.config.VapidProperties;
+import com.danburn.congestion.notification.dto.SubscribeResult;
+import com.danburn.congestion.notification.exception.AlreadyNotBusyException;
+import com.danburn.congestion.notification.exception.AreaNotFoundException;
+import com.danburn.congestion.notification.service.SubscriptionService;
+import com.danburn.congestion.domain.CongestionLevel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = NotificationController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration.class
+        })
+@ActiveProfiles("test")
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private SubscriptionService subscriptionService;
+
+    @MockitoBean
+    private VapidProperties vapidProperties;
+
+    private static final String SUBSCRIBE_URL = "/api/v1/notifications/subscribe";
+    private static final String UNSUBSCRIBE_URL = "/api/v1/notifications/unsubscribe";
+    private static final String VAPID_KEY_URL = "/api/v1/notifications/vapid-public-key";
+
+    private String subscribeBody(String areaCode) {
+        return """
+                {
+                  "endpoint": "https://fcm.example.com/endpoint",
+                  "keys": { "p256dh": "someKey", "auth": "someAuth" },
+                  "areaCode": "%s"
+                }
+                """.formatted(areaCode);
+    }
+
+    @Nested
+    @DisplayName("POST /subscribe")
+    class Subscribe {
+
+        @Test
+        @DisplayName("새 구독 → 201 Created, status=SUBSCRIBED")
+        void newSubscription() throws Exception {
+            given(subscriptionService.subscribe(any()))
+                    .willReturn(new SubscribeResult("SUBSCRIBED", Instant.now().plusSeconds(43200)));
+
+            mockMvc.perform(post(SUBSCRIBE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(subscribeBody("POI001")))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201));
+        }
+
+        @Test
+        @DisplayName("기존 구독 갱신 → 200 OK, status=RENEWED")
+        void renewSubscription() throws Exception {
+            given(subscriptionService.subscribe(any()))
+                    .willReturn(new SubscribeResult("RENEWED", Instant.now().plusSeconds(43200)));
+
+            mockMvc.perform(post(SUBSCRIBE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(subscribeBody("POI001")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 areaCode → 404")
+        void areaNotFound() throws Exception {
+            given(subscriptionService.subscribe(any()))
+                    .willThrow(new AreaNotFoundException("POI999"));
+
+            mockMvc.perform(post(SUBSCRIBE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(subscribeBody("POI999")))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.status").value(404));
+        }
+
+        @Test
+        @DisplayName("이미 한가한 지역 → 409 Conflict")
+        void alreadyNotBusy() throws Exception {
+            given(subscriptionService.subscribe(any()))
+                    .willThrow(new AlreadyNotBusyException(CongestionLevel.RELAXED));
+
+            mockMvc.perform(post(SUBSCRIBE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(subscribeBody("POI001")))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value(409));
+        }
+
+        @Test
+        @DisplayName("유효성 검증 실패(endpoint 누락) → 400")
+        void validationFail() throws Exception {
+            String invalidBody = """
+                    {
+                      "keys": { "p256dh": "someKey", "auth": "someAuth" },
+                      "areaCode": "POI001"
+                    }
+                    """;
+
+            mockMvc.perform(post(SUBSCRIBE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidBody))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /unsubscribe")
+    class Unsubscribe {
+
+        @Test
+        @DisplayName("구독 취소 → 200 OK")
+        void unsubscribeSuccess() throws Exception {
+            willDoNothing().given(subscriptionService).unsubscribe(any(), any());
+
+            String body = """
+                    {
+                      "endpoint": "https://fcm.example.com/endpoint",
+                      "areaCode": "POI001"
+                    }
+                    """;
+
+            mockMvc.perform(post(UNSUBSCRIBE_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /vapid-public-key")
+    class VapidPublicKey {
+
+        @Test
+        @DisplayName("VAPID 키 설정됨 → 200 + Cache-Control 헤더")
+        void keyConfigured() throws Exception {
+            given(vapidProperties.publicKey()).willReturn("BExamplePublicKey");
+
+            mockMvc.perform(get(VAPID_KEY_URL))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Cache-Control", "public, max-age=86400"))
+                    .andExpect(jsonPath("$.data.publicKey").value("BExamplePublicKey"));
+        }
+
+        @Test
+        @DisplayName("VAPID 키 미설정(null) → 503 + Retry-After 헤더")
+        void keyNotConfigured() throws Exception {
+            given(vapidProperties.publicKey()).willReturn(null);
+
+            mockMvc.perform(get(VAPID_KEY_URL))
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(header().exists("Retry-After"))
+                    .andExpect(jsonPath("$.status").value(503));
+        }
+
+        @Test
+        @DisplayName("VAPID 키 빈 문자열 → 503")
+        void keyBlank() throws Exception {
+            given(vapidProperties.publicKey()).willReturn("");
+
+            mockMvc.perform(get(VAPID_KEY_URL))
+                    .andExpect(status().isServiceUnavailable());
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/notification/health/WebPushHealthIndicatorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/notification/health/WebPushHealthIndicatorTest.java
@@ -1,0 +1,51 @@
+package com.danburn.congestion.notification.health;
+
+import com.danburn.congestion.notification.service.WebPushSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WebPushHealthIndicatorTest {
+
+    @Mock
+    private WebPushSender webPushSender;
+
+    @InjectMocks
+    private WebPushHealthIndicator healthIndicator;
+
+    @Nested
+    @DisplayName("health")
+    class HealthCheck {
+
+        @Test
+        @DisplayName("WebPushSender 설정됨 → UP")
+        void upWhenConfigured() {
+            given(webPushSender.isConfigured()).willReturn(true);
+
+            Health health = healthIndicator.health();
+
+            assertThat(health.getStatus()).isEqualTo(Status.UP);
+        }
+
+        @Test
+        @DisplayName("WebPushSender 미설정 → DOWN + detail")
+        void downWhenNotConfigured() {
+            given(webPushSender.isConfigured()).willReturn(false);
+
+            Health health = healthIndicator.health();
+
+            assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+            assertThat(health.getDetails()).containsKey("reason");
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/notification/scheduler/ExpiredSubscriptionCleanupTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/notification/scheduler/ExpiredSubscriptionCleanupTest.java
@@ -1,0 +1,64 @@
+package com.danburn.congestion.notification.scheduler;
+
+import com.danburn.congestion.notification.repository.NotificationSubscriptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+
+@ExtendWith(MockitoExtension.class)
+class ExpiredSubscriptionCleanupTest {
+
+    @Mock
+    private NotificationSubscriptionRepository repository;
+
+    @InjectMocks
+    private ExpiredSubscriptionCleanup cleanup;
+
+    @Nested
+    @DisplayName("cleanupExpiredSubscriptions")
+    class CleanupExpiredSubscriptions {
+
+        @Test
+        @DisplayName("만료된 구독 정리 → deleteByExpiresAtBefore 호출")
+        void callsDeleteByExpiresAtBefore() {
+            given(repository.deleteByExpiresAtBefore(any(Instant.class))).willReturn(5);
+
+            cleanup.cleanupExpiredSubscriptions();
+
+            then(repository).should().deleteByExpiresAtBefore(any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("삭제 0건이어도 정상 완료")
+        void zeroDeletedIsOk() {
+            given(repository.deleteByExpiresAtBefore(any(Instant.class))).willReturn(0);
+
+            cleanup.cleanupExpiredSubscriptions();
+
+            then(repository).should().deleteByExpiresAtBefore(any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("예외 발생해도 전파되지 않음")
+        void exceptionIsSwallowed() {
+            given(repository.deleteByExpiresAtBefore(any(Instant.class)))
+                    .willThrow(new RuntimeException("DB 오류"));
+
+            // 예외가 전파되지 않아야 함
+            cleanup.cleanupExpiredSubscriptions();
+
+            then(repository).should().deleteByExpiresAtBefore(any(Instant.class));
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/notification/service/SubscriptionServiceTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/notification/service/SubscriptionServiceTest.java
@@ -1,0 +1,233 @@
+package com.danburn.congestion.notification.service;
+
+import com.danburn.congestion.domain.CongestionLevel;
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.notification.domain.NotificationSubscription;
+import com.danburn.congestion.notification.dto.SubscribeRequest;
+import com.danburn.congestion.notification.dto.SubscribeResult;
+import com.danburn.congestion.notification.exception.AlreadyNotBusyException;
+import com.danburn.congestion.notification.exception.AreaNotFoundException;
+import com.danburn.congestion.notification.repository.NotificationFiredMarkerRepository;
+import com.danburn.congestion.notification.repository.NotificationSubscriptionRepository;
+import com.danburn.congestion.repository.CongestionRedisRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionServiceTest {
+
+    @Mock
+    private NotificationSubscriptionRepository repository;
+
+    @Mock
+    private CongestionRedisRepository congestionRedisRepository;
+
+    @Mock
+    private WebPushSender webPushSender;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private NotificationFiredMarkerRepository firedMarkerRepository;
+
+    @InjectMocks
+    private SubscriptionService subscriptionService;
+
+    private CongestionRedisDto busyDto(String areaCode) {
+        return new CongestionRedisDto(
+                "명동", areaCode, "붐빔", "붐빔 메시지",
+                30000, 34000, "2026-04-01 14:00", List.of()
+        );
+    }
+
+    private SubscribeRequest subscribeRequest(String areaCode) {
+        return new SubscribeRequest(
+                "https://fcm.example.com/endpoint",
+                new SubscribeRequest.Keys("p256dhKey", "authKey"),
+                areaCode
+        );
+    }
+
+    private NotificationSubscription buildSub(String endpoint, String areaCode) {
+        return NotificationSubscription.builder()
+                .endpoint(endpoint)
+                .p256dhKey("p256dhKey")
+                .authKey("authKey")
+                .areaCode(areaCode)
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("subscribe")
+    class Subscribe {
+
+        @Test
+        @DisplayName("areaCode가 Redis에 없으면 AreaNotFoundException")
+        void areaNotFound() {
+            given(congestionRedisRepository.findByAreaCode("POI999")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> subscriptionService.subscribe(subscribeRequest("POI999")))
+                    .isInstanceOf(AreaNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("혼잡도가 BUSY가 아니면 AlreadyNotBusyException")
+        void notBusy() {
+            CongestionRedisDto normalDto = new CongestionRedisDto(
+                    "명동", "POI001", "보통", "메시지", 10000, 12000, "2026-04-01 14:00", List.of()
+            );
+            given(congestionRedisRepository.findByAreaCode("POI001")).willReturn(Optional.of(normalDto));
+
+            assertThatThrownBy(() -> subscriptionService.subscribe(subscribeRequest("POI001")))
+                    .isInstanceOf(AlreadyNotBusyException.class);
+        }
+
+        @Test
+        @DisplayName("최근 알림 발송된 경우 AlreadyNotBusyException")
+        void recentlyFired() {
+            given(congestionRedisRepository.findByAreaCode("POI001")).willReturn(Optional.of(busyDto("POI001")));
+            given(firedMarkerRepository.isRecentlyFired("POI001")).willReturn(true);
+
+            assertThatThrownBy(() -> subscriptionService.subscribe(subscribeRequest("POI001")))
+                    .isInstanceOf(AlreadyNotBusyException.class);
+        }
+
+        @Test
+        @DisplayName("기존 구독 없음 → 새 구독 SUBSCRIBED 반환")
+        void newSubscription() {
+            SubscribeRequest req = subscribeRequest("POI001");
+            NotificationSubscription saved = buildSub(req.endpoint(), "POI001");
+
+            given(congestionRedisRepository.findByAreaCode("POI001")).willReturn(Optional.of(busyDto("POI001")));
+            given(firedMarkerRepository.isRecentlyFired("POI001")).willReturn(false);
+            given(repository.findByEndpointAndAreaCode(req.endpoint(), "POI001")).willReturn(Optional.empty());
+            given(repository.save(any())).willReturn(saved);
+
+            SubscribeResult result = subscriptionService.subscribe(req);
+
+            assertThat(result.status()).isEqualTo("SUBSCRIBED");
+        }
+
+        @Test
+        @DisplayName("기존 구독 있음 → 갱신 RENEWED 반환")
+        void renewSubscription() {
+            SubscribeRequest req = subscribeRequest("POI001");
+            NotificationSubscription existing = buildSub(req.endpoint(), "POI001");
+
+            given(congestionRedisRepository.findByAreaCode("POI001")).willReturn(Optional.of(busyDto("POI001")));
+            given(firedMarkerRepository.isRecentlyFired("POI001")).willReturn(false);
+            given(repository.findByEndpointAndAreaCode(req.endpoint(), "POI001")).willReturn(Optional.of(existing));
+            given(repository.save(existing)).willReturn(existing);
+
+            SubscribeResult result = subscriptionService.subscribe(req);
+
+            assertThat(result.status()).isEqualTo("RENEWED");
+        }
+
+        @Test
+        @DisplayName("저장 중 DataIntegrityViolationException → 재조회 후 RENEWED 반환")
+        void conflictOnSave() {
+            SubscribeRequest req = subscribeRequest("POI001");
+            NotificationSubscription conflicted = buildSub(req.endpoint(), "POI001");
+
+            given(congestionRedisRepository.findByAreaCode("POI001")).willReturn(Optional.of(busyDto("POI001")));
+            given(firedMarkerRepository.isRecentlyFired("POI001")).willReturn(false);
+            given(repository.findByEndpointAndAreaCode(req.endpoint(), "POI001"))
+                    .willReturn(Optional.empty())
+                    .willReturn(Optional.of(conflicted));
+            given(repository.save(any()))
+                    .willThrow(new DataIntegrityViolationException("uk violation"))
+                    .willReturn(conflicted);
+
+            SubscribeResult result = subscriptionService.subscribe(req);
+
+            assertThat(result.status()).isEqualTo("RENEWED");
+        }
+    }
+
+    @Nested
+    @DisplayName("unsubscribe")
+    class Unsubscribe {
+
+        @Test
+        @DisplayName("구독 취소 → deleteByEndpointAndAreaCode 호출")
+        void unsubscribe() {
+            subscriptionService.unsubscribe("https://fcm.example.com/endpoint", "POI001");
+
+            then(repository).should().deleteByEndpointAndAreaCode("https://fcm.example.com/endpoint", "POI001");
+        }
+    }
+
+    @Nested
+    @DisplayName("notifyAndCleanup")
+    class NotifyAndCleanup {
+
+        @Test
+        @DisplayName("구독자 없으면 전송 없음")
+        void noSubscribers() {
+            given(repository.findByAreaCodeAndExpiresAtAfter(anyString(), any())).willReturn(List.of());
+
+            subscriptionService.notifyAndCleanup("POI001", "명동");
+
+            then(webPushSender).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("전송 성공(SUCCESS) → 구독 삭제")
+        void sendSuccess() {
+            NotificationSubscription sub = buildSub("https://fcm.example.com/ep", "POI001");
+            given(repository.findByAreaCodeAndExpiresAtAfter(anyString(), any())).willReturn(List.of(sub));
+            given(webPushSender.send(any(), anyString())).willReturn(WebPushSender.SendResult.SUCCESS);
+
+            subscriptionService.notifyAndCleanup("POI001", "명동");
+
+            then(repository).should().deleteByEndpointAndAreaCode(sub.getEndpoint(), sub.getAreaCode());
+        }
+
+        @Test
+        @DisplayName("전송 만료(DEAD) → 구독 삭제")
+        void sendDead() {
+            NotificationSubscription sub = buildSub("https://fcm.example.com/ep", "POI001");
+            given(repository.findByAreaCodeAndExpiresAtAfter(anyString(), any())).willReturn(List.of(sub));
+            given(webPushSender.send(any(), anyString())).willReturn(WebPushSender.SendResult.DEAD);
+
+            subscriptionService.notifyAndCleanup("POI001", "명동");
+
+            then(repository).should().deleteByEndpointAndAreaCode(sub.getEndpoint(), sub.getAreaCode());
+        }
+
+        @Test
+        @DisplayName("전송 재시도(RETRY) → 구독 삭제 안 함")
+        void sendRetry() {
+            NotificationSubscription sub = buildSub("https://fcm.example.com/ep", "POI001");
+            given(repository.findByAreaCodeAndExpiresAtAfter(anyString(), any())).willReturn(List.of(sub));
+            given(webPushSender.send(any(), anyString())).willReturn(WebPushSender.SendResult.RETRY);
+
+            subscriptionService.notifyAndCleanup("POI001", "명동");
+
+            then(repository).should(never()).deleteByEndpointAndAreaCode(anyString(), anyString());
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/notification/service/WebPushSenderTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/notification/service/WebPushSenderTest.java
@@ -1,0 +1,79 @@
+package com.danburn.congestion.notification.service;
+
+import com.danburn.congestion.notification.config.VapidProperties;
+import com.danburn.congestion.notification.domain.NotificationSubscription;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class WebPushSenderTest {
+
+    private NotificationSubscription buildSub() {
+        return NotificationSubscription.builder()
+                .endpoint("https://fcm.example.com/endpoint")
+                .p256dhKey("p256dhKey")
+                .authKey("authKey")
+                .areaCode("POI001")
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("init - VAPID 키 설정 여부에 따른 초기화")
+    class Init {
+
+        @Test
+        @DisplayName("VAPID 키 미설정 → configured=false")
+        void notConfiguredWhenKeysBlank() {
+            VapidProperties props = new VapidProperties(null, null, "mailto:test@example.com");
+            WebPushSender sender = new WebPushSender(props);
+            sender.init();
+
+            assertThat(sender.isConfigured()).isFalse();
+        }
+
+        @Test
+        @DisplayName("VAPID 키 빈 문자열 → configured=false")
+        void notConfiguredWhenKeysEmpty() {
+            VapidProperties props = new VapidProperties("", "", "mailto:test@example.com");
+            WebPushSender sender = new WebPushSender(props);
+            sender.init();
+
+            assertThat(sender.isConfigured()).isFalse();
+        }
+
+        @Test
+        @DisplayName("VAPID 키 잘못된 형식 → init 예외 삼켜서 configured=false")
+        void notConfiguredWhenKeysInvalid() {
+            VapidProperties props = new VapidProperties("invalidPublicKey", "invalidPrivateKey", "mailto:test@example.com");
+            WebPushSender sender = new WebPushSender(props);
+            sender.init();
+
+            assertThat(sender.isConfigured()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("send - PushService 미초기화 시")
+    class Send {
+
+        @Test
+        @DisplayName("PushService null이면 RETRY 반환")
+        void returnsRetryWhenNotInitialized() {
+            VapidProperties props = new VapidProperties(null, null, "mailto:test@example.com");
+            WebPushSender sender = new WebPushSender(props);
+            sender.init(); // configured=false, pushService=null
+
+            WebPushSender.SendResult result = sender.send(buildSub(), "{\"title\":\"test\"}");
+
+            assertThat(result).isEqualTo(WebPushSender.SendResult.RETRY);
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -1,0 +1,150 @@
+package com.danburn.congestion.repository;
+
+import com.danburn.congestion.dto.CongestionRedisDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionRedisRepositoryImplTest {
+
+    @Mock
+    private RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, CongestionRedisDto> valueOps;
+
+    @Mock
+    private Cursor<String> emptyCursor;
+
+    @InjectMocks
+    private CongestionRedisRepositoryImpl repository;
+
+    private CongestionRedisDto dto(String areaCode) {
+        return new CongestionRedisDto(
+                "명동", areaCode, "붐빔", "메시지",
+                30000, 34000, "2026-04-01 14:00", List.of()
+        );
+    }
+
+    @Nested
+    @DisplayName("save")
+    class Save {
+
+        @Test
+        @DisplayName("단건 저장 → opsForValue().set 호출")
+        void save() {
+            CongestionRedisDto item = dto("POI001");
+            given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+
+            repository.save(item);
+
+            then(valueOps).should().set(eq("congestion:dto:POI001"), eq(item), eq(15L), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("findByAreaCode")
+    class FindByAreaCode {
+
+        @Test
+        @DisplayName("캐시 히트 → Optional에 값 포함")
+        void hit() {
+            CongestionRedisDto item = dto("POI001");
+            given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get("congestion:dto:POI001")).willReturn(item);
+
+            Optional<CongestionRedisDto> result = repository.findByAreaCode("POI001");
+
+            assertThat(result).contains(item);
+        }
+
+        @Test
+        @DisplayName("캐시 미스 → Optional.empty")
+        void miss() {
+            given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get("congestion:dto:POI999")).willReturn(null);
+
+            Optional<CongestionRedisDto> result = repository.findByAreaCode("POI999");
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByAreaCodes")
+    class FindAllByAreaCodes {
+
+        @Test
+        @DisplayName("키 목록으로 multiGet 호출")
+        void multiGet() {
+            CongestionRedisDto item = dto("POI001");
+            given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.multiGet(anyList())).willReturn(List.of(item));
+
+            List<CongestionRedisDto> result = repository.findAllByAreaCodes(List.of("POI001"));
+
+            assertThat(result).containsExactly(item);
+        }
+
+        @Test
+        @DisplayName("multiGet null 반환 시 → size만큼 null로 채워진 목록")
+        void multiGetNull() {
+            given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.multiGet(anyList())).willReturn(null);
+
+            List<CongestionRedisDto> result = repository.findAllByAreaCodes(List.of("POI001", "POI002"));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0)).isNull();
+            assertThat(result.get(1)).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAll")
+    class FindAll {
+
+        @Test
+        @DisplayName("키 없으면 빈 목록")
+        void emptyWhenNoKeys() {
+            given(congestionRedisTemplate.scan(any(ScanOptions.class))).willReturn(emptyCursor);
+            given(emptyCursor.hasNext()).willReturn(false);
+
+            List<CongestionRedisDto> result = repository.findAll();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        @DisplayName("areaCode → key 변환 후 delete 호출")
+        void delete() {
+            repository.delete("POI001");
+
+            then(congestionRedisTemplate).should().delete("congestion:dto:POI001");
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -1,0 +1,150 @@
+package com.danburn.congestion.service;
+
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.event.CongestionAnomalyEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class AnomalyDetectorTest {
+
+    @Mock
+    private HourlyAvgCacheService hourlyAvgCacheService;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    @Mock
+    private Cursor<String> emptyCursor;
+
+    @InjectMocks
+    private AnomalyDetector anomalyDetector;
+
+    private CongestionRedisDto busyDto(String areaCode, int maxPeople) {
+        return new CongestionRedisDto(
+                "명동", areaCode, "붐빔", "메시지",
+                maxPeople - 2000, maxPeople,
+                "2026-04-01 14:00", List.of()
+        );
+    }
+
+    @Nested
+    @DisplayName("detectAnomalies")
+    class DetectAnomalies {
+
+        @Test
+        @DisplayName("빈 목록 → 빈 이벤트 목록")
+        void emptyInput() {
+            List<CongestionAnomalyEvent> result = anomalyDetector.detectAnomalies(List.of());
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("baseline 없음 → fallback anomaly=true, tryArm 성공 시 이벤트 발행")
+        void baselineMissingFallback() {
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).areaCode()).isEqualTo("POI001");
+            assertThat(events.get(0).ratio()).isNull();
+        }
+
+        @Test
+        @DisplayName("ratio >= threshold → anomaly 이벤트 발행")
+        void ratioExceedsThreshold() {
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            // avgMax=15000, ratio=2.0 >= 1.5
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.of(15000.0));
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).ratio()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("ratio < threshold → anomaly 없음")
+        void ratioBelowThreshold() {
+            CongestionRedisDto dto = busyDto("POI001", 15000);
+            // avgMax=20000, ratio=0.75 < 1.5
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.of(20000.0));
+
+            List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
+
+            assertThat(events).isEmpty();
+        }
+
+        @Test
+        @DisplayName("tryArm 실패(이미 armed) → 이벤트 미발행")
+        void tryArmFails() {
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(false);
+
+            List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
+
+            assertThat(events).isEmpty();
+        }
+
+        @Test
+        @DisplayName("maxPeopleCount null → 해당 dto 건너뜀")
+        void nullMaxPeopleCount() {
+            CongestionRedisDto dto = new CongestionRedisDto(
+                    "명동", "POI001", "붐빔", "메시지",
+                    null, null, "2026-04-01 14:00", List.of()
+            );
+
+            List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
+
+            assertThat(events).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("releaseArmedForNonBusy")
+    class ReleaseArmedForNonBusy {
+
+        @Test
+        @DisplayName("armed 키 없으면 Redis delete 미호출")
+        void noArmedKeys() {
+            given(stringRedisTemplate.scan(any(ScanOptions.class))).willReturn(emptyCursor);
+            given(emptyCursor.hasNext()).willReturn(false);
+
+            anomalyDetector.releaseArmedForNonBusy(List.of());
+
+            then(stringRedisTemplate).should().scan(any(ScanOptions.class));
+            then(stringRedisTemplate).shouldHaveNoMoreInteractions();
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/CongestionStateTrackerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/CongestionStateTrackerTest.java
@@ -1,0 +1,157 @@
+package com.danburn.congestion.service;
+
+import com.danburn.congestion.domain.Congestion;
+import com.danburn.congestion.domain.CongestionLevel;
+import com.danburn.congestion.dto.CongestionRedisDto;
+import com.danburn.congestion.repository.CongestionJpaRepository;
+import com.danburn.congestion.repository.CongestionRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionStateTrackerTest {
+
+    @Mock
+    private CongestionRedisRepository congestionRedisRepository;
+
+    @Mock
+    private CongestionJpaRepository congestionJpaRepository;
+
+    @InjectMocks
+    private CongestionStateTracker tracker;
+
+    private CongestionRedisDto dto(String areaCode, String level) {
+        return new CongestionRedisDto(
+                "테스트", areaCode, level, "메시지",
+                10000, 12000, "2026-04-01 14:00", List.of()
+        );
+    }
+
+    private Congestion entity(String areaCode, CongestionLevel level) {
+        return Congestion.builder()
+                .areaCode(areaCode)
+                .congestionLevel(level)
+                .congestionMessage("메시지")
+                .minPeopleCount(10000)
+                .maxPeopleCount(12000)
+                .forecast("[]")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("filterAreaCodesForAnalysis")
+    class FilterAreaCodesForAnalysis {
+
+        @Test
+        @DisplayName("BUSY 지역 없으면 빈 목록")
+        void noBusy() {
+            List<String> result = tracker.filterAreaCodesForAnalysis(List.of(dto("POI001", "보통")));
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이전 상태 없음(최초 감지) → BUSY 지역 포함")
+        void firstDetection() {
+            given(congestionRedisRepository.findAllByAreaCodes(List.of("POI001")))
+                    .willReturn(Arrays.asList((CongestionRedisDto) null));
+            given(congestionJpaRepository.findLatestByAreaCodes(List.of("POI001")))
+                    .willReturn(List.of());
+
+            List<String> result = tracker.filterAreaCodesForAnalysis(List.of(dto("POI001", "붐빔")));
+
+            assertThat(result).containsExactly("POI001");
+        }
+
+        @Test
+        @DisplayName("이전 non-BUSY → 상승 엣지 감지")
+        void risingEdge() {
+            given(congestionRedisRepository.findAllByAreaCodes(List.of("POI001")))
+                    .willReturn(List.of(dto("POI001", "보통")));
+
+            List<String> result = tracker.filterAreaCodesForAnalysis(List.of(dto("POI001", "붐빔")));
+
+            assertThat(result).containsExactly("POI001");
+        }
+
+        @Test
+        @DisplayName("이전 BUSY → 상승 엣지 없음")
+        void alreadyBusy() {
+            given(congestionRedisRepository.findAllByAreaCodes(List.of("POI001")))
+                    .willReturn(List.of(dto("POI001", "붐빔")));
+
+            List<String> result = tracker.filterAreaCodesForAnalysis(List.of(dto("POI001", "붐빔")));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Redis 미스 → DB 폴백으로 이전 상태 조회")
+        void redisMissFallbackToDb() {
+            given(congestionRedisRepository.findAllByAreaCodes(List.of("POI001")))
+                    .willReturn(Arrays.asList((CongestionRedisDto) null));
+            given(congestionJpaRepository.findLatestByAreaCodes(List.of("POI001")))
+                    .willReturn(List.of(entity("POI001", CongestionLevel.BUSY)));
+
+            List<String> result = tracker.filterAreaCodesForAnalysis(List.of(dto("POI001", "붐빔")));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("filterAreaCodesForRelaxedNotification")
+    class FilterAreaCodesForRelaxedNotification {
+
+        @Test
+        @DisplayName("non-BUSY 지역 없으면 빈 목록")
+        void allBusy() {
+            List<String> result = tracker.filterAreaCodesForRelaxedNotification(List.of(dto("POI001", "붐빔")));
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이전 BUSY → 하강 엣지 감지")
+        void fallingEdge() {
+            given(congestionRedisRepository.findAllByAreaCodes(List.of("POI001")))
+                    .willReturn(List.of(dto("POI001", "붐빔")));
+
+            List<String> result = tracker.filterAreaCodesForRelaxedNotification(List.of(dto("POI001", "보통")));
+
+            assertThat(result).containsExactly("POI001");
+        }
+
+        @Test
+        @DisplayName("이전 non-BUSY → 하강 엣지 없음")
+        void alreadyNotBusy() {
+            given(congestionRedisRepository.findAllByAreaCodes(List.of("POI001")))
+                    .willReturn(List.of(dto("POI001", "보통")));
+
+            List<String> result = tracker.filterAreaCodesForRelaxedNotification(List.of(dto("POI001", "여유")));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("congestionLevel null → 해당 dto 건너뜀")
+        void nullLevel() {
+            CongestionRedisDto nullLevelDto = new CongestionRedisDto(
+                    "명동", "POI001", null, "메시지", 10000, 12000, "2026-04-01 14:00", List.of()
+            );
+
+            List<String> result = tracker.filterAreaCodesForRelaxedNotification(List.of(nullLevelDto));
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/HourlyAvgCacheServiceTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/HourlyAvgCacheServiceTest.java
@@ -1,0 +1,125 @@
+package com.danburn.congestion.service;
+
+import com.danburn.congestion.dto.response.CongestionTrendResponse;
+import com.danburn.congestion.dto.response.CongestionTrendResponse.TrendData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class HourlyAvgCacheServiceTest {
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private CongestionAnalysisService analysisService;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    @InjectMocks
+    private HourlyAvgCacheService hourlyAvgCacheService;
+
+    private CongestionTrendResponse trendWith(int hour, double avgMax) {
+        TrendData data = new TrendData(hour, String.valueOf(hour) + "시", "보통", 10000.0, avgMax, 5L);
+        return new CongestionTrendResponse("POI001", "명동", List.of(data));
+    }
+
+    @Nested
+    @DisplayName("getAvgMax")
+    class GetAvgMax {
+
+        @Test
+        @DisplayName("Redis 캐시 히트 → DB 미조회")
+        void cacheHit() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get("congestion:hourly-avg:POI001:14")).willReturn("20000.0");
+
+            Optional<Double> result = hourlyAvgCacheService.getAvgMax("POI001", 14);
+
+            assertThat(result).contains(20000.0);
+            then(analysisService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("Redis 미스 + DB 데이터 있음 → DB 조회 후 캐시 저장")
+        void cacheMissDbHit() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get(anyString())).willReturn(null);
+            given(analysisService.getHourlyTrend("POI001", 7)).willReturn(trendWith(14, 18000.0));
+
+            Optional<Double> result = hourlyAvgCacheService.getAvgMax("POI001", 14);
+
+            assertThat(result).contains(18000.0);
+            then(valueOps).should().set(eq("congestion:hourly-avg:POI001:14"), eq("18000.0"), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("Redis 미스 + DB 해당 시간 없음 → Optional.empty")
+        void cacheMissDbMissHour() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get(anyString())).willReturn(null);
+            given(analysisService.getHourlyTrend("POI001", 7)).willReturn(trendWith(10, 18000.0));
+
+            Optional<Double> result = hourlyAvgCacheService.getAvgMax("POI001", 14);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Redis 캐시 파싱 오류 → DB 폴백")
+        void cacheParseError() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get(anyString())).willReturn("not-a-number");
+            given(analysisService.getHourlyTrend("POI001", 7)).willReturn(trendWith(14, 15000.0));
+
+            Optional<Double> result = hourlyAvgCacheService.getAvgMax("POI001", 14);
+
+            assertThat(result).contains(15000.0);
+        }
+
+        @Test
+        @DisplayName("DB 조회 예외 → Optional.empty")
+        void dbException() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get(anyString())).willReturn(null);
+            given(analysisService.getHourlyTrend("POI001", 7)).willThrow(new RuntimeException("DB 오류"));
+
+            Optional<Double> result = hourlyAvgCacheService.getAvgMax("POI001", 14);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("avgMaxPeople가 0이면 결과에서 제외")
+        void zeroAvgExcluded() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.get(anyString())).willReturn(null);
+            TrendData data = new TrendData(14, "14시", "보통", 0.0, 0.0, 3L);
+            CongestionTrendResponse trend = new CongestionTrendResponse("POI001", "명동", List.of(data));
+            given(analysisService.getHourlyTrend("POI001", 7)).willReturn(trend);
+
+            Optional<Double> result = hourlyAvgCacheService.getAvgMax("POI001", 14);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/service-gateway/src/test/java/com/danburn/gateway/config/CorsPropertiesTest.java
+++ b/service-gateway/src/test/java/com/danburn/gateway/config/CorsPropertiesTest.java
@@ -1,0 +1,85 @@
+package com.danburn.gateway.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CorsProperties")
+class CorsPropertiesTest {
+
+    @Nested
+    @DisplayName("allowedOrigins")
+    class AllowedOrigins {
+
+        @Test
+        @DisplayName("setAllowedOrigins 후 getAllowedOrigins 반환 일치")
+        void origins_설정_조회() {
+            CorsProperties props = new CorsProperties();
+            List<String> origins = List.of("https://example.com", "https://api.example.com");
+
+            props.setAllowedOrigins(origins);
+
+            assertThat(props.getAllowedOrigins()).containsExactlyElementsOf(origins);
+        }
+
+        @Test
+        @DisplayName("설정 전 기본값은 null")
+        void origins_기본값_null() {
+            CorsProperties props = new CorsProperties();
+
+            assertThat(props.getAllowedOrigins()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("allowedMethods")
+    class AllowedMethods {
+
+        @Test
+        @DisplayName("setAllowedMethods 후 getAllowedMethods 반환 일치")
+        void methods_설정_조회() {
+            CorsProperties props = new CorsProperties();
+            List<String> methods = List.of("GET", "POST", "PUT", "DELETE");
+
+            props.setAllowedMethods(methods);
+
+            assertThat(props.getAllowedMethods()).containsExactlyElementsOf(methods);
+        }
+
+        @Test
+        @DisplayName("설정 전 기본값은 null")
+        void methods_기본값_null() {
+            CorsProperties props = new CorsProperties();
+
+            assertThat(props.getAllowedMethods()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("allowedHeaders")
+    class AllowedHeaders {
+
+        @Test
+        @DisplayName("setAllowedHeaders 후 getAllowedHeaders 반환 일치")
+        void headers_설정_조회() {
+            CorsProperties props = new CorsProperties();
+            List<String> headers = List.of("Content-Type", "Authorization");
+
+            props.setAllowedHeaders(headers);
+
+            assertThat(props.getAllowedHeaders()).containsExactlyElementsOf(headers);
+        }
+
+        @Test
+        @DisplayName("설정 전 기본값은 null")
+        void headers_기본값_null() {
+            CorsProperties props = new CorsProperties();
+
+            assertThat(props.getAllowedHeaders()).isNull();
+        }
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/controller/AlternativeLocationControllerTest.java
+++ b/service-map/src/test/java/com/danburn/map/controller/AlternativeLocationControllerTest.java
@@ -1,0 +1,104 @@
+package com.danburn.map.controller;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.map.dto.response.AlternativeLocationResponse;
+import com.danburn.map.service.AlternativeLocationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AlternativeLocationController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration.class
+        })
+@ActiveProfiles("test")
+class AlternativeLocationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AlternativeLocationService alternativeLocationService;
+
+    private AlternativeLocationResponse createResponse(String areaCode, String locationName, String congestionLevel) {
+        return new AlternativeLocationResponse(areaCode, locationName, 37.5759, 126.9769, 1, congestionLevel);
+    }
+
+    @Test
+    @DisplayName("GET /api/map/alternative-location → 정상 조회 성공")
+    void getAlternativeLocation_success() throws Exception {
+        given(alternativeLocationService.getAlternativeLocations(anyString()))
+                .willReturn(List.of(
+                        createResponse("ALT001", "북촌", "여유"),
+                        createResponse("ALT002", "인사동", "보통")
+                ));
+
+        mockMvc.perform(get("/api/map/alternative-location")
+                        .param("areaCode", "POI009"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].areaCode").value("ALT001"))
+                .andExpect(jsonPath("$.data[0].congestionLevel").value("여유"));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/alternative-location → 결과 없을 때 빈 배열 반환")
+    void getAlternativeLocation_empty() throws Exception {
+        given(alternativeLocationService.getAlternativeLocations(anyString()))
+                .willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/map/alternative-location")
+                        .param("areaCode", "POI009"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/alternative-location → 존재하지 않는 areaCode 404")
+    void getAlternativeLocation_invalidAreaCode_notFound() throws Exception {
+        willThrow(new GlobalException(404, "존재하지 않는 지역 코드입니다: UNKNOWN"))
+                .given(alternativeLocationService).getAlternativeLocations("UNKNOWN");
+
+        mockMvc.perform(get("/api/map/alternative-location")
+                        .param("areaCode", "UNKNOWN"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/alternative-location → 503 서비스 응답 지연")
+    void getAlternativeLocation_serviceUnavailable() throws Exception {
+        willThrow(new GlobalException(503, "서비스 응답 지연으로 요청을 처리할 수 없습니다."))
+                .given(alternativeLocationService).getAlternativeLocations(anyString());
+
+        mockMvc.perform(get("/api/map/alternative-location")
+                        .param("areaCode", "POI009"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.status").value(503));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/alternative-location → areaCode 파라미터 누락 시 500 (catch-all handler)")
+    void getAlternativeLocation_missingParam_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/alternative-location"))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/controller/CultureEventControllerTest.java
+++ b/service-map/src/test/java/com/danburn/map/controller/CultureEventControllerTest.java
@@ -1,0 +1,127 @@
+package com.danburn.map.controller;
+
+import com.danburn.map.dto.response.CultureEventResponse;
+import com.danburn.map.service.CultureEventService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CultureEventController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration.class
+        })
+@ActiveProfiles("test")
+class CultureEventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CultureEventService cultureEventService;
+
+    private CultureEventResponse createResponse(String title) {
+        return new CultureEventResponse(
+                title, "광화문", "전시/미술",
+                LocalDate.of(2025, 7, 1), LocalDate.of(2025, 12, 31),
+                "무료", "https://link", "https://img",
+                37.5759, 126.9769
+        );
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → 정상 조회 성공")
+    void getCultureEvents_success() throws Exception {
+        given(cultureEventService.getCultureEvents(anyDouble(), anyDouble()))
+                .willReturn(List.of(createResponse("서울 전시회"), createResponse("마포 축제")));
+
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].title").value("서울 전시회"));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → 결과 없을 때 빈 배열 반환")
+    void getCultureEvents_empty() throws Exception {
+        given(cultureEventService.getCultureEvents(anyDouble(), anyDouble()))
+                .willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → 위도 범위 초과 (38.9 초과) 400")
+    void getCultureEvents_latitudeOverMax_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "39.0")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → 위도 범위 미달 (33.0 미만) 400")
+    void getCultureEvents_latitudeUnderMin_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "32.9")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → 경도 범위 초과 (132.0 초과) 400")
+    void getCultureEvents_longitudeOverMax_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "132.1"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → 경도 범위 미달 (124.5 미만) 400")
+    void getCultureEvents_longitudeUnderMin_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "37.5759")
+                        .param("longitude", "124.4"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → latitude 파라미터 누락 시 500 (catch-all handler)")
+    void getCultureEvents_missingLatitude_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("longitude", "126.9769"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("GET /api/map/culture-events → longitude 파라미터 누락 시 500 (catch-all handler)")
+    void getCultureEvents_missingLongitude_badRequest() throws Exception {
+        mockMvc.perform(get("/api/map/culture-events")
+                        .param("latitude", "37.5759"))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/scheduler/EventSyncSchedulerTest.java
+++ b/service-map/src/test/java/com/danburn/map/scheduler/EventSyncSchedulerTest.java
@@ -1,0 +1,41 @@
+package com.danburn.map.scheduler;
+
+import com.danburn.map.service.EventService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+class EventSyncSchedulerTest {
+
+    @Mock
+    private EventService eventService;
+
+    @InjectMocks
+    private EventSyncScheduler eventSyncScheduler;
+
+    @Test
+    @DisplayName("syncCulturalEvents - EventService.fetchAndSyncEvents 1회 호출")
+    void syncCulturalEvents_callsFetchAndSyncOnce() {
+        eventSyncScheduler.syncCulturalEvents();
+
+        then(eventService).should().fetchAndSyncEvents();
+    }
+
+    @Test
+    @DisplayName("syncCulturalEvents - EventService 예외 발생 시 전파됨")
+    void syncCulturalEvents_exceptionPropagated() {
+        willThrow(new RuntimeException("동기화 실패"))
+                .given(eventService).fetchAndSyncEvents();
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> eventSyncScheduler.syncCulturalEvents())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("동기화 실패");
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/service/AlternativeLocationServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/AlternativeLocationServiceTest.java
@@ -1,0 +1,184 @@
+package com.danburn.map.service;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.map.domain.AlternativeLocation;
+import com.danburn.map.domain.Location;
+import com.danburn.map.dto.response.AlternativeLocationResponse;
+import com.danburn.map.infra.CongestionApiClient;
+import com.danburn.map.repository.AlternativeLocationJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class AlternativeLocationServiceTest {
+
+    @Mock
+    private LocationCodeMapper locationCodeMapper;
+
+    @Mock
+    private AlternativeLocationJpaRepository alternativeLocationJpaRepository;
+
+    @Mock
+    private CongestionApiClient congestionApiClient;
+
+    @InjectMocks
+    private AlternativeLocationService alternativeLocationService;
+
+    private static final String AREA_CODE = "POI009";
+    private static final Long LOCATION_ID = 1L;
+
+    private Location buildLocation(String areaCode, String name, double lat, double lon) {
+        return Location.builder()
+                .apiAreaCode(areaCode)
+                .locationName(name)
+                .latitude(lat)
+                .longitude(lon)
+                .category("관광특구")
+                .build();
+    }
+
+    private AlternativeLocation buildAlternative(Location main, Location alt, Integer priority) {
+        return AlternativeLocation.builder()
+                .location(main)
+                .alternativeLocation(alt)
+                .priority(priority)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(locationCodeMapper.getLocationIdByAreaCode(AREA_CODE)).thenReturn(Optional.of(LOCATION_ID));
+    }
+
+    @Nested
+    @DisplayName("getAlternativeLocations - 정상 조회")
+    class NormalCases {
+
+        @Test
+        @DisplayName("혼잡도 포함 대체지역 목록 반환")
+        void returnsListWithCongestionLevel() {
+            Location main = buildLocation(AREA_CODE, "광화문", 37.5759, 126.9769);
+            Location alt1 = buildLocation("ALT001", "북촌", 37.58, 126.98);
+            AlternativeLocation altLoc = buildAlternative(main, alt1, 1);
+
+            given(alternativeLocationJpaRepository.findAlternativeLocationIdOrderByPriority(LOCATION_ID))
+                    .willReturn(List.of(altLoc));
+            given(congestionApiClient.getCongestionLevel("ALT001"))
+                    .willReturn(Mono.just("여유"));
+
+            List<AlternativeLocationResponse> result = alternativeLocationService.getAlternativeLocations(AREA_CODE);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).areaCode()).isEqualTo("ALT001");
+            assertThat(result.get(0).congestionLevel()).isEqualTo("여유");
+            assertThat(result.get(0).priority()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("혼잡도 조회 실패 시 null로 포함 반환")
+        void congestionApiEmpty_returnsNullCongestionLevel() {
+            Location main = buildLocation(AREA_CODE, "광화문", 37.5759, 126.9769);
+            Location alt1 = buildLocation("ALT001", "북촌", 37.58, 126.98);
+            AlternativeLocation altLoc = buildAlternative(main, alt1, 1);
+
+            given(alternativeLocationJpaRepository.findAlternativeLocationIdOrderByPriority(LOCATION_ID))
+                    .willReturn(List.of(altLoc));
+            given(congestionApiClient.getCongestionLevel("ALT001"))
+                    .willReturn(Mono.empty());
+
+            List<AlternativeLocationResponse> result = alternativeLocationService.getAlternativeLocations(AREA_CODE);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).congestionLevel()).isNull();
+        }
+
+        @Test
+        @DisplayName("혼잡도 기준으로 정렬 - 여유 < 보통 < 약간 붐빔 < 붐빔")
+        void sortsByCongestionLevelOrder() {
+            Location main = buildLocation(AREA_CODE, "광화문", 37.5759, 126.9769);
+            Location alt1 = buildLocation("ALT001", "북촌", 37.58, 126.98);
+            Location alt2 = buildLocation("ALT002", "인사동", 37.57, 126.97);
+            Location alt3 = buildLocation("ALT003", "명동", 37.56, 126.96);
+
+            given(alternativeLocationJpaRepository.findAlternativeLocationIdOrderByPriority(LOCATION_ID))
+                    .willReturn(List.of(
+                            buildAlternative(main, alt1, 1),
+                            buildAlternative(main, alt2, 2),
+                            buildAlternative(main, alt3, 3)
+                    ));
+            given(congestionApiClient.getCongestionLevel("ALT001")).willReturn(Mono.just("붐빔"));
+            given(congestionApiClient.getCongestionLevel("ALT002")).willReturn(Mono.just("여유"));
+            given(congestionApiClient.getCongestionLevel("ALT003")).willReturn(Mono.just("보통"));
+
+            List<AlternativeLocationResponse> result = alternativeLocationService.getAlternativeLocations(AREA_CODE);
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).congestionLevel()).isEqualTo("여유");
+            assertThat(result.get(1).congestionLevel()).isEqualTo("보통");
+            assertThat(result.get(2).congestionLevel()).isEqualTo("붐빔");
+        }
+
+        @Test
+        @DisplayName("혼잡도 null인 항목 - 정렬 마지막")
+        void nullCongestion_sortedLast() {
+            Location main = buildLocation(AREA_CODE, "광화문", 37.5759, 126.9769);
+            Location alt1 = buildLocation("ALT001", "북촌", 37.58, 126.98);
+            Location alt2 = buildLocation("ALT002", "인사동", 37.57, 126.97);
+
+            given(alternativeLocationJpaRepository.findAlternativeLocationIdOrderByPriority(LOCATION_ID))
+                    .willReturn(List.of(
+                            buildAlternative(main, alt1, 1),
+                            buildAlternative(main, alt2, 2)
+                    ));
+            given(congestionApiClient.getCongestionLevel("ALT001")).willReturn(Mono.empty());
+            given(congestionApiClient.getCongestionLevel("ALT002")).willReturn(Mono.just("여유"));
+
+            List<AlternativeLocationResponse> result = alternativeLocationService.getAlternativeLocations(AREA_CODE);
+
+            assertThat(result.get(0).areaCode()).isEqualTo("ALT002");
+            assertThat(result.get(1).areaCode()).isEqualTo("ALT001");
+        }
+
+        @Test
+        @DisplayName("대체지역 없음 - 빈 리스트 반환")
+        void noAlternatives_returnsEmptyList() {
+            given(alternativeLocationJpaRepository.findAlternativeLocationIdOrderByPriority(LOCATION_ID))
+                    .willReturn(List.of());
+
+            List<AlternativeLocationResponse> result = alternativeLocationService.getAlternativeLocations(AREA_CODE);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getAlternativeLocations - 예외")
+    class ExceptionCases {
+
+        @Test
+        @DisplayName("존재하지 않는 areaCode - GlobalException 404")
+        void unknownAreaCode_throwsGlobalException404() {
+            given(locationCodeMapper.getLocationIdByAreaCode("INVALID"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alternativeLocationService.getAlternativeLocations("INVALID"))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessageContaining("INVALID");
+        }
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/service/CultureEventServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/CultureEventServiceTest.java
@@ -1,0 +1,108 @@
+package com.danburn.map.service;
+
+import com.danburn.map.domain.Event;
+import com.danburn.map.dto.response.CultureEventResponse;
+import com.danburn.map.repository.EventJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class CultureEventServiceTest {
+
+    @Mock
+    private EventJpaRepository eventJpaRepository;
+
+    @InjectMocks
+    private CultureEventService cultureEventService;
+
+    private static final double LAT = 37.5759;
+    private static final double LON = 126.9769;
+    private static final double RADIUS = 1000.0;
+
+    private Event buildEvent(String title, String place) {
+        return Event.builder()
+                .eventTitle(title)
+                .place(place)
+                .codename("전시/미술")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .endDate(LocalDate.of(2025, 12, 31))
+                .useFee("무료")
+                .orgLink("https://link")
+                .mainImg("https://img")
+                .latitude(LAT)
+                .longitude(LON)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getCultureEvents")
+    class GetCultureEvents {
+
+        @Test
+        @DisplayName("반경 내 행사 존재 - 행사 목록 반환")
+        void eventsWithinRadius_returnsList() {
+            given(eventJpaRepository.findEventsWithinRadius(LAT, LON, RADIUS))
+                    .willReturn(List.of(buildEvent("서울 전시회", "광화문"), buildEvent("마포 축제", "홍대")));
+
+            List<CultureEventResponse> result = cultureEventService.getCultureEvents(LAT, LON);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).title()).isEqualTo("서울 전시회");
+            assertThat(result.get(1).title()).isEqualTo("마포 축제");
+        }
+
+        @Test
+        @DisplayName("반경 내 행사 없음 - 빈 리스트 반환")
+        void noEventsWithinRadius_returnsEmptyList() {
+            given(eventJpaRepository.findEventsWithinRadius(LAT, LON, RADIUS))
+                    .willReturn(List.of());
+
+            List<CultureEventResponse> result = cultureEventService.getCultureEvents(LAT, LON);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("반환된 Event → CultureEventResponse 필드 매핑 검증")
+        void eventToResponse_fieldMapping() {
+            Event event = buildEvent("테스트 행사", "테스트 장소");
+            given(eventJpaRepository.findEventsWithinRadius(LAT, LON, RADIUS))
+                    .willReturn(List.of(event));
+
+            List<CultureEventResponse> result = cultureEventService.getCultureEvents(LAT, LON);
+
+            CultureEventResponse r = result.get(0);
+            assertThat(r.title()).isEqualTo("테스트 행사");
+            assertThat(r.place()).isEqualTo("테스트 장소");
+            assertThat(r.codename()).isEqualTo("전시/미술");
+            assertThat(r.startDate()).isEqualTo(LocalDate.of(2025, 1, 1));
+            assertThat(r.endDate()).isEqualTo(LocalDate.of(2025, 12, 31));
+            assertThat(r.useFee()).isEqualTo("무료");
+            assertThat(r.latitude()).isEqualTo(LAT);
+            assertThat(r.longitude()).isEqualTo(LON);
+        }
+
+        @Test
+        @DisplayName("정확히 1000m 반경으로 findEventsWithinRadius 호출")
+        void callsRepositoryWithCorrectRadius() {
+            given(eventJpaRepository.findEventsWithinRadius(LAT, LON, RADIUS))
+                    .willReturn(List.of());
+
+            cultureEventService.getCultureEvents(LAT, LON);
+
+            then(eventJpaRepository).should().findEventsWithinRadius(LAT, LON, RADIUS);
+        }
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/service/EventServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/EventServiceTest.java
@@ -1,0 +1,153 @@
+package com.danburn.map.service;
+
+import com.danburn.map.domain.Event;
+import com.danburn.map.dto.response.SeoulCultureInfoApiResponse;
+import com.danburn.map.infra.SeoulCultureInfoApiClient;
+import com.danburn.map.repository.EventJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock
+    private SeoulCultureInfoApiClient apiClient;
+
+    @Mock
+    private EventUpsertService eventUpsertService;
+
+    @Mock
+    private EventJpaRepository eventJpaRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private SeoulCultureInfoApiResponse buildResponse(int totalCount, List<SeoulCultureInfoApiResponse.Row> rows) {
+        return new SeoulCultureInfoApiResponse(
+                new SeoulCultureInfoApiResponse.CulturalEventInfo(totalCount, rows)
+        );
+    }
+
+    private SeoulCultureInfoApiResponse.Row buildRow(String title) {
+        return new SeoulCultureInfoApiResponse.Row(
+                title, "2025-07-01", "2025-12-31", "전시", "광화문",
+                "무료", "02-1234-5678", "설명", "https://link", "https://img",
+                "37.5759", "126.9769"
+        );
+    }
+
+    @Nested
+    @DisplayName("fetchAndSyncEvents - 정상 흐름")
+    class NormalFlow {
+
+        @Test
+        @DisplayName("단일 배치(1000건 미만) 응답 - upsert 1회 호출 후 deleteByEndDateBefore")
+        void singleBatch_upsertOnce_thenDelete() {
+            given(eventJpaRepository.findAll()).willReturn(List.of());
+            given(apiClient.fetchEvents(any()))
+                    .willReturn(buildResponse(500, List.of(buildRow("행사1"))));
+
+            eventService.fetchAndSyncEvents();
+
+            then(eventUpsertService).should(times(1)).upsertEventBatch(anyList(), any(), anyMap());
+            then(eventJpaRepository).should().deleteByEndDateBefore(any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("null 응답 - upsert 호출 안 함, deleteByEndDateBefore는 호출")
+        void nullResponse_noUpsert_deletesCalled() {
+            given(eventJpaRepository.findAll()).willReturn(List.of());
+            given(apiClient.fetchEvents(any())).willReturn(null);
+
+            eventService.fetchAndSyncEvents();
+
+            then(eventUpsertService).should(never()).upsertEventBatch(anyList(), any(), anyMap());
+            then(eventJpaRepository).should().deleteByEndDateBefore(any(LocalDate.class));
+        }
+
+        @Test
+        @DisplayName("응답 row가 null인 경우 - upsert 호출 안 함")
+        void nullRows_noUpsert() {
+            given(eventJpaRepository.findAll()).willReturn(List.of());
+            given(apiClient.fetchEvents(any()))
+                    .willReturn(new SeoulCultureInfoApiResponse(
+                            new SeoulCultureInfoApiResponse.CulturalEventInfo(0, null)
+                    ));
+
+            eventService.fetchAndSyncEvents();
+
+            then(eventUpsertService).should(never()).upsertEventBatch(anyList(), any(), anyMap());
+        }
+
+        @Test
+        @DisplayName("기존 이벤트가 있을 때 - existingEventMap 초기화 후 upsert 전달")
+        void existingEvents_buildMapFromDb() {
+            Event existing = Event.builder()
+                    .eventTitle("기존 행사").place("홍대").startDate(LocalDate.of(2025, 1, 1))
+                    .endDate(LocalDate.of(2025, 12, 31)).build();
+            given(eventJpaRepository.findAll()).willReturn(List.of(existing));
+            given(apiClient.fetchEvents(any()))
+                    .willReturn(buildResponse(1, List.of(buildRow("신규 행사"))));
+
+            eventService.fetchAndSyncEvents();
+
+            then(eventUpsertService).should().upsertEventBatch(anyList(), any(), anyMap());
+        }
+
+        @Test
+        @DisplayName("첫 배치 응답에서 listTotalCount로 maxBatches 재계산")
+        void firstBatchTotalCount_recalculatesMaxBatches() {
+            // totalCount=2000 → 2 batches
+            List<SeoulCultureInfoApiResponse.Row> fullBatch = List.of(buildRow("행사1"));
+            // First response: 2000 total, 1000 rows (full)
+            SeoulCultureInfoApiResponse firstResponse = new SeoulCultureInfoApiResponse(
+                    new SeoulCultureInfoApiResponse.CulturalEventInfo(2000,
+                            java.util.Collections.nCopies(1000, buildRow("행사")))
+            );
+            SeoulCultureInfoApiResponse secondResponse = buildResponse(2000, fullBatch);
+
+            given(eventJpaRepository.findAll()).willReturn(List.of());
+            given(apiClient.fetchEvents(any()))
+                    .willReturn(firstResponse)
+                    .willReturn(secondResponse);
+
+            eventService.fetchAndSyncEvents();
+
+            then(eventUpsertService).should(times(2)).upsertEventBatch(anyList(), any(), anyMap());
+        }
+    }
+
+    @Nested
+    @DisplayName("fetchAndSyncEvents - 예외 처리")
+    class ExceptionHandling {
+
+        @Test
+        @DisplayName("API 호출 예외 - 예외 로그 후 다음 배치 진행, deleteByEndDateBefore 호출")
+        void apiException_logsAndContinues_deletesCalled() {
+            given(eventJpaRepository.findAll()).willReturn(List.of());
+            given(apiClient.fetchEvents(any())).willThrow(new RuntimeException("API 오류"));
+
+            eventService.fetchAndSyncEvents();
+
+            then(eventUpsertService).should(never()).upsertEventBatch(anyList(), any(), anyMap());
+            then(eventJpaRepository).should().deleteByEndDateBefore(any(LocalDate.class));
+        }
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/service/EventUpsertServiceTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/EventUpsertServiceTest.java
@@ -1,0 +1,236 @@
+package com.danburn.map.service;
+
+import com.danburn.map.domain.Event;
+import com.danburn.map.dto.response.SeoulCultureInfoApiResponse;
+import com.danburn.map.repository.EventJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class EventUpsertServiceTest {
+
+    @Mock
+    private EventJpaRepository eventJpaRepository;
+
+    @InjectMocks
+    private EventUpsertService eventUpsertService;
+
+    private static final LocalDate TODAY = LocalDate.of(2025, 6, 1);
+
+    private SeoulCultureInfoApiResponse.Row buildRow(String title, String place, String start, String end,
+                                                      String lat, String lon) {
+        return new SeoulCultureInfoApiResponse.Row(
+                title, start, end, "전시/미술", place,
+                "무료", "02-1234-5678", "설명", "https://link", "https://img",
+                lat, lon
+        );
+    }
+
+    @Nested
+    @DisplayName("신규 행사 삽입")
+    class Insert {
+
+        @Test
+        @DisplayName("existingEventMap에 없는 행사 - 신규 저장")
+        void newEvent_savedToRepository() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("새 행사", "광화문", "2025-07-01", "2025-07-31", "37.5759", "126.9769");
+            Map<String, Event> existingMap = new HashMap<>();
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+            then(eventJpaRepository).should().save(captor.capture());
+            Event saved = captor.getValue();
+            assertThat(saved.getEventTitle()).isEqualTo("새 행사");
+            assertThat(saved.getLatitude()).isEqualTo(37.5759);
+        }
+
+        @Test
+        @DisplayName("신규 행사 저장 후 existingEventMap에 추가")
+        void newEvent_addedToExistingMap() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("새 행사", "광화문", "2025-07-01", "2025-07-31", "37.5759", "126.9769");
+            Map<String, Event> existingMap = new HashMap<>();
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            assertThat(existingMap).containsKey("새 행사|광화문|2025-07-01");
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 행사 업데이트")
+    class Update {
+
+        @Test
+        @DisplayName("existingEventMap에 있는 행사 - updateDetails 호출 후 저장")
+        void existingEvent_updatedAndSaved() {
+            Event existing = Event.builder()
+                    .eventTitle("기존 행사").place("홍대").startDate(LocalDate.of(2025, 6, 1))
+                    .endDate(LocalDate.of(2025, 6, 30)).latitude(37.0).longitude(126.0)
+                    .build();
+            Map<String, Event> existingMap = new HashMap<>();
+            existingMap.put("기존 행사|홍대|2025-06-01", existing);
+
+            SeoulCultureInfoApiResponse.Row row = buildRow("기존 행사", "홍대", "2025-06-01", "2025-08-31", "37.5759", "126.9769");
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            then(eventJpaRepository).should().save(existing);
+            assertThat(existing.getEndDate()).isEqualTo(LocalDate.of(2025, 8, 31));
+        }
+
+        @Test
+        @DisplayName("좌표가 null인 업데이트 - 기존 좌표 유지")
+        void existingEvent_nullCoordinate_keepsExistingCoordinate() {
+            Event existing = Event.builder()
+                    .eventTitle("기존 행사").place("홍대").startDate(LocalDate.of(2025, 6, 1))
+                    .endDate(LocalDate.of(2025, 6, 30)).latitude(37.0).longitude(126.0)
+                    .build();
+            Map<String, Event> existingMap = new HashMap<>();
+            existingMap.put("기존 행사|홍대|2025-06-01", existing);
+
+            SeoulCultureInfoApiResponse.Row row = buildRow("기존 행사", "홍대", "2025-06-01", "2025-08-31", null, null);
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            assertThat(existing.getLatitude()).isEqualTo(37.0);
+            assertThat(existing.getLongitude()).isEqualTo(126.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("필터링 조건")
+    class Filtering {
+
+        @Test
+        @DisplayName("endDate가 today 이전인 행사 - 저장 안 함")
+        void expiredEvent_skipped() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("만료 행사", "종로", "2025-01-01", "2025-05-31", "37.5", "126.9");
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, new HashMap<>());
+
+            then(eventJpaRepository).should(never()).save(org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        @DisplayName("startDate가 null인 행사 - 저장 안 함")
+        void nullStartDate_skipped() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("행사", "종로", null, "2025-12-31", "37.5", "126.9");
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, new HashMap<>());
+
+            then(eventJpaRepository).should(never()).save(org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        @DisplayName("endDate가 null인 행사 - 저장 안 함")
+        void nullEndDate_skipped() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("행사", "종로", "2025-07-01", null, "37.5", "126.9");
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, new HashMap<>());
+
+            then(eventJpaRepository).should(never()).save(org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        @DisplayName("날짜 형식이 10자 미만인 경우 - 저장 안 함")
+        void shortDateString_skipped() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("행사", "종로", "2025-07", "2025-12-31", "37.5", "126.9");
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, new HashMap<>());
+
+            then(eventJpaRepository).should(never()).save(org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        @DisplayName("유효 행사와 만료 행사 혼재 - 유효한 것만 저장")
+        void mixedRows_onlyValidSaved() {
+            SeoulCultureInfoApiResponse.Row valid = buildRow("유효 행사", "마포", "2025-06-01", "2025-12-31", "37.5", "126.9");
+            SeoulCultureInfoApiResponse.Row expired = buildRow("만료 행사", "종로", "2024-01-01", "2024-12-31", "37.5", "126.9");
+
+            eventUpsertService.upsertEventBatch(List.of(valid, expired), TODAY, new HashMap<>());
+
+            then(eventJpaRepository).should(times(1)).save(org.mockito.ArgumentMatchers.any());
+        }
+    }
+
+    @Nested
+    @DisplayName("좌표 파싱")
+    class CoordinateParsing {
+
+        @Test
+        @DisplayName("틸다(~) 포함 좌표 - 앞 숫자만 파싱")
+        void coordinateWithTilde_parsedCorrectly() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("행사", "장소", "2025-07-01", "2025-12-31",
+                    "37.5759~38.0", "126.9769~127.0");
+            Map<String, Event> existingMap = new HashMap<>();
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+            then(eventJpaRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getLatitude()).isEqualTo(37.5759);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 좌표 - null로 저장")
+        void blankCoordinate_storedAsNull() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("행사", "장소", "2025-07-01", "2025-12-31", "", "");
+            Map<String, Event> existingMap = new HashMap<>();
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+            then(eventJpaRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getLatitude()).isNull();
+            assertThat(captor.getValue().getLongitude()).isNull();
+        }
+
+        @Test
+        @DisplayName("숫자가 아닌 좌표 문자열 - null로 저장")
+        void invalidCoordinateString_storedAsNull() {
+            SeoulCultureInfoApiResponse.Row row = buildRow("행사", "장소", "2025-07-01", "2025-12-31", "abc", "xyz");
+            Map<String, Event> existingMap = new HashMap<>();
+
+            eventUpsertService.upsertEventBatch(List.of(row), TODAY, existingMap);
+
+            ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+            then(eventJpaRepository).should().save(captor.capture());
+            assertThat(captor.getValue().getLatitude()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    class ExceptionHandling {
+
+        @Test
+        @DisplayName("한 건 처리 중 예외 발생 - 나머지 건 정상 처리")
+        void oneRowFails_restProcessedNormally() {
+            SeoulCultureInfoApiResponse.Row badRow = buildRow("행사", "장소", "not-a-date", "2025-12-31", null, null);
+            SeoulCultureInfoApiResponse.Row goodRow = buildRow("정상 행사", "홍대", "2025-07-01", "2025-12-31", "37.5", "126.9");
+
+            eventUpsertService.upsertEventBatch(List.of(badRow, goodRow), TODAY, new HashMap<>());
+
+            then(eventJpaRepository).should(times(1)).save(org.mockito.ArgumentMatchers.any());
+        }
+    }
+}

--- a/service-map/src/test/java/com/danburn/map/service/LocationCodeMapperTest.java
+++ b/service-map/src/test/java/com/danburn/map/service/LocationCodeMapperTest.java
@@ -1,0 +1,127 @@
+package com.danburn.map.service;
+
+import com.danburn.map.domain.Location;
+import com.danburn.map.repository.LocationJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class LocationCodeMapperTest {
+
+    @Mock
+    private LocationJpaRepository locationJpaRepository;
+
+    @InjectMocks
+    private LocationCodeMapper locationCodeMapper;
+
+    private Location buildLocation(Long id, String areaCode, Double lat, Double lon) {
+        Location loc = Location.builder()
+                .apiAreaCode(areaCode)
+                .locationName("테스트 장소")
+                .latitude(lat)
+                .longitude(lon)
+                .category("관광특구")
+                .build();
+        try {
+            Field field = Location.class.getDeclaredField("locationId");
+            field.setAccessible(true);
+            field.set(loc, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return loc;
+    }
+
+    @BeforeEach
+    void init() {
+        given(locationJpaRepository.findAll()).willReturn(List.of(
+                buildLocation(1L, "POI001", 37.5665, 126.9780),
+                buildLocation(2L, "POI002", null, null)
+        ));
+        locationCodeMapper.init();
+    }
+
+    @Nested
+    @DisplayName("getLocationIdByAreaCode")
+    class GetLocationIdByAreaCode {
+
+        @Test
+        @DisplayName("존재하는 areaCode - locationId 반환")
+        void existingAreaCode_returnsId() {
+            Optional<Long> result = locationCodeMapper.getLocationIdByAreaCode("POI001");
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 areaCode - Optional.empty 반환")
+        void unknownAreaCode_returnsEmpty() {
+            Optional<Long> result = locationCodeMapper.getLocationIdByAreaCode("UNKNOWN");
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getCoordinateByAreaCode")
+    class GetCoordinateByAreaCode {
+
+        @Test
+        @DisplayName("좌표가 있는 areaCode - Coordinate 반환")
+        void existingAreaCodeWithCoordinate_returnsCoordinate() {
+            Optional<LocationCodeMapper.Coordinate> result = locationCodeMapper.getCoordinateByAreaCode("POI001");
+            assertThat(result).isPresent();
+            assertThat(result.get().latitude()).isEqualTo(37.5665);
+            assertThat(result.get().longitude()).isEqualTo(126.9780);
+        }
+
+        @Test
+        @DisplayName("좌표가 null인 areaCode - Optional.empty 반환")
+        void areaCodeWithNullCoordinate_returnsEmpty() {
+            Optional<LocationCodeMapper.Coordinate> result = locationCodeMapper.getCoordinateByAreaCode("POI002");
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 areaCode - Optional.empty 반환")
+        void unknownAreaCode_returnsEmpty() {
+            Optional<LocationCodeMapper.Coordinate> result = locationCodeMapper.getCoordinateByAreaCode("NOTEXIST");
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("init - @PostConstruct 캐시 초기화")
+    class Init {
+
+        @Test
+        @DisplayName("init 호출 시 findAll 1회 실행")
+        void init_callsFindAllOnce() {
+            // init() was already called in @BeforeEach; call once more to verify
+            locationCodeMapper.init();
+            then(locationJpaRepository).should(org.mockito.Mockito.times(2)).findAll();
+        }
+
+        @Test
+        @DisplayName("빈 목록 - 맵이 비어있어 어떤 areaCode도 미반환")
+        void emptyLocations_allLookupsReturnEmpty() {
+            given(locationJpaRepository.findAll()).willReturn(List.of());
+            locationCodeMapper.init();
+
+            assertThat(locationCodeMapper.getLocationIdByAreaCode("POI001")).isEmpty();
+            assertThat(locationCodeMapper.getCoordinateByAreaCode("POI001")).isEmpty();
+        }
+    }
+}

--- a/service-mobility/src/test/java/com/danburn/mobility/controller/OdsayControllerTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/controller/OdsayControllerTest.java
@@ -1,0 +1,160 @@
+package com.danburn.mobility.controller;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.mobility.dto.response.TransitRouteResponse;
+import com.danburn.mobility.service.OdsayService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OdsayController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration.class
+        })
+@ActiveProfiles("test")
+@DisplayName("OdsayController 단위 테스트")
+class OdsayControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OdsayService odsayService;
+
+    private static final String URL = "/api/mobility/route";
+
+    private TransitRouteResponse emptyResponse() {
+        return new TransitRouteResponse(List.of());
+    }
+
+    @Nested
+    @DisplayName("GET /api/mobility/route")
+    class GetRoute {
+
+        @Test
+        @DisplayName("유효한 좌표 파라미터로 요청하면 200과 경로 목록을 반환한다")
+        void valid_params_returns_200() throws Exception {
+            given(odsayService.fetchOdsayRoute(any())).willReturn(emptyResponse());
+
+            mockMvc.perform(get(URL)
+                            .param("originLng", "127.1272127")
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.paths").isArray());
+        }
+
+        @Test
+        @DisplayName("경로가 있을 때 paths 배열 크기가 응답에 반영된다")
+        void response_paths_reflected_in_data() throws Exception {
+            TransitRouteResponse.Info info =
+                    new TransitRouteResponse.Info(30, 1500, 1, 0, "출발역", "도착역");
+            TransitRouteResponse.Path path =
+                    new TransitRouteResponse.Path(info, List.of());
+            given(odsayService.fetchOdsayRoute(any()))
+                    .willReturn(new TransitRouteResponse(List.of(path, path)));
+
+            mockMvc.perform(get(URL)
+                            .param("originLng", "127.1272127")
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.paths.length()").value(2));
+        }
+
+        @Test
+        @DisplayName("필수 파라미터 originLng 누락 시 400을 반환한다")
+        void missing_originLng_returns_400() throws Exception {
+            mockMvc.perform(get(URL)
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400));
+        }
+
+        @Test
+        @DisplayName("필수 파라미터 destLat 누락 시 400을 반환한다")
+        void missing_destLat_returns_400() throws Exception {
+            mockMvc.perform(get(URL)
+                            .param("originLng", "127.1272127")
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400));
+        }
+
+        @Test
+        @DisplayName("originLng 범위 초과(-180~180) 시 400을 반환한다")
+        void originLng_out_of_range_returns_400() throws Exception {
+            mockMvc.perform(get(URL)
+                            .param("originLng", "200.0")
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400));
+        }
+
+        @Test
+        @DisplayName("originLat 범위 초과(-90~90) 시 400을 반환한다")
+        void originLat_out_of_range_returns_400() throws Exception {
+            mockMvc.perform(get(URL)
+                            .param("originLng", "127.1272127")
+                            .param("originLat", "100.0")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400));
+        }
+
+        @Test
+        @DisplayName("서비스가 GlobalException(502)을 던지면 해당 상태코드를 반환한다")
+        void service_throws_global_exception_returns_mapped_status() throws Exception {
+            willThrow(new GlobalException(502, "ODsay API 응답이 올바르지 않습니다."))
+                    .given(odsayService).fetchOdsayRoute(any());
+
+            mockMvc.perform(get(URL)
+                            .param("originLng", "127.1272127")
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.status").value(502))
+                    .andExpect(jsonPath("$.message").value("ODsay API 응답이 올바르지 않습니다."));
+        }
+
+        @Test
+        @DisplayName("서비스가 예기치 않은 예외를 던지면 500을 반환한다")
+        void service_throws_unexpected_exception_returns_500() throws Exception {
+            willThrow(new RuntimeException("예상치 못한 오류"))
+                    .given(odsayService).fetchOdsayRoute(any());
+
+            mockMvc.perform(get(URL)
+                            .param("originLng", "127.1272127")
+                            .param("originLat", "37.3213399")
+                            .param("destLng", "127.028001")
+                            .param("destLat", "37.498086"))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.status").value(500));
+        }
+    }
+}

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -1,0 +1,96 @@
+package com.danburn.mobility.service;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.mobility.dto.request.OdsayApiRequest;
+import com.danburn.mobility.dto.response.OdsayApiResponse;
+import com.danburn.mobility.dto.response.TransitRouteResponse;
+import com.danburn.mobility.infra.OdsayApiClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OdsayService 단위 테스트")
+class OdsayServiceTest {
+
+    @Mock
+    private OdsayApiClient odsayApiClient;
+
+    @Mock
+    private OdsayResponseMapper odsayResponseMapper;
+
+    @InjectMocks
+    private OdsayService odsayService;
+
+    private static final OdsayApiRequest REQUEST =
+            new OdsayApiRequest(127.1272127, 37.3213399, 127.028001, 37.498086);
+
+    @Nested
+    @DisplayName("fetchOdsayRoute")
+    class FetchOdsayRoute {
+
+        @Test
+        @DisplayName("정상 요청 시 client 결과를 mapper에 전달하고 매핑된 응답을 반환한다")
+        void success_returns_mapped_response() {
+            OdsayApiResponse apiResponse = buildApiResponse();
+            TransitRouteResponse expected = new TransitRouteResponse(List.of());
+
+            given(odsayApiClient.fetchOdsayRoute(REQUEST)).willReturn(apiResponse);
+            given(odsayResponseMapper.toResponse(apiResponse)).willReturn(expected);
+
+            TransitRouteResponse result = odsayService.fetchOdsayRoute(REQUEST);
+
+            assertThat(result).isSameAs(expected);
+            then(odsayApiClient).should().fetchOdsayRoute(REQUEST);
+            then(odsayResponseMapper).should().toResponse(apiResponse);
+        }
+
+        @Test
+        @DisplayName("client가 GlobalException을 던지면 그대로 전파된다")
+        void client_throws_global_exception_propagates() {
+            given(odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .willThrow(new GlobalException(502, "ODsay API 응답이 올바르지 않습니다."));
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("ODsay API 응답이 올바르지 않습니다.");
+
+            then(odsayResponseMapper).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("mapper가 예외를 던지면 그대로 전파된다")
+        void mapper_throws_exception_propagates() {
+            OdsayApiResponse apiResponse = buildApiResponse();
+
+            given(odsayApiClient.fetchOdsayRoute(REQUEST)).willReturn(apiResponse);
+            given(odsayResponseMapper.toResponse(apiResponse))
+                    .willThrow(new RuntimeException("매핑 오류"));
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("매핑 오류");
+        }
+    }
+
+    private OdsayApiResponse buildApiResponse() {
+        OdsayApiResponse.Info info =
+                new OdsayApiResponse.Info(30, 1500, 1, 0, "출발역", "도착역");
+        OdsayApiResponse.SubPath walk =
+                new OdsayApiResponse.SubPath(3, 5, null, null, null, null);
+        OdsayApiResponse.Path path =
+                new OdsayApiResponse.Path(info, List.of(walk));
+        return new OdsayApiResponse(new OdsayApiResponse.Result(0, List.of(path)));
+    }
+}


### PR DESCRIPTION
## Summary
- 미커버 영역 단위 테스트를 5개 서비스 전반에 추가 (커버리지 측정 도구 셋업은 다음 이슈)
- Java 215개 / Python 128개 전부 통과

## 서비스별
- **service-ai**: factory/stub/consumer/publisher/mcp client/schemas/config 등 pytest 43개 추가 (총 128 통과)
- **service-congestion**: notification 전체(Subscription/WebPush/Controller/Health/Cleanup), AnomalyDetector/CongestionStateTracker/HourlyAvgCacheService, event publisher·consumer, redis repository impl, SeoulArea
- **service-map**: AlternativeLocation/CultureEvent/Event/EventUpsert/LocationCodeMapper, 컨트롤러, EventSyncScheduler
- **service-mobility**: OdsayService, OdsayController
- **service-common**: ApiResponse, GlobalException
- **service-gateway**: CorsProperties

## 참고
- `service-common/build.gradle`: 테스트 의존성(JUnit/AssertJ/Mockito) 추가 — 기존엔 test classpath가 없어 테스트 컴파일 불가했음. JaCoCo 등 커버리지 도구는 미추가.
- **프로덕션 갭 발견(service-map)**: 필수 `@RequestParam` 누락 시 `GlobalExceptionHandler`의 catch-all `Exception` 핸들러가 `MissingServletRequestParameterException`을 삼켜 400이 아닌 **500**을 반환. 테스트는 현재 실제 동작(500)에 맞춰 두었으며, 별도 핸들러 추가는 후속 이슈 권장.
- 스킵: observability.py(Loki 소켓), WebPushSender 실전송 경로(VAPID+HTTP), OdsayApiClient/StubSeoulApiClient(RestClient 래핑/스텁), TestController(WebFlux 컨텍스트).

## Test plan
- [x] `./gradlew clean test` — 5개 모듈 BUILD SUCCESSFUL (215 tests, 0 fail)
- [x] service-ai `pytest -q` — 128 passed