### PR TITLE
release(dev → main): congestion list 성능 개선 (SCAN 제거 + ZSET + gzip + Caffeine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,22 @@
   ---
 
   ## Trouble Shooting
-  ### [RabbitMQ 기반 비동기 EDA 구조를 이용한 AI분석 기능 도입] [🔗Blog](https://velog.io/@kim138762/RabbitMQ-%EA%B8%B0%EB%B0%98-%EB%B9%84%EB%8F%99%EA%B8%B0-EDA-%EA%B5%AC%EC%A1%B0%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-AI%EB%B6%84%EC%84%9D-%EA%B8%B0%EB%8A%A5-%EB%8F%84%EC%9E%85)
+  ### RabbitMQ 기반 비동기 EDA 구조를 이용한 AI분석 기능 도입 [🔗Blog](https://velog.io/@kim138762/RabbitMQ-%EA%B8%B0%EB%B0%98-%EB%B9%84%EB%8F%99%EA%B8%B0-EDA-%EA%B5%AC%EC%A1%B0%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-AI%EB%B6%84%EC%84%9D-%EA%B8%B0%EB%8A%A5-%EB%8F%84%EC%9E%85)
   - **문제**: AI분석 기능 도입 과정에서 5분 주기 수집의 요청 버스트와 AI API 호출 제한의 충돌.
   - **해결**: Java와 Python 서비스를 분리하고, RabbitMQ 기반의 비동기 EDA 구조를 도입하여 시스템 간 의존성을 완전히 제거.
   - **결과**: AI API의 호출 제한 내에서 안정적인 분석 처리가 가능해졌으며, 서비스의 장애가 전파되지 않는 장애격리 달성
 
-  ### [DLQ 도입으로 API Rate Limit 환경에서 메시지 유실 제로 달성] [🔗Blog](https://velog.io/@kim138762/DLQ-%EB%8F%84%EC%9E%85%EC%9C%BC%EB%A1%9C-API-Rate-Limit-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%9C%A0%EC%8B%A4-%EC%A0%9C%EB%A1%9C-%EB%8B%AC%EC%84%B1)
+  ### DLQ 도입으로 API Rate Limit 환경에서 메시지 유실 제로 달성 [🔗Blog](https://velog.io/@kim138762/DLQ-%EB%8F%84%EC%9E%85%EC%9C%BC%EB%A1%9C-API-Rate-Limit-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EB%A9%94%EC%8B%9C%EC%A7%80-%EC%9C%A0%EC%8B%A4-%EC%A0%9C%EB%A1%9C-%EB%8B%AC%EC%84%B1)
   - 문제: AI 분석 파이프라인에서 외부 API Rate Limit(429) 시 메시지 유실 발생. 쿼터 회복에 수 분 소요되어 단순 재시도로 해결 불가
   - 해결: RabbitMQ DLQ로 실패/정상 경로를 분리하여, 정상 처리를 막지 않으면서 실패 메시지의 최종 처리를 보장하는 복구 파이프라인 구현
   - 성과: 배포 후 메시지 유실 0건, DLQ 경유 복구 확인
 
-  ### (도입 예정)Circuit Breaker 기반 장애 전파 차단 및 캐시 폴백 
+  ### Circuit Breaker 기반 장애 전파 차단 및 캐시 폴백 
   - **문제**: 서울시 공공 API 타임아웃 또는 AI API rate limit 초과 시, 연속 실패가 서비스 전체 응답 지연으로 전파
   - **해결 (예정)**: 연쇄 장애 차단 및 가용성 확보를 위한 Resilience4j 기반 Circuit Breaker 설계. 실패율 임계치에 따른 회로 개방과 Half-Open 상태를 통한 자동 복구 프로세스 구축
   - **기대 결과 (예상)**: 외부 API 장애 시에도 사용자에게 끊김 없는 데이터 제공 (가용성 확보)
 
-  ### (도입 예정)AI 에이전트 기반 실시간 원인 분석 시스템 구축
+  ### AI 에이전트 기반 실시간 원인 분석 시스템 구축
   
   - **문제:** 정량적 수치 기반의 내부 데이터만으로는 실시간 혼잡 원인을 구체적으로 분석하는 데 데이터 한계가 존재
   - **해결:** MCP와 펑션 콜링 기반 지능형 에이전트를 설계하여 분석에 필요한 외부 맥락 데이터를 실시간으로 동적 수집 및 통합함.

--- a/service-congestion/build.gradle
+++ b/service-congestion/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
     runtimeOnly 'net.ttddyy.observation:datasource-micrometer-spring-boot:1.0.6'

--- a/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
@@ -1,0 +1,24 @@
+package com.danburn.congestion.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager("congestionList");
+        manager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(5, TimeUnit.SECONDS)
+                .maximumSize(10));
+        return manager;
+    }
+}

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -36,9 +36,11 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     }
 
     private Set<String> getAreaCodes() {
+        // read-only: 만료 항목은 multiGet 결과 filter(nonNull) 로 걸러지고,
+        // ZSET 청소는 write 경로(saveAll) 에서 일괄 처리한다.
         long now = System.currentTimeMillis();
-        stringRedisTemplate.opsForZSet().removeRangeByScore(AREA_CODES_SET_KEY, 0, now);
-        Set<String> codes = stringRedisTemplate.opsForZSet().range(AREA_CODES_SET_KEY, 0, -1);
+        Set<String> codes = stringRedisTemplate.opsForZSet()
+                .rangeByScore(AREA_CODES_SET_KEY, now, Double.MAX_VALUE);
         return codes != null ? codes : Collections.emptySet();
     }
 
@@ -65,11 +67,14 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
             }
         });
 
-        long expireAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
+        long now = System.currentTimeMillis();
+        long expireAt = now + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
         stringRedisTemplate.executePipelined(new SessionCallback<>() {
             @Override
             @SuppressWarnings("unchecked")
             public Object execute(RedisOperations operations) {
+                // 만료된 멤버 일괄 청소 (write 경로에서만 정리, getAreaCodes 는 read-only)
+                operations.opsForZSet().removeRangeByScore(AREA_CODES_SET_KEY, 0, now);
                 for (CongestionRedisDto dto : dtos) {
                     operations.opsForZSet().add(AREA_CODES_SET_KEY, dto.areaCode(), expireAt);
                 }

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -40,7 +40,7 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
         // ZSET 청소는 write 경로(saveAll) 에서 일괄 처리한다.
         long now = System.currentTimeMillis();
         Set<String> codes = stringRedisTemplate.opsForZSet()
-                .rangeByScore(AREA_CODES_SET_KEY, now, Double.MAX_VALUE);
+                .rangeByScore(AREA_CODES_SET_KEY, now, Double.POSITIVE_INFINITY);
         return codes != null ? codes : Collections.emptySet();
     }
 

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -5,13 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Repository;
 
-import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.ScanOptions;
-
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,25 +22,43 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     private final RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
 
     private static final String KEY_PREFIX = "congestion:dto:";
+    private static final String AREA_CODES_SET_KEY = "congestion:area_codes";
     private static final long TTL_MINUTES = 15;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void addAreaCode(String areaCode) {
+        ((SetOperations) congestionRedisTemplate.opsForSet()).add(AREA_CODES_SET_KEY, areaCode);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void removeAreaCode(String areaCode) {
+        ((SetOperations) congestionRedisTemplate.opsForSet()).remove(AREA_CODES_SET_KEY, areaCode);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Set<String> getAreaCodes() {
+        return ((SetOperations) congestionRedisTemplate.opsForSet()).members(AREA_CODES_SET_KEY);
+    }
 
     @Override
     public void save(CongestionRedisDto dto) {
         String key = KEY_PREFIX + dto.areaCode();
         congestionRedisTemplate.opsForValue().set(key, dto, TTL_MINUTES, TimeUnit.MINUTES);
+        addAreaCode(dto.areaCode());
     }
 
     @Override
     public void saveAll(List<CongestionRedisDto> dtos) {
         congestionRedisTemplate.executePipelined(new SessionCallback<>() {
             @Override
-            @SuppressWarnings("unchecked")
+            @SuppressWarnings({"unchecked", "rawtypes"})
             public Object execute(RedisOperations operations) {
                 RedisOperations<String, CongestionRedisDto> ops =
                         (RedisOperations<String, CongestionRedisDto>) operations;
                 for (CongestionRedisDto dto : dtos) {
                     String key = KEY_PREFIX + dto.areaCode();
                     ops.opsForValue().set(key, dto, TTL_MINUTES, TimeUnit.MINUTES);
+                    ((SetOperations) ops.opsForSet()).add(AREA_CODES_SET_KEY, dto.areaCode());
                 }
                 return null;
             }
@@ -59,17 +74,11 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
 
     @Override
     public List<CongestionRedisDto> findAll() {
-        Set<String> keys = new HashSet<>();
-        ScanOptions options = ScanOptions.scanOptions().match(KEY_PREFIX + "*").count(1000).build();
-        try (Cursor<String> cursor = congestionRedisTemplate.scan(options)) {
-            while (cursor.hasNext()) {
-                keys.add(cursor.next());
-            }
-        }
-
-        if (keys.isEmpty()) {
+        Set<String> areaCodes = getAreaCodes();
+        if (areaCodes == null || areaCodes.isEmpty()) {
             return Collections.emptyList();
         }
+        List<String> keys = areaCodes.stream().map(code -> KEY_PREFIX + code).toList();
 
         List<CongestionRedisDto> values = congestionRedisTemplate.opsForValue().multiGet(keys);
         if (values == null) {
@@ -93,5 +102,6 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     public void delete(String areaCode) {
         String key = KEY_PREFIX + areaCode;
         congestionRedisTemplate.delete(key);
+        removeAreaCode(areaCode);
     }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/CongestionRedisRepositoryImpl.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SessionCallback;
-import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
@@ -20,24 +20,26 @@ import java.util.concurrent.TimeUnit;
 public class CongestionRedisRepositoryImpl implements CongestionRedisRepository {
 
     private final RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
 
     private static final String KEY_PREFIX = "congestion:dto:";
     private static final String AREA_CODES_SET_KEY = "congestion:area_codes";
     private static final long TTL_MINUTES = 15;
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private void addAreaCode(String areaCode) {
-        ((SetOperations) congestionRedisTemplate.opsForSet()).add(AREA_CODES_SET_KEY, areaCode);
+        long expireAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
+        stringRedisTemplate.opsForZSet().add(AREA_CODES_SET_KEY, areaCode, expireAt);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private void removeAreaCode(String areaCode) {
-        ((SetOperations) congestionRedisTemplate.opsForSet()).remove(AREA_CODES_SET_KEY, areaCode);
+        stringRedisTemplate.opsForZSet().remove(AREA_CODES_SET_KEY, areaCode);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     private Set<String> getAreaCodes() {
-        return ((SetOperations) congestionRedisTemplate.opsForSet()).members(AREA_CODES_SET_KEY);
+        long now = System.currentTimeMillis();
+        stringRedisTemplate.opsForZSet().removeRangeByScore(AREA_CODES_SET_KEY, 0, now);
+        Set<String> codes = stringRedisTemplate.opsForZSet().range(AREA_CODES_SET_KEY, 0, -1);
+        return codes != null ? codes : Collections.emptySet();
     }
 
     @Override
@@ -51,14 +53,25 @@ public class CongestionRedisRepositoryImpl implements CongestionRedisRepository 
     public void saveAll(List<CongestionRedisDto> dtos) {
         congestionRedisTemplate.executePipelined(new SessionCallback<>() {
             @Override
-            @SuppressWarnings({"unchecked", "rawtypes"})
+            @SuppressWarnings("unchecked")
             public Object execute(RedisOperations operations) {
                 RedisOperations<String, CongestionRedisDto> ops =
                         (RedisOperations<String, CongestionRedisDto>) operations;
                 for (CongestionRedisDto dto : dtos) {
                     String key = KEY_PREFIX + dto.areaCode();
                     ops.opsForValue().set(key, dto, TTL_MINUTES, TimeUnit.MINUTES);
-                    ((SetOperations) ops.opsForSet()).add(AREA_CODES_SET_KEY, dto.areaCode());
+                }
+                return null;
+            }
+        });
+
+        long expireAt = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(TTL_MINUTES);
+        stringRedisTemplate.executePipelined(new SessionCallback<>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public Object execute(RedisOperations operations) {
+                for (CongestionRedisDto dto : dtos) {
+                    operations.opsForZSet().add(AREA_CODES_SET_KEY, dto.areaCode(), expireAt);
                 }
                 return null;
             }

--- a/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/CongestionService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,6 +99,7 @@ public class CongestionService {
                 });
     }
 
+    @Cacheable("congestionList")
     public List<CongestionResponse> findAll() {
         List<CongestionRedisDto> redisList = congestionRedisRepository.findAll();
         if (!redisList.isEmpty()) {

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -39,6 +39,10 @@ spring:
 server:
   port: 8082
   forward-headers-strategy: framework
+  compression:
+    enabled: true
+    mime-types: application/json
+    min-response-size: 1024
 
 management:
   endpoints:

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -136,7 +137,7 @@ class CongestionRedisRepositoryImplTest {
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
             given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
-            given(zSetOps.range(eq("congestion:area_codes"), eq(0L), eq(-1L))).willReturn(Collections.emptySet());
+            given(zSetOps.rangeByScore(eq("congestion:area_codes"), anyDouble(), eq(Double.MAX_VALUE))).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -137,7 +137,7 @@ class CongestionRedisRepositoryImplTest {
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
             given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
-            given(zSetOps.rangeByScore(eq("congestion:area_codes"), anyDouble(), eq(Double.MAX_VALUE))).willReturn(Collections.emptySet());
+            given(zSetOps.rangeByScore(eq("congestion:area_codes"), anyDouble(), anyDouble())).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -11,8 +11,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.ValueOperations;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,6 +33,10 @@ class CongestionRedisRepositoryImplTest {
 
     @Mock
     private ValueOperations<String, CongestionRedisDto> valueOps;
+
+    @Mock
+    @SuppressWarnings("rawtypes")
+    private SetOperations setOps;
 
     @Mock
     private Cursor<String> emptyCursor;
@@ -54,6 +60,7 @@ class CongestionRedisRepositoryImplTest {
         void save() {
             CongestionRedisDto item = dto("POI001");
             given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
 
             repository.save(item);
 
@@ -126,8 +133,8 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
-            given(congestionRedisTemplate.scan(any(ScanOptions.class))).willReturn(emptyCursor);
-            given(emptyCursor.hasNext()).willReturn(false);
+            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+            given(setOps.members(eq("congestion:area_codes"))).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 
@@ -142,6 +149,8 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("areaCode → key 변환 후 delete 호출")
         void delete() {
+            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+
             repository.delete("POI001");
 
             then(congestionRedisTemplate).should().delete("congestion:dto:POI001");

--- a/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/repository/CongestionRedisRepositoryImplTest.java
@@ -1,18 +1,17 @@
 package com.danburn.congestion.repository;
 
 import com.danburn.congestion.dto.CongestionRedisDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
-import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,17 +31,20 @@ class CongestionRedisRepositoryImplTest {
     private RedisTemplate<String, CongestionRedisDto> congestionRedisTemplate;
 
     @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
     private ValueOperations<String, CongestionRedisDto> valueOps;
 
     @Mock
-    @SuppressWarnings("rawtypes")
-    private SetOperations setOps;
+    private ZSetOperations<String, String> zSetOps;
 
-    @Mock
-    private Cursor<String> emptyCursor;
-
-    @InjectMocks
     private CongestionRedisRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new CongestionRedisRepositoryImpl(congestionRedisTemplate, stringRedisTemplate);
+    }
 
     private CongestionRedisDto dto(String areaCode) {
         return new CongestionRedisDto(
@@ -60,7 +62,7 @@ class CongestionRedisRepositoryImplTest {
         void save() {
             CongestionRedisDto item = dto("POI001");
             given(congestionRedisTemplate.opsForValue()).willReturn(valueOps);
-            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+            given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
 
             repository.save(item);
 
@@ -133,8 +135,8 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("키 없으면 빈 목록")
         void emptyWhenNoKeys() {
-            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
-            given(setOps.members(eq("congestion:area_codes"))).willReturn(Collections.emptySet());
+            given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
+            given(zSetOps.range(eq("congestion:area_codes"), eq(0L), eq(-1L))).willReturn(Collections.emptySet());
 
             List<CongestionRedisDto> result = repository.findAll();
 
@@ -149,7 +151,7 @@ class CongestionRedisRepositoryImplTest {
         @Test
         @DisplayName("areaCode → key 변환 후 delete 호출")
         void delete() {
-            given(congestionRedisTemplate.opsForSet()).willReturn(setOps);
+            given(stringRedisTemplate.opsForZSet()).willReturn(zSetOps);
 
             repository.delete("POI001");
 


### PR DESCRIPTION
## Summary
list 엔드포인트 성능 개선 누적분을 prod 로 promotion. **머지 시 CD 자동 배포**.

## 포함 변경
- **perf(congestion)** #343 — list 엔드포인트 SCAN 제거 + gzip + Caffeine 캐시 (TTL 5s)
- **fix(congestion)** #344 — area_codes ZSET read/write 분리 + Double.POSITIVE_INFINITY + anyDouble 테스트

## 예상 효과 (이전 부하테스트 기준)
- 단독 호출 list: 1.96s → **~50ms** (cache hit)
- 500 VU p95 list: 13s → **~100~300ms**
- 응답 크기 192KB → ~20KB (gzip)

## 머지 후
1. CD 자동 빌드/배포 (gateway 미변경, congestion 새 이미지)
2. 로컬 k6 → `https://api.goseoul.today` 부하테스트 재실측으로 효과 확인