### PR TITLE
fix: 실시간 이벤트(집회·행사) 혼잡 분석 누락 차단

### DIFF
--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -85,9 +85,10 @@ def _has_today_marker(text: str, today: date) -> bool:
 # 기사 합성이므로 정확히 오늘이 아니라 최근이면 충분하다. 다일(多日) 집회·행사 커버.
 _RECENT_WINDOW_DAYS = 2
 
-# DDG 백엔드별 상대 발행일 표기 ("15 hours ago", "1일 전" 등) 파싱용
+# DDG 백엔드별 상대 발행일 표기 ("15 hours ago", "1일 전" 등) 파싱용.
+# ago/전 접미사를 강제해 절대날짜("5월 1일")의 '1일'을 상대표현으로 오파싱하는 것을 막는다.
 _RELATIVE_DATE_RE = re.compile(
-    r"(\d+)\s*(second|minute|hour|day|week|month|초|분|시간|일|주|개월|달)"
+    r"(\d+)\s*(second|minute|hour|day|week|month|초|분|시간|일|주|개월|달)(?:s?\s+ago|\s*전)"
 )
 
 
@@ -101,7 +102,9 @@ def _parse_pub_date(date_str: str, today: date) -> date | None:
     if not s:
         return None
     try:
-        dt = datetime.fromisoformat(s)
+        # Python 3.10 이하 fromisoformat 은 'Z' 접미사 미지원 → +00:00 으로 치환
+        iso = s[:-1] + "+00:00" if s.endswith("Z") else s
+        dt = datetime.fromisoformat(iso)
         dt = dt.astimezone(_KST) if dt.tzinfo else dt.replace(tzinfo=_KST)
         return dt.date()
     except ValueError:

--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import logging
 import re
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -81,12 +81,74 @@ def _has_today_marker(text: str, today: date) -> bool:
     return any(v in text for v in _today_date_variants(today))
 
 
-def _results_cover_today(tool_results: list[dict[str, Any]], today: date) -> bool:
-    """검색 결과(title+body) 합본에 오늘 날짜 표기가 하나라도 있으면 True.
+# 발행일을 이벤트일 기준 '최근'으로 인정할 폭(일). 가드의 실제 적은 몇 달 전
+# 기사 합성이므로 정확히 오늘이 아니라 최근이면 충분하다. 다일(多日) 집회·행사 커버.
+_RECENT_WINDOW_DAYS = 2
 
-    있으면 검색이 오늘 일정을 다룬 것으로 보고 모델 응답을 신뢰한다.
-    없으면 모델이 과거 기사로 사건을 합성했을 수 있으므로 신뢰하지 않는다.
+# DDG 백엔드별 상대 발행일 표기 ("15 hours ago", "1일 전" 등) 파싱용
+_RELATIVE_DATE_RE = re.compile(
+    r"(\d+)\s*(second|minute|hour|day|week|month|초|분|시간|일|주|개월|달)"
+)
+
+
+def _parse_pub_date(date_str: str, today: date) -> date | None:
+    """기사 발행일을 date 로 파싱. ISO·상대표현 모두 처리, 실패 시 None.
+
+    DDG 는 호출마다 백엔드를 바꿔 date 형식이 ISO 거나 "15 hours ago" 처럼
+    상대표현이다. 상대표현은 today(이벤트일) 기준으로 환산한다.
     """
+    s = date_str.strip()
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s)
+        dt = dt.astimezone(_KST) if dt.tzinfo else dt.replace(tzinfo=_KST)
+        return dt.date()
+    except ValueError:
+        pass
+    low = s.lower()
+    if "today" in low or "오늘" in low:
+        return today
+    if "yesterday" in low or "어제" in low:
+        return today - timedelta(days=1)
+    m = _RELATIVE_DATE_RE.search(low)
+    if m:
+        n = int(m.group(1))
+        unit = m.group(2)
+        if unit in ("second", "minute", "hour", "초", "분", "시간"):
+            return today
+        if unit in ("day", "일"):
+            return today - timedelta(days=n)
+        if unit in ("week", "주"):
+            return today - timedelta(weeks=n)
+        if unit in ("month", "개월", "달"):
+            return today - timedelta(days=30 * n)
+    return None
+
+
+def _result_date_recent(date_str: str, today: date) -> bool:
+    """기사 발행일이 이벤트일 기준 _RECENT_WINDOW_DAYS 이내면 True.
+
+    한국 뉴스는 본문에 '6일'처럼 월을 생략해 본문 토큰 매칭이 자주 실패한다.
+    최근 발행 뉴스는 오늘 이벤트일 가능성이 높고, 발행일 기준이라 몇 달 전
+    기사 합성은 같이 차단되므로 본문 토큰 매칭의 보완 신호로 쓴다.
+    """
+    art = _parse_pub_date(date_str, today)
+    if art is None:
+        return False
+    return abs((art - today).days) <= _RECENT_WINDOW_DAYS
+
+
+def _results_cover_today(tool_results: list[dict[str, Any]], today: date) -> bool:
+    """검색 결과가 오늘(이벤트일) 일정을 다룬 것으로 볼 수 있으면 True.
+
+    - 기사 발행일이 최근(±_RECENT_WINDOW_DAYS)이거나
+    - title+body 합본에 오늘 날짜 표기가 하나라도 있으면 통과.
+    있으면 모델 응답을 신뢰한다. 없으면 모델이 과거 기사로 사건을 합성했을 수
+    있으므로 신뢰하지 않는다.
+    """
+    if any(_result_date_recent(r.get("date") or "", today) for r in tool_results):
+        return True
     haystack = " ".join(
         part
         for r in tool_results

--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -103,7 +103,7 @@ def _parse_pub_date(date_str: str, today: date) -> date | None:
         return None
     try:
         # Python 3.10 이하 fromisoformat 은 'Z' 접미사 미지원 → +00:00 으로 치환
-        iso = s[:-1] + "+00:00" if s.endswith("Z") else s
+        iso = s[:-1] + "+00:00" if s.endswith(("Z", "z")) else s
         dt = datetime.fromisoformat(iso)
         dt = dt.astimezone(_KST) if dt.tzinfo else dt.replace(tzinfo=_KST)
         return dt.date()

--- a/service-ai/tests/test_anti_hallucination.py
+++ b/service-ai/tests/test_anti_hallucination.py
@@ -11,6 +11,8 @@ from datetime import date
 
 from app.ai.openai.client import (
     _has_today_marker,
+    _parse_pub_date,
+    _result_date_recent,
     _results_cover_today,
     _today_date_variants,
 )
@@ -86,3 +88,67 @@ class TestResultsCoverToday:
 
     def test_false_on_empty_results(self) -> None:
         assert _results_cover_today([], TODAY) is False
+
+    def test_true_when_pubdate_today_but_body_omits_month(self) -> None:
+        # 운영 사고 재현: 오늘 발행 집회 기사인데 본문이 '19일'처럼 월을 생략해
+        # 본문 토큰 매칭은 실패하지만 발행일로 통과해야 한다.
+        results = [
+            {
+                "title": "재선거 요구 잠실 개표소 앞 3000명 집결",
+                "date": "2026-05-19T04:52:59+00:00",
+                "body": "19일 연합뉴스에 따르면 이날 낮 12시 잠실 일대에 2000명쯤 집결",
+            },
+        ]
+        assert _has_today_marker(results[0]["body"], TODAY) is False
+        assert _results_cover_today(results, TODAY) is True
+
+    def test_true_when_relative_pubdate(self) -> None:
+        # DDG yahoo/bing 백엔드가 뱉는 상대표현 — 본문엔 날짜 없음
+        results = [
+            {
+                "title": "올림픽공원 개표소 봉쇄 집회",
+                "date": "Opinion15 hours ago",
+                "body": "재선거 요구 시위대가 핸드볼경기장 일대에 집결",
+            },
+        ]
+        assert _results_cover_today(results, TODAY) is True
+
+
+class TestParsePubDate:
+    def test_iso_utc_converted_to_kst(self) -> None:
+        # 04:52 UTC == 13:52 KST 같은 날
+        assert _parse_pub_date("2026-05-19T04:52:59+00:00", TODAY) == date(2026, 5, 19)
+
+    def test_iso_kst_boundary(self) -> None:
+        # 2026-05-19 16:00 UTC == 2026-05-20 01:00 KST
+        assert _parse_pub_date("2026-05-19T16:00:00+00:00", TODAY) == date(2026, 5, 20)
+
+    def test_relative_hours_ago_maps_to_today(self) -> None:
+        assert _parse_pub_date("15 hours ago", TODAY) == TODAY
+        assert _parse_pub_date("3시간 전", TODAY) == TODAY
+
+    def test_relative_days_ago(self) -> None:
+        assert _parse_pub_date("2 days ago", TODAY) == date(2026, 5, 17)
+        assert _parse_pub_date("1일 전", TODAY) == date(2026, 5, 18)
+
+    def test_today_yesterday_words(self) -> None:
+        assert _parse_pub_date("today", TODAY) == TODAY
+        assert _parse_pub_date("어제", TODAY) == date(2026, 5, 18)
+
+    def test_none_on_empty_or_unparsable(self) -> None:
+        assert _parse_pub_date("", TODAY) is None
+        assert _parse_pub_date("not-a-date", TODAY) is None
+
+
+class TestResultDateRecent:
+    def test_recent_within_window(self) -> None:
+        assert _result_date_recent("2026-05-18T00:00:00+00:00", TODAY) is True  # 1일 전
+        assert _result_date_recent("15 hours ago", TODAY) is True
+
+    def test_old_article_rejected(self) -> None:
+        # 원래 사고: 두 달 전 기사
+        assert _result_date_recent("2026-03-29T09:02:00+00:00", TODAY) is False
+
+    def test_unparsable_rejected(self) -> None:
+        assert _result_date_recent("", TODAY) is False
+        assert _result_date_recent("garbage", TODAY) is False

--- a/service-ai/tests/test_anti_hallucination.py
+++ b/service-ai/tests/test_anti_hallucination.py
@@ -139,6 +139,12 @@ class TestParsePubDate:
         assert _parse_pub_date("", TODAY) is None
         assert _parse_pub_date("not-a-date", TODAY) is None
 
+    def test_absolute_korean_date_not_parsed_as_relative(self) -> None:
+        # ago/전 접미사 없는 절대날짜는 상대표현으로 오파싱되면 안 된다.
+        # "5월 1일"의 '1일'을 today-1 로 오판하면 옛 기사가 최근으로 둔갑(가드 우회).
+        assert _parse_pub_date("2026년 5월 19일", TODAY) is None
+        assert _parse_pub_date("5월 1일", TODAY) is None
+
 
 class TestResultDateRecent:
     def test_recent_within_window(self) -> None:

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -42,11 +42,11 @@ public class AnomalyDetector {
     private final StringRedisTemplate stringRedisTemplate;
 
     // 필드 초기값 = @Value 기본값. Spring 미기동 단위 테스트에서도 실제 임계값으로 동작.
-    @Value("${congestion.anomaly.max-people-ratio:1.5}")
-    private double ratioThreshold = 1.5;
+    @Value("${congestion.anomaly.max-people-ratio:1.3}")
+    private double ratioThreshold = 1.3;
 
-    @Value("${congestion.anomaly.min-people-delta:3000}")
-    private double deltaThreshold = 3000;
+    @Value("${congestion.anomaly.min-people-delta:2000}")
+    private double deltaThreshold = 2000;
 
     public List<CongestionAnomalyEvent> detectAnomalies(List<CongestionRedisDto> busyDtos) {
         if (busyDtos.isEmpty()) {

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -90,5 +90,5 @@ congestion:
     cron: ${CONGESTION_CLEANUP_CRON:0 0 3 * * *}
     retention-days: ${CONGESTION_CLEANUP_RETENTION_DAYS:7}
   anomaly:
-    max-people-ratio: ${CONGESTION_ANOMALY_MAX_PEOPLE_RATIO:1.5}
-    min-people-delta: ${CONGESTION_ANOMALY_MIN_PEOPLE_DELTA:3000}
+    max-people-ratio: ${CONGESTION_ANOMALY_MAX_PEOPLE_RATIO:1.3}
+    min-people-delta: ${CONGESTION_ANOMALY_MIN_PEOPLE_DELTA:2000}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -82,7 +82,7 @@ class AnomalyDetectorTest {
         @DisplayName("ratio >= threshold → anomaly 이벤트 발행")
         void ratioExceedsThreshold() {
             CongestionRedisDto dto = busyDto("POI001", 30000);
-            // avgMax=15000, ratio=2.0 >= 1.5
+            // avgMax=15000, ratio=2.0 >= 1.3
             given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.of(15000.0));
             given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
             given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
@@ -97,7 +97,7 @@ class AnomalyDetectorTest {
         @DisplayName("ratio < threshold 이나 절대 증가분 >= delta → anomaly 발행 (baseline 높은 지역)")
         void deltaExceedsThreshold() {
             CongestionRedisDto dto = busyDto("POI127", 20000);
-            // avgMax=17000, ratio=1.18 < 1.5, delta=3000 >= 3000
+            // avgMax=17000, ratio=1.18 < 1.3, delta=3000 >= 2000
             given(hourlyAvgCacheService.getAvgMax(eq("POI127"), any(int.class))).willReturn(Optional.of(17000.0));
             given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
             given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
@@ -112,8 +112,8 @@ class AnomalyDetectorTest {
         @DisplayName("ratio < threshold 이고 절대 증가분 < delta → anomaly 없음")
         void ratioAndDeltaBelowThreshold() {
             CongestionRedisDto dto = busyDto("POI127", 20000);
-            // avgMax=18000, ratio=1.11 < 1.5, delta=2000 < 3000
-            given(hourlyAvgCacheService.getAvgMax(eq("POI127"), any(int.class))).willReturn(Optional.of(18000.0));
+            // avgMax=19000, ratio=1.05 < 1.3, delta=1000 < 2000
+            given(hourlyAvgCacheService.getAvgMax(eq("POI127"), any(int.class))).willReturn(Optional.of(19000.0));
 
             List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
 
@@ -123,10 +123,25 @@ class AnomalyDetectorTest {
         }
 
         @Test
+        @DisplayName("baseline 높은 지역 평소보다 +2000(delta 임계) → anomaly 발행 (집회·행사 캐치)")
+        void deltaAtThresholdCatchesHighBaseline() {
+            CongestionRedisDto dto = busyDto("POI127", 20000);
+            // avgMax=18000, ratio=1.11 < 1.3, delta=2000 >= 2000 (하향된 임계로 새로 잡힘)
+            given(hourlyAvgCacheService.getAvgMax(eq("POI127"), any(int.class))).willReturn(Optional.of(18000.0));
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).ratio()).isNotNull();
+        }
+
+        @Test
         @DisplayName("ratio < threshold → anomaly 없음")
         void ratioBelowThreshold() {
             CongestionRedisDto dto = busyDto("POI001", 15000);
-            // avgMax=20000, ratio=0.75 < 1.5
+            // avgMax=20000, ratio=0.75 < 1.3
             given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.of(20000.0));
 
             List<CongestionAnomalyEvent> events = anomalyDetector.detectAnomalies(List.of(dto));


### PR DESCRIPTION
## 문제
집회 등 실시간 이벤트로 붐비는데도 AI 분석이 \"점심 방문객\" 같은 일반 문구로 묻히는 사례.

운영 로그(올림픽공원/월드컵공원)와 실측으로 원인 추적:
- anomaly 분류·`search_web` 호출·검색 결과 수신까지 **모두 정상 동작**
- 진짜 원인은 `_results_cover_today`: 오늘 발행된 집회 기사인데도 본문이 `6일`처럼 월을 생략하면 `6월 6일` 토큰 매칭에 실패 → 통째로 폐기 → 일반 분석으로 재생성

## 변경
### service-ai (핵심 수정)
- `_results_cover_today`: \"정확히 오늘 날짜 토큰\" → **\"발행일이 이벤트일 기준 최근(±2일)\"** 으로 보완
- `_parse_pub_date`: ISO + DDG 백엔드별 상대표현(`15 hours ago`, `N일 전`, `오늘/어제`) 파싱
- 가드 본래 목적(몇 달 전 기사 합성 차단)은 유지 — 발행일 기준이라 오히려 더 견고
- 실측: 기존 방식이면 폐기됐을 집회 케이스 3/3 통과

### service-congestion (부수 개선)
- anomaly 임계 하향: ratio 1.5→1.3, delta 3000→2000
- baseline 높은 공원·체육시설이 +2~3천명에도 normal로 빠지던 케이스 보완

## 테스트
- service-ai: 전체 통과 (anti_hallucination 신규 헬퍼/회귀 테스트 포함)
- service-congestion: 전체 통과 (delta 임계 회귀 테스트 추가)

## 알려진 한계
- 예고형 단발 행사는 best-effort (발행일로 행사일을 구분 못 함, hop2 LLM 프롬프트가 보완)
- DDG 백엔드 로테이션으로 검색 비결정적 — 단, 실패 시 기존 동작(일반 문구)이라 회귀 없음