### PR TITLE
fix(congestion): list 응답에 컨트롤러 직접 ETag/304 처리 (필터 우회)

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/config/CacheConfig.java
@@ -6,9 +6,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.web.filter.ShallowEtagHeaderFilter;
-
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -24,11 +21,4 @@ public class CacheConfig {
         return manager;
     }
 
-    @Bean
-    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-        FilterRegistrationBean<ShallowEtagHeaderFilter> registration = new FilterRegistrationBean<>();
-        registration.setFilter(new ShallowEtagHeaderFilter());
-        registration.addUrlPatterns("/api/congestion");
-        return registration;
-    }
 }

--- a/service-congestion/src/main/java/com/danburn/congestion/controller/CongestionController.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/controller/CongestionController.java
@@ -9,11 +9,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -28,10 +30,21 @@ public class CongestionController {
 
     @Operation(summary = "전체 혼잡도 조회", description = "122개 서울 주요 장소의 실시간 혼잡도를 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CongestionResponse>>> findAll() {
+    public ResponseEntity<ApiResponse<List<CongestionResponse>>> findAll(WebRequest webRequest) {
+        List<CongestionResponse> data = congestionService.findAll();
+        String eTag = "\"" + Integer.toHexString(data.hashCode()) + "\"";
+
+        if (webRequest.checkNotModified(eTag)) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED)
+                    .eTag(eTag)
+                    .cacheControl(CacheControl.maxAge(5, TimeUnit.SECONDS).mustRevalidate())
+                    .build();
+        }
+
         return ResponseEntity.ok()
+                .eTag(eTag)
                 .cacheControl(CacheControl.maxAge(5, TimeUnit.SECONDS).mustRevalidate())
-                .body(ApiResponse.ok(congestionService.findAll()));
+                .body(ApiResponse.ok(data));
     }
 
     @Operation(summary = "장소별 혼잡도 조회", description = "areaCode로 특정 장소의 실시간 혼잡도를 조회합니다.")

--- a/service-congestion/src/test/java/com/danburn/congestion/controller/CongestionControllerTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/controller/CongestionControllerTest.java
@@ -16,6 +16,8 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -95,5 +97,31 @@ class CongestionControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.message").value("해당 장소의 혼잡도 데이터가 없습니다. areaCode: POI999"));
+    }
+
+    @Test
+    @DisplayName("GET /api/congestion → 200 OK + ETag 헤더 반환")
+    void findAll_returnsETag() throws Exception {
+        List<CongestionResponse> responses = List.of(createResponse("POI001", "붐빔"));
+        given(congestionService.findAll()).willReturn(responses);
+        String expectedETag = "\"" + Integer.toHexString(responses.hashCode()) + "\"";
+
+        mockMvc.perform(get("/api/congestion"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("ETag", expectedETag));
+    }
+
+    @Test
+    @DisplayName("GET /api/congestion → If-None-Match 일치 시 304 Not Modified 반환")
+    void findAll_notModified() throws Exception {
+        List<CongestionResponse> responses = List.of(createResponse("POI001", "붐빔"));
+        given(congestionService.findAll()).willReturn(responses);
+        String expectedETag = "\"" + Integer.toHexString(responses.hashCode()) + "\"";
+
+        mockMvc.perform(get("/api/congestion")
+                        .header("If-None-Match", expectedETag))
+                .andExpect(status().isNotModified())
+                .andExpect(header().string("ETag", expectedETag))
+                .andExpect(content().string(""));
     }
 }


### PR DESCRIPTION
## Summary
- prod 검증 결과 `ShallowEtagHeaderFilter` 가 응답에 ETag 헤더를 추가하지 않음 (gzip/응답 크기/필터 체인 추정)
- 컨트롤러에서 `WebRequest#checkNotModified` 로 직접 처리하도록 전환 → ETag 헤더 보장 + 304 응답

## 변경
- `CongestionController.findAll` 에 `WebRequest` 주입 + `data.hashCode()` 기반 ETag + `checkNotModified` 분기
- `CacheConfig` 의 `ShallowEtagHeaderFilter` Bean/import 제거

## Test plan
- [x] :service-congestion:test 통과
- [ ] CI 통과 → dev 머지
- [ ] dev → main 후 prod 검증: `curl -I -H "If-None-Match: <etag>" https://api.goseoul.today/api/congestion` 가 304 반환