### PR TITLE
feat(congestion): 혼잡 지속 시 anomaly 1시간 주기 재분석

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -141,8 +141,9 @@ public class AnomalyDetector {
     private boolean tryArm(String areaCode) {
         String key = ARMED_KEY_PREFIX + areaCode;
         try {
+            long ttlMinutes = Math.max(1, reanalysisTtlMinutes);
             Boolean set = stringRedisTemplate.opsForValue()
-                    .setIfAbsent(key, "1", Duration.ofMinutes(reanalysisTtlMinutes));
+                    .setIfAbsent(key, "1", Duration.ofMinutes(ttlMinutes));
             return Boolean.TRUE.equals(set);
         } catch (Exception e) {
             log.warn("[AnomalyDetector] armed 마킹 실패 - areaCode={}, reason={}", areaCode, e.getMessage());

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -140,8 +140,9 @@ public class AnomalyDetector {
 
     private boolean tryArm(String areaCode) {
         String key = ARMED_KEY_PREFIX + areaCode;
+        // 오설정(0 이하) 시 1분 스팸 대신 기본값으로 안전 복귀 (재분석 비용 보호)
+        long ttlMinutes = reanalysisTtlMinutes > 0 ? reanalysisTtlMinutes : 60;
         try {
-            long ttlMinutes = Math.max(1, reanalysisTtlMinutes);
             Boolean set = stringRedisTemplate.opsForValue()
                     .setIfAbsent(key, "1", Duration.ofMinutes(ttlMinutes));
             return Boolean.TRUE.equals(set);

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -25,8 +25,9 @@ import java.util.Set;
  *
  * - baseline 높은 지역(관광지·체육시설)은 비율로 묻히므로 절대 증가분 OR 조건 병행
  *
- * - rising-edge 1회 발행: Redis SETNX armed 플래그(`congestion:anomaly-armed:{areaCode}`, TTL 24h)
- * - BUSY 해제 시 armed 플래그 명시 삭제 (BUSY 재진입 시 재발행 허용)
+ * - 발행 중복 차단: Redis SETNX armed 플래그(`congestion:anomaly-armed:{areaCode}`, TTL=reanalysis-ttl-minutes)
+ *   TTL 만료 후에도 BUSY 지속이면 재arm → 재발행 → 재분석. 즉 BUSY 지속 시 주기적 재분석(기본 60분)
+ * - BUSY 해제 시 armed 플래그 명시 삭제 (BUSY 재진입 시 즉시 재발행 허용)
  * - baseline 부재 시 보수적으로 anomaly=true fallback
  */
 @Slf4j
@@ -35,7 +36,6 @@ import java.util.Set;
 public class AnomalyDetector {
 
     private static final String ARMED_KEY_PREFIX = "congestion:anomaly-armed:";
-    private static final Duration ARMED_TTL = Duration.ofHours(24);
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final HourlyAvgCacheService hourlyAvgCacheService;
@@ -47,6 +47,10 @@ public class AnomalyDetector {
 
     @Value("${congestion.anomaly.min-people-delta:2000}")
     private double deltaThreshold = 2000;
+
+    // armed 플래그 TTL(분) = anomaly 재분석 주기. 만료 후 BUSY 지속이면 재발행 → 재분석.
+    @Value("${congestion.anomaly.reanalysis-ttl-minutes:60}")
+    private long reanalysisTtlMinutes = 60;
 
     public List<CongestionAnomalyEvent> detectAnomalies(List<CongestionRedisDto> busyDtos) {
         if (busyDtos.isEmpty()) {
@@ -137,7 +141,8 @@ public class AnomalyDetector {
     private boolean tryArm(String areaCode) {
         String key = ARMED_KEY_PREFIX + areaCode;
         try {
-            Boolean set = stringRedisTemplate.opsForValue().setIfAbsent(key, "1", ARMED_TTL);
+            Boolean set = stringRedisTemplate.opsForValue()
+                    .setIfAbsent(key, "1", Duration.ofMinutes(reanalysisTtlMinutes));
             return Boolean.TRUE.equals(set);
         } catch (Exception e) {
             log.warn("[AnomalyDetector] armed 마킹 실패 - areaCode={}, reason={}", areaCode, e.getMessage());

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -92,3 +92,4 @@ congestion:
   anomaly:
     max-people-ratio: ${CONGESTION_ANOMALY_MAX_PEOPLE_RATIO:1.3}
     min-people-delta: ${CONGESTION_ANOMALY_MIN_PEOPLE_DELTA:2000}
+    reanalysis-ttl-minutes: ${CONGESTION_ANOMALY_REANALYSIS_TTL_MINUTES:60}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -76,6 +77,21 @@ class AnomalyDetectorTest {
             assertThat(events).hasSize(1);
             assertThat(events.get(0).areaCode()).isEqualTo("POI001");
             assertThat(events.get(0).ratio()).isNull();
+        }
+
+        @Test
+        @DisplayName("armed 플래그 TTL = 재분석 주기(기본 1시간)로 SETNX")
+        void armedTtlIsReanalysisInterval() {
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            anomalyDetector.detectAnomalies(List.of(dto));
+
+            ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+            then(valueOps).should().setIfAbsent(anyString(), eq("1"), ttlCaptor.capture());
+            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofHours(1));
         }
 
         @Test

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -98,6 +98,23 @@ class AnomalyDetectorTest {
         }
 
         @Test
+        @DisplayName("reanalysisTtlMinutes 0 이하 오설정 → 기본 60분으로 안전 복귀")
+        void armedTtlFallsBackToDefaultWhenNonPositive() {
+            ReflectionTestUtils.setField(anomalyDetector, "reanalysisTtlMinutes", 0L);
+
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            anomalyDetector.detectAnomalies(List.of(dto));
+
+            ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+            then(valueOps).should().setIfAbsent(anyString(), eq("1"), ttlCaptor.capture());
+            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofMinutes(60));
+        }
+
+        @Test
         @DisplayName("ratio >= threshold → anomaly 이벤트 발행")
         void ratioExceedsThreshold() {
             CongestionRedisDto dto = busyDto("POI001", 30000);

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
 import java.util.List;
@@ -80,8 +81,10 @@ class AnomalyDetectorTest {
         }
 
         @Test
-        @DisplayName("armed 플래그 TTL = 재분석 주기(기본 1시간)로 SETNX")
+        @DisplayName("armed 플래그 TTL = 설정된 재분석 주기(reanalysisTtlMinutes)로 SETNX")
         void armedTtlIsReanalysisInterval() {
+            ReflectionTestUtils.setField(anomalyDetector, "reanalysisTtlMinutes", 30L);
+
             CongestionRedisDto dto = busyDto("POI001", 30000);
             given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
             given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
@@ -91,7 +94,7 @@ class AnomalyDetectorTest {
 
             ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
             then(valueOps).should().setIfAbsent(anyString(), eq("1"), ttlCaptor.capture());
-            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofHours(1));
+            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofMinutes(30));
         }
 
         @Test


### PR DESCRIPTION
## 배경
지금 AI 분석은 BUSY 상승 엣지(non-BUSY→BUSY) 때 1회만 수행돼, 집회처럼 수 시간 지속되는 혼잡은 첫 분석 1건으로 고정되고 인파·원인이 바뀌어도 리포트가 갱신되지 않음.

## 변경
- AnomalyDetector 의 armed 플래그 TTL 을 24h 고정 → 설정값(`reanalysis-ttl-minutes`, 기본 60분)으로 전환
- TTL 만료 후에도 BUSY 지속이면 재arm → 재발행 → 재분석. 즉 BUSY 지속 시 1시간 주기 재분석
- BUSY 해제 시 armed 삭제(기존 로직)는 유지 — 재진입 시 즉시 재발행

## 범위/비용
- **anomaly(이상 패턴)만** 재분석 — 원인이 변하는 곳만 갱신. 일반 패턴 BUSY(출퇴근·점심)는 문구 고정이라 제외해 LLM/TPD 비용 최소화
- 재분석도 기존 batch + rate limiter + TPD soft limit 파이프라인을 그대로 탐

## 구현 메모
- `@Value`→`Duration` 직접 바인딩 선례가 없어 코드베이스 관례(primitive 바인딩 + 코드에서 Duration 생성)에 맞춰 분 단위 long 으로 바인딩
- 테스트: armed TTL = 재분석 주기(1h) SETNX 검증 추가

## 테스트
- service-congestion 전체 통과 (AnomalyDetectorTest 12건)