### PR TITLE
fix: 의존성 추가 및 서킷브레이커 모니터링 추가(#356)

### DIFF
--- a/service-mobility/build.gradle
+++ b/service-mobility/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
 

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -19,10 +19,13 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics
+        include: health, info, metrics, circuitbreakers
   endpoint:
     health:
       show-details: always
+  health:
+    circuitbreakers:
+      enabled: true
   metrics:
     distribution:
       percentiles-histogram:
@@ -42,6 +45,7 @@ resilience4j:
   circuitbreaker:
     instances:
       odsay:
+        register-health-indicator: true
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 5


### PR DESCRIPTION
## 작업 이유
ODsay API 호출 시 아무런 장애 대응이 없어, 서버 다운 시 타임아웃 5초까지
블로킹 상태가 유지되고 사용자에게 느린 에러 응답이 반환되는 문제 개선

---

## 작업 내용
- [x] `OdsayServerException` 추가 (ODsay 서버 장애 전용 예외)
- [x] `OdsayApiClient` 예외 분리
  - [x] 네트워크 오류 / 응답 null → `OdsayServerException`
  - [x] 경로 없음(result null) → `GlobalException` 404
- [x] Resilience4j 의존성 추가 및 서킷 브레이커 설정 (`application.yml`)
- [x] `OdsayService`에 `@CircuitBreaker` 및 fallback 메서드 적용
- [x] fallback에서 `GlobalException` rethrow 처리 (비즈니스 예외 메시지 보존)
- [x] `@Retry` 추가 (max-attempts: 2, wait-duration: 500ms)
- [x] `OdsayApiClientTest` 추가
- [x] `OdsayServiceTest` fallback 및 rethrow 테스트 추가