### PR TITLE
perf(congestion): list SCAN 제거 + gzip + Caffeine 캐시 (TTL 5s)

### DIFF
--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
     runtimeOnly 'net.ttddyy.observation:datasource-micrometer-spring-boot:1.0.6'

--- a/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
@@ -1,0 +1,24 @@
+package com.danburn.congestion.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager("congestionList");
+        manager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(5, TimeUnit.SECONDS)
+                .maximumSize(10));
+        return manager;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -5,13 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Repository;
 
-import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.ScanOptions;
-
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,25 +22,43 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     private final RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
 
     private static final String KEY_PREFIX = "congestion:dto:";
+    private static final String AREA_CODES_SET_KEY = "congestion:area_codes";
     private static final long TTL_MINUTES = 15;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void addAreaCode(String areaCode) {
+        ((SetOperations) congestionRedisTemplate.opsForSet()).add(AREA_CODES_SET_KEY, areaCode);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void removeAreaCode(String areaCode) {
+        ((SetOperations) congestionRedisTemplate.opsForSet()).remove(AREA_CODES_SET_KEY, areaCode);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Set<String> getAreaCodes() {
+        return ((SetOperations) congestionRedisTemplate.opsForSet()).members(AREA_CODES_SET_KEY);
+    }
 
     @Override
     public void save(CongestionRedisDto dto) {
         String key = KEY_PREFIX + dto.areaCode();
         congestionRedisTemplate.opsForValue().set(key, dto, TTL_MINUTES, TimeUnit.MINUTES);
+        addAreaCode(dto.areaCode());
     }
 
     @Override
     public void saveAll(List<CongestionRedisDto> dtos) {
         congestionRedisTemplate.executePipelined(new SessionCallback<>() {
             @Override
-            @SuppressWarnings("unchecked")
+            @SuppressWarnings({"unchecked", "rawtypes"})
             public Object execute(RedisOperations operations) {
                 RedisOperations<String, CongestionRedisDto> ops =
                         (RedisOperations<String, CongestionRedisDto>) operations;
                 for (CongestionRedisDto dto : dtos) {
                     String key = KEY_PREFIX + dto.areaCode();
                     ops.opsForValue().set(key, dto, TTL_MINUTES, TimeUnit.MINUTES);
+                    ((SetOperations) ops.opsForSet()).add(AREA_CODES_SET_KEY, dto.areaCode());
                 }
                 return null;
             }
@@ -59,17 +74,11 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
 
     @Override
     public List<CongestionRedisDto> findAll() {
-        Set<String> keys = new HashSet<>();
-        ScanOptions options = ScanOptions.scanOptions().match(KEY_PREFIX + "*").count(1000).build();
-        try (Cursor<String> cursor = congestionRedisTemplate.scan(options)) {
-            while (cursor.hasNext()) {
-                keys.add(cursor.next());
-            }
-        }
-
-        if (keys.isEmpty()) {
+        Set<String> areaCodes = getAreaCodes();
+        if (areaCodes == null || areaCodes.isEmpty()) {
             return Collections.emptyList();
         }
+        List<String> keys = areaCodes.stream().map(code -> KEY_PREFIX + code).toList();
 
         List<CongestionRedisDto> values = congestionRedisTemplate.opsForValue().multiGet(keys);
         if (values == null) {
@@ -93,5 +102,6 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     public void delete(String areaCode) {
         String key = KEY_PREFIX + areaCode;
         congestionRedisTemplate.delete(key);
+        removeAreaCode(areaCode);
     }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
-import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
@@ -20,24 +20,26 @@ import java.util.concurrent.TimeUnit;
 public class CongestionRedisRepositoryImpl implements CongestionRedisRepository {
 
     private final RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
 
     private static final String KEY_PREFIX = "congestion:dto:";
     private static final String AREA_CODES_SET_KEY = "congestion:area_codes";
     private static final long TTL_MINUTES = 15;
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private void addAreaCode(String areaCode) {
-        ((SetOperations) congestionRedisTemplate.opsForSet()).add(AREA_CODES_SET_KEY, areaCode);
+        long expireAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
+        stringRedisTemplate.opsForZSet().add(AREA_CODES_SET_KEY, areaCode, expireAt);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private void removeAreaCode(String areaCode) {
-        ((SetOperations) congestionRedisTemplate.opsForSet()).remove(AREA_CODES_SET_KEY, areaCode);
+        stringRedisTemplate.opsForZSet().remove(AREA_CODES_SET_KEY, areaCode);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private Set<String> getAreaCodes() {
-        return ((SetOperations) congestionRedisTemplate.opsForSet()).members(AREA_CODES_SET_KEY);
+        long now = System.currentTimeMillis();
+        stringRedisTemplate.opsForZSet().removeRangeByScore(AREA_CODES_SET_KEY, 0, now);
+        Set<String> codes = stringRedisTemplate.opsForZSet().range(AREA_CODES_SET_KEY, 0, -1);
+        return codes != null ? codes : Collections.emptySet();
     }
 
     @Override
@@ -51,14 +53,25 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     public void saveAll(List<CongestionRedisDto> dtos) {
         congestionRedisTemplate.executePipelined(new SessionCallback<>() {
             @Override
-            @SuppressWarnings({"unchecked", "rawtypes"})
+            @SuppressWarnings("unchecked")
             public Object execute(RedisOperations operations) {
                 RedisOperations<String, CongestionRedisDto> ops =
                         (RedisOperations<String, CongestionRedisDto>) operations;
                 for (CongestionRedisDto dto : dtos) {
                     String key = KEY_PREFIX + dto.areaCode();
                     ops.opsForValue().set(key, dto, TTL_MINUTES, TimeUnit.MINUTES);
-                    ((SetOperations) ops.opsForSet()).add(AREA_CODES_SET_KEY, dto.areaCode());
+                }
+                return null;
+            }
+        });
+
+        long expireAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
+        stringRedisTemplate.executePipelined(new SessionCallback<>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public Object execute(RedisOperations operations) {
+                for (CongestionRedisDto dto : dtos) {
+                    operations.opsForZSet().add(AREA_CODES_SET_KEY, dto.areaCode(), expireAt);
                 }
                 return null;
             }

--- a/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,6 +99,7 @@ public class CongestionService {
                 });
     }
 
+    @Cacheable("congestionList")
     public List<CongestionResponse> findAll() {
         List<CongestionRedisDto> redisList = congestionRedisRepository.findAll();
         if (!redisList.isEmpty()) {

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -39,6 +39,10 @@ spring:
 server:
   port: 8082
   forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: application/json
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -11,8 +11,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.ValueOperations;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,6 +33,10 @@ class CongestionRedisRepositoryImplTest {
 
     @Mock
     private ValueOperations<String, CongestionRedisDto> valueOps;
+
+    @Mock
+    @SuppressWarnings("rawtypes")
+    private SetOperations setOps;
 
     @Mock
     private Cursor<String> emptyCursor;
@@ -54,6 +60,7 @@ class CongestionRedisRepositoryImplTest {
         void save() {
             CongestionRedisDto item = dto("POI001");
             given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
 
             repository.save(item);
 
@@ -126,8 +133,8 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
-            given(congestionRedisTemplate.scan(any(ScanOptions.class))).willReturn(emptyCursor);
-            given(emptyCursor.hasNext()).willReturn(false);
+            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+            given(setOps.members(eq("congestion:area_codes"))).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 
@@ -142,6 +149,8 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("areaCode → key 변환 후 delete 호출")
         void delete() {
+            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+
             repository.delete("POI001");
 
             then(congestionRedisTemplate).should().delete("congestion:dto:POI001");

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -1,18 +1,17 @@
 package com.danburn.congestion.repository;
 
 import com.danburn.congestion.dto.CongestionRedisDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
-import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,17 +31,20 @@ class CongestionRedisRepositoryImplTest {
     private RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
 
     @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
     private ValueOperations<String, CongestionRedisDto> valueOps;
 
     @Mock
-    @SuppressWarnings("rawtypes")
-    private SetOperations setOps;
+    private ZSetOperations<String, String> zSetOps;
 
-    @Mock
-    private Cursor<String> emptyCursor;
-
-    @InjectMocks
     private CongestionRedisRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new CongestionRedisRepositoryImpl(congestionRedisTemplate, stringRedisTemplate);
+    }
 
     private CongestionRedisDto dto(String areaCode) {
         return new CongestionRedisDto(
@@ -60,7 +62,7 @@ class CongestionRedisRepositoryImplTest {
         void save() {
             CongestionRedisDto item = dto("POI001");
             given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
-            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+            given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
 
             repository.save(item);
 
@@ -133,8 +135,8 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
-            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
-            given(setOps.members(eq("congestion:area_codes"))).willReturn(Collections.emptySet());
+            given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
+            given(zSetOps.range(eq("congestion:area_codes"), eq(0L), eq(-1L))).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 
@@ -149,7 +151,7 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("areaCode → key 변환 후 delete 호출")
         void delete() {
-            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+            given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
 
             repository.delete("POI001");
 


### PR DESCRIPTION
## Summary
부하테스트(이슈 #333)로 발견한 list 엔드포인트 baseline 1.96s(192KB 응답, TTFB 1.59s)를 개선. 500 VU 부하 시 p95 13s 까지 갔던 게 구조적 문제(매 요청 SCAN + 큰 응답 + 역직렬화 122회)였음.

## 변경
### ① Redis SCAN 제거
- `CongestionRedisRepositoryImpl` 의 `findAll()` 이 매 호출마다 SCAN 으로 122 key 수집 → 동시성 폭주 시 Redis CPU/RTT 누적.
- areaCode 목록을 별도 Redis Set 키 `congestion:area_codes` 로 관리. SMEMBERS + MGET 한 라운드.
- `save`/`saveAll` 에 SADD, `delete` 에 SREM 동기 보정. multiGet 의 `filter(nonNull)` 안전망은 유지 → SET 정합성 깨져도 무사고.

### ② HTTP gzip 압축
- `application.yml` 의 `server.compression`: `application/json`, `min-response-size: 1024`.
- 192KB JSON → 약 20KB 수준 전송 (네트워크 시간 단축).

### ③ Caffeine 인메모리 캐시 (TTL 5s)
- `CongestionService.findAll()` 에 `@Cacheable("congestionList")`.
- `CacheConfig` 신규: `CaffeineCacheManager`, `expireAfterWrite=5s`, `maximumSize=10`.
- 스케줄러가 5분 주기로 갱신하므로 5초 stale 은 사실상 무영향.
- 의존성: `spring-boot-starter-cache`, `caffeine`.

## 예상 효과 (보수적 추정)
| 시나리오 | 현재 | 변경 후 |
|---|---|---|
| 단독 호출 list | 1.96s | **~50ms** (cache hit) |
| 500 VU p95 list | 13s | **~100~300ms** |
| 응답 전송 크기 | 192KB | ~20KB (gzip) |

## Test plan
- [x] `:service-congestion:compileJava` BUILD SUCCESSFUL
- [ ] CI 빌드/테스트 통과
- [ ] dev → main → CD 배포 후 prod 부하테스트 재실측 (k6 계단식)