### PR TITLE
fix(congestion): area_codes ZSET read/write 분리 (#343 후속)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -36,9 +36,11 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     }
 
     private Set<String> getAreaCodes() {
+        // read-only: 만료 항목은 multiGet 결과 filter(nonNull) 로 걸러지고,
+        // ZSET 청소는 write 경로(saveAll) 에서 일괄 처리한다.
         long now = System.currentTimeMillis();
-        stringRedisTemplate.opsForZSet().removeRangeByScore(AREA_CODES_SET_KEY, 0, now);
-        Set<String> codes = stringRedisTemplate.opsForZSet().range(AREA_CODES_SET_KEY, 0, -1);
+        Set<String> codes = stringRedisTemplate.opsForZSet()
+                .rangeByScore(AREA_CODES_SET_KEY, now, Double.MAX_VALUE);
         return codes != null ? codes : Collections.emptySet();
     }
 
@@ -65,11 +67,14 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
             }
         });
 
-        long expireAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
+        long now = System.currentTimeMillis();
+        long expireAt = now + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
         stringRedisTemplate.executePipelined(new SessionCallback<>() {
             @Override
             @SuppressWarnings("unchecked")
             public Object execute(RedisOperations operations) {
+                // 만료된 멤버 일괄 청소 (write 경로에서만 정리, getAreaCodes 는 read-only)
+                operations.opsForZSet().removeRangeByScore(AREA_CODES_SET_KEY, 0, now);
                 for (CongestionRedisDto dto : dtos) {
                     operations.opsForZSet().add(AREA_CODES_SET_KEY, dto.areaCode(), expireAt);
                 }

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -40,7 +40,7 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
         // ZSET 청소는 write 경로(saveAll) 에서 일괄 처리한다.
         long now = System.currentTimeMillis();
         Set<String> codes = stringRedisTemplate.opsForZSet()
-                .rangeByScore(AREA_CODES_SET_KEY, now, Double.MAX_VALUE);
+                .rangeByScore(AREA_CODES_SET_KEY, now, Double.POSITIVE_INFINITY);
         return codes != null ? codes : Collections.emptySet();
     }
 

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -136,7 +137,7 @@ class CongestionRedisRepositoryImplTest {
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
             given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
-            given(zSetOps.range(eq("congestion:area_codes"), eq(0L), eq(-1L))).willReturn(Collections.emptySet());
+            given(zSetOps.rangeByScore(eq("congestion:area_codes"), anyDouble(), eq(Double.MAX_VALUE))).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -137,7 +137,7 @@ class CongestionRedisRepositoryImplTest {
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
             given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
-            given(zSetOps.rangeByScore(eq("congestion:area_codes"), anyDouble(), eq(Double.MAX_VALUE))).willReturn(Collections.emptySet());
+            given(zSetOps.rangeByScore(eq("congestion:area_codes"), anyDouble(), anyDouble())).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 


### PR DESCRIPTION
## Summary
PR #343 머지 직후 추가된 gemini HIGH 리뷰 반영. `getAreaCodes()` 가 read 경로인데 매 조회마다 `removeRangeByScore`(write) 호출 → 고부하 시 Redis AOF/replication 부담.

## 변경
- `getAreaCodes()` 를 **read-only** 로: `rangeByScore(now, Double.MAX_VALUE)` 로 유효 멤버만 순수 조회. 만료된 항목은 기존 `multiGet` 결과 `filter(nonNull)` 가 자연스럽게 걸러줌.
- **만료 청소는 write 경로(saveAll)** 의 ZSET pipeline 안에 `removeRangeByScore(0, now)` 한 줄로 일괄 처리. 5분 주기 스케줄러에 묶여서 비용 거의 무시 가능.
- 테스트: `emptyWhenNoKeys` mock 을 `zSetOps.range` → `rangeByScore(any, MAX)` 로 교체.

## Test plan
- [x] `:service-congestion:test --tests CongestionRedisRepositoryImplTest` → 7 passed
- [ ] CI 빌드/테스트 통과
- [ ] dev 머지 후 main PR 묶어서 prod 배포