### PR TITLE
fix(ai): 상대 발행일 hour 24h↑ 일 환산 (recency 가드 우회 차단)

### DIFF
--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -118,8 +118,11 @@ def _parse_pub_date(date_str: str, today: date) -> date | None:
     if m:
         n = int(m.group(1))
         unit = m.group(2)
-        if unit in ("second", "minute", "hour", "초", "분", "시간"):
+        if unit in ("second", "minute", "초", "분"):
             return today
+        if unit in ("hour", "시간"):
+            # 24h 이상(예: 72 hours ago=3일 전)은 일 단위로 환산해야 가드를 우회 안 함
+            return today - timedelta(days=n // 24)
         if unit in ("day", "일"):
             return today - timedelta(days=n)
         if unit in ("week", "주"):

--- a/service-ai/tests/test_anti_hallucination.py
+++ b/service-ai/tests/test_anti_hallucination.py
@@ -127,6 +127,12 @@ class TestParsePubDate:
         assert _parse_pub_date("15 hours ago", TODAY) == TODAY
         assert _parse_pub_date("3시간 전", TODAY) == TODAY
 
+    def test_relative_hours_over_24_convert_to_days(self) -> None:
+        # 24h 이상은 일 단위 환산 — today 로 오판해 가드 우회하면 안 됨
+        assert _parse_pub_date("36 hours ago", TODAY) == date(2026, 5, 18)
+        assert _parse_pub_date("48 hours ago", TODAY) == date(2026, 5, 17)
+        assert _parse_pub_date("72시간 전", TODAY) == date(2026, 5, 16)
+
     def test_relative_days_ago(self) -> None:
         assert _parse_pub_date("2 days ago", TODAY) == date(2026, 5, 17)
         assert _parse_pub_date("1일 전", TODAY) == date(2026, 5, 18)


### PR DESCRIPTION
## 문제 (#354 gemini 리뷰 지적)
`_parse_pub_date` 의 hour 단위가 값과 무관하게 `today` 반환 → `"72 hours ago"`(3일 전) 같은 옛 기사도 오늘로 오판해 ±2일 recency 가드를 우회.

## 수정
- hour/시간 단위: `today - timedelta(days=n // 24)` 로 환산
  - 15h→오늘, 36h→1일전, 48h→2일전(통과), 72h→3일전(정상 폐기)
- 24h 이상 환산 회귀 테스트 추가

## 테스트
- service-ai anti_hallucination 23건 통과