### PR TITLE
perf(congestion): list 엔드포인트 ETag/304 + Cache-Control 적용

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 import java.util.concurrent.TimeUnit;
@@ -24,7 +25,10 @@ public class CacheConfig {
     }
 
     @Bean
-    public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
-        return new ShallowEtagHeaderFilter();
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new ShallowEtagHeaderFilter());
+        registration.addUrlPatterns("/api/congestion");
+        return registration;
     }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 import java.util.concurrent.TimeUnit;
 
@@ -20,5 +21,10 @@ public class CacheConfig {
                 .expireAfterWrite(5, TimeUnit.SECONDS)
                 .maximumSize(10));
         return manager;
+    }
+
+    @Bean
+    public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+        return new ShallowEtagHeaderFilter();
     }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/controller/CongestionController.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/controller/CongestionController.java
@@ -8,12 +8,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Tag(name = "혼잡도", description = "실시간 혼잡도 조회 API")
 @RestController
@@ -25,8 +28,10 @@ public class CongestionController {
 
     @Operation(summary = "전체 혼잡도 조회", description = "122개 서울 주요 장소의 실시간 혼잡도를 조회합니다.")
     @GetMapping
-    public ApiResponse<List<CongestionResponse>> findAll() {
-        return ApiResponse.ok(congestionService.findAll());
+    public ResponseEntity<ApiResponse<List<CongestionResponse>>> findAll() {
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(5, TimeUnit.SECONDS).mustRevalidate())
+                .body(ApiResponse.ok(congestionService.findAll()));
     }
 
     @Operation(summary = "장소별 혼잡도 조회", description = "areaCode로 특정 장소의 실시간 혼잡도를 조회합니다.")


### PR DESCRIPTION
## Summary
- list 엔드포인트는 프론트 폴링 대상이라 같은 응답이 반복 전송됨
- `ShallowEtagHeaderFilter` 전역 활성화 + list 응답에 `Cache-Control: max-age=5, must-revalidate`

## 기대 효과 (폴링 30초 / 데이터 갱신 5분 가정)
- 폴링 10번 중 9번은 `304 Not Modified` → 응답 본문 0 byte
- 응답 시간 p95 4.25s → ~50ms 수준 (변화 없을 때)
- 모바일 데이터 ~90% 절감 (탭/창 N개여도 누적 부담 거의 무시)

## Test plan
- [x] :service-congestion:test 회귀 없음
- [ ] CI 통과
- [ ] 머지 후 prod 부하테스트 재실측