### PR TITLE
refactor: Mobility service 서킷 브레이커 적용 및 추가개선

### DIFF
--- a/service-mobility/build.gradle
+++ b/service-mobility/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
 

--- a/service-mobility/src/main/java/com/danburn/mobility/exception/OdsayServerException.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/exception/OdsayServerException.java
@@ -1,0 +1,8 @@
+package com.danburn.mobility.exception;
+
+public class OdsayServerException extends RuntimeException {
+
+    public OdsayServerException(String message) {
+        super(message);
+    }
+}

--- a/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Component
 @RequiredArgsConstructor
@@ -19,18 +20,23 @@ public class OdsayApiClient {
   private String odsayApiKey;
 
   public OdsayApiResponse fetchOdsayRoute(OdsayApiRequest odsayApiRequest){
-    OdsayApiResponse response = odsayRestClient.get()
-      .uri(uriBuilder -> uriBuilder
-        .path("/searchPubTransPathT")
-        .queryParam("apiKey",odsayApiKey)
-        .queryParam("SX",odsayApiRequest.originLng())
-        .queryParam("SY",odsayApiRequest.originLat())
-        .queryParam("EX",odsayApiRequest.destLng())
-        .queryParam("EY",odsayApiRequest.destLat())
-        .queryParam("SearchType",0)
-        .build())
-      .retrieve()
-      .body(OdsayApiResponse.class);
+    OdsayApiResponse response;
+    try {
+      response = odsayRestClient.get()
+        .uri(uriBuilder -> uriBuilder
+          .path("/searchPubTransPathT")
+          .queryParam("apiKey",odsayApiKey)
+          .queryParam("SX",odsayApiRequest.originLng())
+          .queryParam("SY",odsayApiRequest.originLat())
+          .queryParam("EX",odsayApiRequest.destLng())
+          .queryParam("EY",odsayApiRequest.destLat())
+          .queryParam("SearchType",0)
+          .build())
+        .retrieve()
+        .body(OdsayApiResponse.class);
+    } catch (RestClientException e) {
+      throw new OdsayServerException("ODsay API 호출 실패: " + e.getMessage());
+    }
     if (response == null) {
       throw new OdsayServerException("ODsay API 응답이 없습니다.");
     }

--- a/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
@@ -3,12 +3,12 @@ package com.danburn.mobility.infra;
 import com.danburn.common.exception.GlobalException;
 import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.OdsayApiResponse;
+import com.danburn.mobility.exception.OdsayServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.util.UriBuilder;
 
 @Component
 @RequiredArgsConstructor
@@ -31,8 +31,11 @@ public class OdsayApiClient {
         .build())
       .retrieve()
       .body(OdsayApiResponse.class);
-    if (response == null || response.result() == null) {
-      throw new GlobalException(HttpStatus.BAD_GATEWAY.value(), "ODsay API 응답이 올바르지 않습니다.");
+    if (response == null) {
+      throw new OdsayServerException("ODsay API 응답이 없습니다.");
+    }
+    if (response.result() == null) {
+      throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "경로를 찾을 수 없습니다.");
     }
     return response;
   }

--- a/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
@@ -41,7 +41,7 @@ public class OdsayApiClient {
       throw new OdsayServerException("ODsay API 응답이 없습니다.");
     }
     if (response.result() == null) {
-      throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "경로를 찾을 수 없습니다.");
+      throw new GlobalException(HttpStatus.NOT_FOUND.value(), "경로를 찾을 수 없습니다.");
     }
     return response;
   }

--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -1,11 +1,16 @@
 package com.danburn.mobility.service;
 
+import com.danburn.common.exception.GlobalException;
 import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.TransitRouteResponse;
 import com.danburn.mobility.infra.OdsayApiClient;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OdsayService {
@@ -13,9 +18,15 @@ public class OdsayService {
     private final OdsayApiClient odsayApiClient;
     private final OdsayResponseMapper odsayResponseMapper;
 
+    @CircuitBreaker(name = "odsay", fallbackMethod = "fetchOdsayRouteFallback")
     public TransitRouteResponse fetchOdsayRoute(OdsayApiRequest odsayApiRequest) {
         return odsayResponseMapper.toResponse(
                 odsayApiClient.fetchOdsayRoute(odsayApiRequest)
         );
+    }
+
+    private TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
+        log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
+        throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }
 }

--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -5,6 +5,7 @@ import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.TransitRouteResponse;
 import com.danburn.mobility.infra.OdsayApiClient;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ public class OdsayService {
     private final OdsayResponseMapper odsayResponseMapper;
 
     @CircuitBreaker(name = "odsay", fallbackMethod = "fetchOdsayRouteFallback")
+    @Retry(name = "odsay")
     public TransitRouteResponse fetchOdsayRoute(OdsayApiRequest odsayApiRequest) {
         return odsayResponseMapper.toResponse(
                 odsayApiClient.fetchOdsayRoute(odsayApiRequest)
@@ -26,6 +28,9 @@ public class OdsayService {
     }
 
     TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
+        if (t instanceof GlobalException e) {
+            throw e;
+        }
         log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
         throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }

--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -25,7 +25,7 @@ public class OdsayService {
         );
     }
 
-    private TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
+    TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
         log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
         throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -38,6 +38,21 @@ management:
     tracing:
       endpoint: ${OTLP_TRACES_URL:http://localhost:4318/v1/traces}
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      odsay:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        record-exceptions:
+          - com.danburn.mobility.exception.OdsayServerException
+        ignore-exceptions:
+          - com.danburn.common.exception.GlobalException
+
 logging:
   loki:
     url: ${LOKI_URL:http://localhost:3100/loki/api/v1/push}

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -52,6 +52,15 @@ resilience4j:
           - com.danburn.mobility.exception.OdsayServerException
         ignore-exceptions:
           - com.danburn.common.exception.GlobalException
+  retry:
+    instances:
+      odsay:
+        max-attempts: 2
+        wait-duration: 500ms
+        retry-exceptions:
+          - com.danburn.mobility.exception.OdsayServerException
+        ignore-exceptions:
+          - com.danburn.common.exception.GlobalException
 
 logging:
   loki:

--- a/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
@@ -79,6 +80,17 @@ class OdsayApiClientTest {
             assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(OdsayServerException.class)
                     .hasMessage("ODsay API 응답이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("네트워크 오류 시 OdsayServerException을 던진다")
+        void network_error_throws_odsay_server_exception() {
+            given(responseSpec.body(OdsayApiResponse.class))
+                    .willThrow(new ResourceAccessException("연결 거부"));
+
+            assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(OdsayServerException.class)
+                    .hasMessageContaining("ODsay API 호출 실패");
         }
 
         @Test

--- a/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
@@ -94,15 +94,15 @@ class OdsayApiClientTest {
         }
 
         @Test
-        @DisplayName("result가 null이면 GlobalException 503을 던진다")
-        void null_result_throws_global_exception_503() {
+        @DisplayName("result가 null이면 GlobalException 404를 던진다")
+        void null_result_throws_global_exception_404() {
             given(responseSpec.body(OdsayApiResponse.class)).willReturn(new OdsayApiResponse(null));
 
             assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage("경로를 찾을 수 없습니다.")
                     .extracting(e -> ((GlobalException) e).getStatus())
-                    .isEqualTo(503);
+                    .isEqualTo(404);
         }
     }
 

--- a/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
@@ -1,0 +1,106 @@
+package com.danburn.mobility.infra;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.mobility.dto.request.OdsayApiRequest;
+import com.danburn.mobility.dto.response.OdsayApiResponse;
+import com.danburn.mobility.exception.OdsayServerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OdsayApiClient 단위 테스트")
+class OdsayApiClientTest {
+
+    @Mock
+    private RestClient restClient;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private RestClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private RestClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private OdsayApiClient odsayApiClient;
+
+    private static final OdsayApiRequest REQUEST =
+            new OdsayApiRequest(127.1272127, 37.3213399, 127.028001, 37.498086);
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        odsayApiClient = new OdsayApiClient(restClient);
+        ReflectionTestUtils.setField(odsayApiClient, "odsayApiKey", "test-key");
+
+        given(restClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(any(Function.class))).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+    }
+
+    @Nested
+    @DisplayName("fetchOdsayRoute")
+    class FetchOdsayRoute {
+
+        @Test
+        @DisplayName("정상 응답 시 OdsayApiResponse를 반환한다")
+        void success_returns_response() {
+            OdsayApiResponse response = buildApiResponse();
+            given(responseSpec.body(OdsayApiResponse.class)).willReturn(response);
+
+            OdsayApiResponse result = odsayApiClient.fetchOdsayRoute(REQUEST);
+
+            assertThat(result).isSameAs(response);
+        }
+
+        @Test
+        @DisplayName("응답이 null이면 OdsayServerException을 던진다")
+        void null_response_throws_odsay_server_exception() {
+            given(responseSpec.body(OdsayApiResponse.class)).willReturn(null);
+
+            assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(OdsayServerException.class)
+                    .hasMessage("ODsay API 응답이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("result가 null이면 GlobalException 503을 던진다")
+        void null_result_throws_global_exception_503() {
+            given(responseSpec.body(OdsayApiResponse.class)).willReturn(new OdsayApiResponse(null));
+
+            assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("경로를 찾을 수 없습니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(503);
+        }
+    }
+
+    private OdsayApiResponse buildApiResponse() {
+        OdsayApiResponse.Info info =
+                new OdsayApiResponse.Info(30, 1500, 1, 0, "출발역", "도착역");
+        OdsayApiResponse.SubPath walk =
+                new OdsayApiResponse.SubPath(3, 5, null, null, null, null);
+        OdsayApiResponse.Path path =
+                new OdsayApiResponse.Path(info, List.of(walk));
+        return new OdsayApiResponse(new OdsayApiResponse.Result(0, List.of(path)));
+    }
+}

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -84,6 +84,35 @@ class OdsayServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("fetchOdsayRouteFallback")
+    class FetchOdsayRouteFallback {
+
+        @Test
+        @DisplayName("OdsayServerException 발생 시 GlobalException 503을 던진다")
+        void fallback_on_server_exception_throws_503() {
+            Throwable cause = new com.danburn.mobility.exception.OdsayServerException("ODsay API 응답이 없습니다.");
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("대중교통 경로 조회 서비스가 일시적으로 불가합니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(503);
+        }
+
+        @Test
+        @DisplayName("RuntimeException 발생 시 GlobalException 503을 던진다")
+        void fallback_on_runtime_exception_throws_503() {
+            Throwable cause = new RuntimeException("네트워크 오류");
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("대중교통 경로 조회 서비스가 일시적으로 불가합니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(503);
+        }
+    }
+
     private OdsayApiResponse buildApiResponse() {
         OdsayApiResponse.Info info =
                 new OdsayApiResponse.Info(30, 1500, 1, 0, "출발역", "도착역");

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -61,7 +61,7 @@ class OdsayServiceTest {
         @DisplayName("client가 GlobalException을 던지면 그대로 전파된다")
         void client_throws_global_exception_propagates() {
             given(odsayApiClient.fetchOdsayRoute(REQUEST))
-                    .willThrow(new GlobalException(503, "경로를 찾을 수 없습니다."));
+                    .willThrow(new GlobalException(404, "경로를 찾을 수 없습니다."));
 
             assertThatThrownBy(() -> odsayService.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(GlobalException.class)
@@ -88,6 +88,18 @@ class OdsayServiceTest {
     @Nested
     @DisplayName("fetchOdsayRouteFallback")
     class FetchOdsayRouteFallback {
+
+        @Test
+        @DisplayName("GlobalException 발생 시 그대로 전파된다")
+        void fallback_on_global_exception_rethrows() {
+            GlobalException cause = new GlobalException(404, "경로를 찾을 수 없습니다.");
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("경로를 찾을 수 없습니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(404);
+        }
 
         @Test
         @DisplayName("OdsayServerException 발생 시 GlobalException 503을 던진다")

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -4,6 +4,7 @@ import com.danburn.common.exception.GlobalException;
 import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.OdsayApiResponse;
 import com.danburn.mobility.dto.response.TransitRouteResponse;
+import com.danburn.mobility.exception.OdsayServerException;
 import com.danburn.mobility.infra.OdsayApiClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,11 +61,11 @@ class OdsayServiceTest {
         @DisplayName("client가 GlobalException을 던지면 그대로 전파된다")
         void client_throws_global_exception_propagates() {
             given(odsayApiClient.fetchOdsayRoute(REQUEST))
-                    .willThrow(new GlobalException(502, "ODsay API 응답이 올바르지 않습니다."));
+                    .willThrow(new GlobalException(503, "경로를 찾을 수 없습니다."));
 
             assertThatThrownBy(() -> odsayService.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(GlobalException.class)
-                    .hasMessage("ODsay API 응답이 올바르지 않습니다.");
+                    .hasMessage("경로를 찾을 수 없습니다.");
 
             then(odsayResponseMapper).shouldHaveNoInteractions();
         }


### PR DESCRIPTION
## 작업 내용

### 서킷 브레이커 적용
- [x] `OdsayServerException` 추가 (ODsay 서버 장애 전용 예외)
- [x] `OdsayApiClient` 예외 분리
  - [x] 네트워크 오류 / 응답 null → `OdsayServerException`
  - [x] 경로 없음(result null) → `GlobalException` ~~503~~ → 404
- [x] Resilience4j 의존성 추가 및 서킷 브레이커 설정 (`application.yml`)
- [x] `OdsayService`에 `@CircuitBreaker` 및 fallback 메서드 적용

--- 

### 추가 개선
- [x] `@Retry` 추가 및 retry 설정 적용 (`max-attempts: 2, wait-duration: 500ms`)
- [x] fallback에서 `GlobalException` rethrow 처리 (비즈니스 예외 메시지 보존)

--- 

### 테스트
- [x] `OdsayApiClientTest` 추가
- [x] `OdsayServiceTest` fallback 테스트 추가
- [x] `GlobalException` rethrow 테스트 추가

--- 

### 참고 내용
- [x] AI 리뷰 중 서킷브레이커 retry 순서에서 서킷브레이커가 우선순위가 높기 때문에 수정하지 않음
