### PR TITLE
promote: dev→main (hour 환산 수정·anomaly 재분석 외)

### DIFF
--- a/service-ai/app/ai/openai/client.py
+++ b/service-ai/app/ai/openai/client.py
@@ -118,8 +118,11 @@ def _parse_pub_date(date_str: str, today: date) -> date | None:
     if m:
         n = int(m.group(1))
         unit = m.group(2)
-        if unit in ("second", "minute", "hour", "초", "분", "시간"):
+        if unit in ("second", "minute", "초", "분"):
             return today
+        if unit in ("hour", "시간"):
+            # 24h 이상(예: 72 hours ago=3일 전)은 일 단위로 환산해야 가드를 우회 안 함
+            return today - timedelta(days=n // 24)
         if unit in ("day", "일"):
             return today - timedelta(days=n)
         if unit in ("week", "주"):

--- a/service-ai/tests/test_anti_hallucination.py
+++ b/service-ai/tests/test_anti_hallucination.py
@@ -127,6 +127,12 @@ class TestParsePubDate:
         assert _parse_pub_date("15 hours ago", TODAY) == TODAY
         assert _parse_pub_date("3시간 전", TODAY) == TODAY
 
+    def test_relative_hours_over_24_convert_to_days(self) -> None:
+        # 24h 이상은 일 단위 환산 — today 로 오판해 가드 우회하면 안 됨
+        assert _parse_pub_date("36 hours ago", TODAY) == date(2026, 5, 18)
+        assert _parse_pub_date("48 hours ago", TODAY) == date(2026, 5, 17)
+        assert _parse_pub_date("72시간 전", TODAY) == date(2026, 5, 16)
+
     def test_relative_days_ago(self) -> None:
         assert _parse_pub_date("2 days ago", TODAY) == date(2026, 5, 17)
         assert _parse_pub_date("1일 전", TODAY) == date(2026, 5, 18)

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -141,8 +141,9 @@ public class AnomalyDetector {
     private boolean tryArm(String areaCode) {
         String key = ARMED_KEY_PREFIX + areaCode;
         try {
+            long ttlMinutes = Math.max(1, reanalysisTtlMinutes);
             Boolean set = stringRedisTemplate.opsForValue()
-                    .setIfAbsent(key, "1", Duration.ofMinutes(reanalysisTtlMinutes));
+                    .setIfAbsent(key, "1", Duration.ofMinutes(ttlMinutes));
             return Boolean.TRUE.equals(set);
         } catch (Exception e) {
             log.warn("[AnomalyDetector] armed 마킹 실패 - areaCode={}, reason={}", areaCode, e.getMessage());

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -140,8 +140,9 @@ public class AnomalyDetector {
 
     private boolean tryArm(String areaCode) {
         String key = ARMED_KEY_PREFIX + areaCode;
+        // 오설정(0 이하) 시 1분 스팸 대신 기본값으로 안전 복귀 (재분석 비용 보호)
+        long ttlMinutes = reanalysisTtlMinutes > 0 ? reanalysisTtlMinutes : 60;
         try {
-            long ttlMinutes = Math.max(1, reanalysisTtlMinutes);
             Boolean set = stringRedisTemplate.opsForValue()
                     .setIfAbsent(key, "1", Duration.ofMinutes(ttlMinutes));
             return Boolean.TRUE.equals(set);

--- a/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/service/AnomalyDetector.java
@@ -25,8 +25,9 @@ import java.util.Set;
  *
  * - baseline 높은 지역(관광지·체육시설)은 비율로 묻히므로 절대 증가분 OR 조건 병행
  *
- * - rising-edge 1회 발행: Redis SETNX armed 플래그(`congestion:anomaly-armed:{areaCode}`, TTL 24h)
- * - BUSY 해제 시 armed 플래그 명시 삭제 (BUSY 재진입 시 재발행 허용)
+ * - 발행 중복 차단: Redis SETNX armed 플래그(`congestion:anomaly-armed:{areaCode}`, TTL=reanalysis-ttl-minutes)
+ *   TTL 만료 후에도 BUSY 지속이면 재arm → 재발행 → 재분석. 즉 BUSY 지속 시 주기적 재분석(기본 60분)
+ * - BUSY 해제 시 armed 플래그 명시 삭제 (BUSY 재진입 시 즉시 재발행 허용)
  * - baseline 부재 시 보수적으로 anomaly=true fallback
  */
 @Slf4j
@@ -35,7 +36,6 @@ import java.util.Set;
 public class AnomalyDetector {
 
     private static final String ARMED_KEY_PREFIX = "congestion:anomaly-armed:";
-    private static final Duration ARMED_TTL = Duration.ofHours(24);
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final HourlyAvgCacheService hourlyAvgCacheService;
@@ -47,6 +47,10 @@ public class AnomalyDetector {
 
     @Value("${congestion.anomaly.min-people-delta:2000}")
     private double deltaThreshold = 2000;
+
+    // armed 플래그 TTL(분) = anomaly 재분석 주기. 만료 후 BUSY 지속이면 재발행 → 재분석.
+    @Value("${congestion.anomaly.reanalysis-ttl-minutes:60}")
+    private long reanalysisTtlMinutes = 60;
 
     public List<CongestionAnomalyEvent> detectAnomalies(List<CongestionRedisDto> busyDtos) {
         if (busyDtos.isEmpty()) {
@@ -137,7 +141,8 @@ public class AnomalyDetector {
     private boolean tryArm(String areaCode) {
         String key = ARMED_KEY_PREFIX + areaCode;
         try {
-            Boolean set = stringRedisTemplate.opsForValue().setIfAbsent(key, "1", ARMED_TTL);
+            Boolean set = stringRedisTemplate.opsForValue()
+                    .setIfAbsent(key, "1", Duration.ofMinutes(reanalysisTtlMinutes));
             return Boolean.TRUE.equals(set);
         } catch (Exception e) {
             log.warn("[AnomalyDetector] armed 마킹 실패 - areaCode={}, reason={}", areaCode, e.getMessage());

--- a/service-congestion/src/main/resources/application.yml
+++ b/service-congestion/src/main/resources/application.yml
@@ -92,3 +92,4 @@ congestion:
   anomaly:
     max-people-ratio: ${CONGESTION_ANOMALY_MAX_PEOPLE_RATIO:1.3}
     min-people-delta: ${CONGESTION_ANOMALY_MIN_PEOPLE_DELTA:2000}
+    reanalysis-ttl-minutes: ${CONGESTION_ANOMALY_REANALYSIS_TTL_MINUTES:60}

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -76,6 +77,21 @@ class AnomalyDetectorTest {
             assertThat(events).hasSize(1);
             assertThat(events.get(0).areaCode()).isEqualTo("POI001");
             assertThat(events.get(0).ratio()).isNull();
+        }
+
+        @Test
+        @DisplayName("armed 플래그 TTL = 재분석 주기(기본 1시간)로 SETNX")
+        void armedTtlIsReanalysisInterval() {
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            anomalyDetector.detectAnomalies(List.of(dto));
+
+            ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+            then(valueOps).should().setIfAbsent(anyString(), eq("1"), ttlCaptor.capture());
+            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofHours(1));
         }
 
         @Test

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -98,6 +98,23 @@ class AnomalyDetectorTest {
         }
 
         @Test
+        @DisplayName("reanalysisTtlMinutes 0 이하 오설정 → 기본 60분으로 안전 복귀")
+        void armedTtlFallsBackToDefaultWhenNonPositive() {
+            ReflectionTestUtils.setField(anomalyDetector, "reanalysisTtlMinutes", 0L);
+
+            CongestionRedisDto dto = busyDto("POI001", 30000);
+            given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
+            given(valueOps.setIfAbsent(anyString(), eq("1"), any(Duration.class))).willReturn(true);
+
+            anomalyDetector.detectAnomalies(List.of(dto));
+
+            ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+            then(valueOps).should().setIfAbsent(anyString(), eq("1"), ttlCaptor.capture());
+            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofMinutes(60));
+        }
+
+        @Test
         @DisplayName("ratio >= threshold → anomaly 이벤트 발행")
         void ratioExceedsThreshold() {
             CongestionRedisDto dto = busyDto("POI001", 30000);

--- a/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
+++ b/service-congestion/src/test/java/com/danburn/congestion/service/AnomalyDetectorTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
 import java.util.List;
@@ -80,8 +81,10 @@ class AnomalyDetectorTest {
         }
 
         @Test
-        @DisplayName("armed 플래그 TTL = 재분석 주기(기본 1시간)로 SETNX")
+        @DisplayName("armed 플래그 TTL = 설정된 재분석 주기(reanalysisTtlMinutes)로 SETNX")
         void armedTtlIsReanalysisInterval() {
+            ReflectionTestUtils.setField(anomalyDetector, "reanalysisTtlMinutes", 30L);
+
             CongestionRedisDto dto = busyDto("POI001", 30000);
             given(hourlyAvgCacheService.getAvgMax(eq("POI001"), any(int.class))).willReturn(Optional.empty());
             given(stringRedisTemplate.opsForValue()).willReturn(valueOps);
@@ -91,7 +94,7 @@ class AnomalyDetectorTest {
 
             ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
             then(valueOps).should().setIfAbsent(anyString(), eq("1"), ttlCaptor.capture());
-            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofHours(1));
+            assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ofMinutes(30));
         }
 
         @Test

--- a/service-mobility/build.gradle
+++ b/service-mobility/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
 

--- a/service-mobility/build.gradle
+++ b/service-mobility/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'io.micrometer:micrometer-registry-otlp'
     implementation 'com.google.protobuf:protobuf-java:3.25.5'
 

--- a/service-mobility/src/main/java/com/danburn/mobility/exception/OdsayServerException.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/exception/OdsayServerException.java
@@ -1,0 +1,8 @@
+package com.danburn.mobility.exception;
+
+public class OdsayServerException extends RuntimeException {
+
+    public OdsayServerException(String message) {
+        super(message);
+    }
+}

--- a/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Component
 @RequiredArgsConstructor
@@ -19,18 +20,23 @@ public class OdsayApiClient {
   private String odsayApiKey;
 
   public OdsayApiResponse fetchOdsayRoute(OdsayApiRequest odsayApiRequest){
-    OdsayApiResponse response = odsayRestClient.get()
-      .uri(uriBuilder -> uriBuilder
-        .path("/searchPubTransPathT")
-        .queryParam("apiKey",odsayApiKey)
-        .queryParam("SX",odsayApiRequest.originLng())
-        .queryParam("SY",odsayApiRequest.originLat())
-        .queryParam("EX",odsayApiRequest.destLng())
-        .queryParam("EY",odsayApiRequest.destLat())
-        .queryParam("SearchType",0)
-        .build())
-      .retrieve()
-      .body(OdsayApiResponse.class);
+    OdsayApiResponse response;
+    try {
+      response = odsayRestClient.get()
+        .uri(uriBuilder -> uriBuilder
+          .path("/searchPubTransPathT")
+          .queryParam("apiKey",odsayApiKey)
+          .queryParam("SX",odsayApiRequest.originLng())
+          .queryParam("SY",odsayApiRequest.originLat())
+          .queryParam("EX",odsayApiRequest.destLng())
+          .queryParam("EY",odsayApiRequest.destLat())
+          .queryParam("SearchType",0)
+          .build())
+        .retrieve()
+        .body(OdsayApiResponse.class);
+    } catch (RestClientException e) {
+      throw new OdsayServerException("ODsay API 호출 실패: " + e.getMessage());
+    }
     if (response == null) {
       throw new OdsayServerException("ODsay API 응답이 없습니다.");
     }

--- a/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
@@ -3,12 +3,12 @@ package com.danburn.mobility.infra;
 import com.danburn.common.exception.GlobalException;
 import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.OdsayApiResponse;
+import com.danburn.mobility.exception.OdsayServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.util.UriBuilder;
 
 @Component
 @RequiredArgsConstructor
@@ -31,8 +31,11 @@ public class OdsayApiClient {
         .build())
       .retrieve()
       .body(OdsayApiResponse.class);
-    if (response == null || response.result() == null) {
-      throw new GlobalException(HttpStatus.BAD_GATEWAY.value(), "ODsay API 응답이 올바르지 않습니다.");
+    if (response == null) {
+      throw new OdsayServerException("ODsay API 응답이 없습니다.");
+    }
+    if (response.result() == null) {
+      throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "경로를 찾을 수 없습니다.");
     }
     return response;
   }

--- a/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/infra/OdsayApiClient.java
@@ -41,7 +41,7 @@ public class OdsayApiClient {
       throw new OdsayServerException("ODsay API 응답이 없습니다.");
     }
     if (response.result() == null) {
-      throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "경로를 찾을 수 없습니다.");
+      throw new GlobalException(HttpStatus.NOT_FOUND.value(), "경로를 찾을 수 없습니다.");
     }
     return response;
   }

--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -1,11 +1,16 @@
 package com.danburn.mobility.service;
 
+import com.danburn.common.exception.GlobalException;
 import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.TransitRouteResponse;
 import com.danburn.mobility.infra.OdsayApiClient;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OdsayService {
@@ -13,9 +18,15 @@ public class OdsayService {
     private final OdsayApiClient odsayApiClient;
     private final OdsayResponseMapper odsayResponseMapper;
 
+    @CircuitBreaker(name = "odsay", fallbackMethod = "fetchOdsayRouteFallback")
     public TransitRouteResponse fetchOdsayRoute(OdsayApiRequest odsayApiRequest) {
         return odsayResponseMapper.toResponse(
                 odsayApiClient.fetchOdsayRoute(odsayApiRequest)
         );
+    }
+
+    private TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
+        log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
+        throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }
 }

--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -5,6 +5,7 @@ import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.TransitRouteResponse;
 import com.danburn.mobility.infra.OdsayApiClient;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ public class OdsayService {
     private final OdsayResponseMapper odsayResponseMapper;
 
     @CircuitBreaker(name = "odsay", fallbackMethod = "fetchOdsayRouteFallback")
+    @Retry(name = "odsay")
     public TransitRouteResponse fetchOdsayRoute(OdsayApiRequest odsayApiRequest) {
         return odsayResponseMapper.toResponse(
                 odsayApiClient.fetchOdsayRoute(odsayApiRequest)
@@ -26,6 +28,9 @@ public class OdsayService {
     }
 
     TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
+        if (t instanceof GlobalException e) {
+            throw e;
+        }
         log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
         throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }

--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -25,7 +25,7 @@ public class OdsayService {
         );
     }
 
-    private TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
+    TransitRouteResponse fetchOdsayRouteFallback(OdsayApiRequest odsayApiRequest, Throwable t) {
         log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
         throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -38,6 +38,21 @@ management:
     tracing:
       endpoint: ${OTLP_TRACES_URL:http://localhost:4318/v1/traces}
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      odsay:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        permitted-number-of-calls-in-half-open-state: 3
+        record-exceptions:
+          - com.danburn.mobility.exception.OdsayServerException
+        ignore-exceptions:
+          - com.danburn.common.exception.GlobalException
+
 logging:
   loki:
     url: ${LOKI_URL:http://localhost:3100/loki/api/v1/push}

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -52,6 +52,15 @@ resilience4j:
           - com.danburn.mobility.exception.OdsayServerException
         ignore-exceptions:
           - com.danburn.common.exception.GlobalException
+  retry:
+    instances:
+      odsay:
+        max-attempts: 2
+        wait-duration: 500ms
+        retry-exceptions:
+          - com.danburn.mobility.exception.OdsayServerException
+        ignore-exceptions:
+          - com.danburn.common.exception.GlobalException
 
 logging:
   loki:

--- a/service-mobility/src/main/resources/application.yml
+++ b/service-mobility/src/main/resources/application.yml
@@ -19,10 +19,13 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics
+        include: health, info, metrics, circuitbreakers
   endpoint:
     health:
       show-details: always
+  health:
+    circuitbreakers:
+      enabled: true
   metrics:
     distribution:
       percentiles-histogram:
@@ -42,6 +45,7 @@ resilience4j:
   circuitbreaker:
     instances:
       odsay:
+        register-health-indicator: true
         sliding-window-type: COUNT_BASED
         sliding-window-size: 10
         minimum-number-of-calls: 5

--- a/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
@@ -79,6 +80,17 @@ class OdsayApiClientTest {
             assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(OdsayServerException.class)
                     .hasMessage("ODsay API 응답이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("네트워크 오류 시 OdsayServerException을 던진다")
+        void network_error_throws_odsay_server_exception() {
+            given(responseSpec.body(OdsayApiResponse.class))
+                    .willThrow(new ResourceAccessException("연결 거부"));
+
+            assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(OdsayServerException.class)
+                    .hasMessageContaining("ODsay API 호출 실패");
         }
 
         @Test

--- a/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
@@ -94,15 +94,15 @@ class OdsayApiClientTest {
         }
 
         @Test
-        @DisplayName("result가 null이면 GlobalException 503을 던진다")
-        void null_result_throws_global_exception_503() {
+        @DisplayName("result가 null이면 GlobalException 404를 던진다")
+        void null_result_throws_global_exception_404() {
             given(responseSpec.body(OdsayApiResponse.class)).willReturn(new OdsayApiResponse(null));
 
             assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage("경로를 찾을 수 없습니다.")
                     .extracting(e -> ((GlobalException) e).getStatus())
-                    .isEqualTo(503);
+                    .isEqualTo(404);
         }
     }
 

--- a/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/infra/OdsayApiClientTest.java
@@ -1,0 +1,106 @@
+package com.danburn.mobility.infra;
+
+import com.danburn.common.exception.GlobalException;
+import com.danburn.mobility.dto.request.OdsayApiRequest;
+import com.danburn.mobility.dto.response.OdsayApiResponse;
+import com.danburn.mobility.exception.OdsayServerException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OdsayApiClient 단위 테스트")
+class OdsayApiClientTest {
+
+    @Mock
+    private RestClient restClient;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private RestClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private RestClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private OdsayApiClient odsayApiClient;
+
+    private static final OdsayApiRequest REQUEST =
+            new OdsayApiRequest(127.1272127, 37.3213399, 127.028001, 37.498086);
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        odsayApiClient = new OdsayApiClient(restClient);
+        ReflectionTestUtils.setField(odsayApiClient, "odsayApiKey", "test-key");
+
+        given(restClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(any(Function.class))).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+    }
+
+    @Nested
+    @DisplayName("fetchOdsayRoute")
+    class FetchOdsayRoute {
+
+        @Test
+        @DisplayName("정상 응답 시 OdsayApiResponse를 반환한다")
+        void success_returns_response() {
+            OdsayApiResponse response = buildApiResponse();
+            given(responseSpec.body(OdsayApiResponse.class)).willReturn(response);
+
+            OdsayApiResponse result = odsayApiClient.fetchOdsayRoute(REQUEST);
+
+            assertThat(result).isSameAs(response);
+        }
+
+        @Test
+        @DisplayName("응답이 null이면 OdsayServerException을 던진다")
+        void null_response_throws_odsay_server_exception() {
+            given(responseSpec.body(OdsayApiResponse.class)).willReturn(null);
+
+            assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(OdsayServerException.class)
+                    .hasMessage("ODsay API 응답이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("result가 null이면 GlobalException 503을 던진다")
+        void null_result_throws_global_exception_503() {
+            given(responseSpec.body(OdsayApiResponse.class)).willReturn(new OdsayApiResponse(null));
+
+            assertThatThrownBy(() -> odsayApiClient.fetchOdsayRoute(REQUEST))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("경로를 찾을 수 없습니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(503);
+        }
+    }
+
+    private OdsayApiResponse buildApiResponse() {
+        OdsayApiResponse.Info info =
+                new OdsayApiResponse.Info(30, 1500, 1, 0, "출발역", "도착역");
+        OdsayApiResponse.SubPath walk =
+                new OdsayApiResponse.SubPath(3, 5, null, null, null, null);
+        OdsayApiResponse.Path path =
+                new OdsayApiResponse.Path(info, List.of(walk));
+        return new OdsayApiResponse(new OdsayApiResponse.Result(0, List.of(path)));
+    }
+}

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -84,6 +84,35 @@ class OdsayServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("fetchOdsayRouteFallback")
+    class FetchOdsayRouteFallback {
+
+        @Test
+        @DisplayName("OdsayServerException 발생 시 GlobalException 503을 던진다")
+        void fallback_on_server_exception_throws_503() {
+            Throwable cause = new com.danburn.mobility.exception.OdsayServerException("ODsay API 응답이 없습니다.");
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("대중교통 경로 조회 서비스가 일시적으로 불가합니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(503);
+        }
+
+        @Test
+        @DisplayName("RuntimeException 발생 시 GlobalException 503을 던진다")
+        void fallback_on_runtime_exception_throws_503() {
+            Throwable cause = new RuntimeException("네트워크 오류");
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("대중교통 경로 조회 서비스가 일시적으로 불가합니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(503);
+        }
+    }
+
     private OdsayApiResponse buildApiResponse() {
         OdsayApiResponse.Info info =
                 new OdsayApiResponse.Info(30, 1500, 1, 0, "출발역", "도착역");

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -61,7 +61,7 @@ class OdsayServiceTest {
         @DisplayName("client가 GlobalException을 던지면 그대로 전파된다")
         void client_throws_global_exception_propagates() {
             given(odsayApiClient.fetchOdsayRoute(REQUEST))
-                    .willThrow(new GlobalException(503, "경로를 찾을 수 없습니다."));
+                    .willThrow(new GlobalException(404, "경로를 찾을 수 없습니다."));
 
             assertThatThrownBy(() -> odsayService.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(GlobalException.class)
@@ -88,6 +88,18 @@ class OdsayServiceTest {
     @Nested
     @DisplayName("fetchOdsayRouteFallback")
     class FetchOdsayRouteFallback {
+
+        @Test
+        @DisplayName("GlobalException 발생 시 그대로 전파된다")
+        void fallback_on_global_exception_rethrows() {
+            GlobalException cause = new GlobalException(404, "경로를 찾을 수 없습니다.");
+
+            assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("경로를 찾을 수 없습니다.")
+                    .extracting(e -> ((GlobalException) e).getStatus())
+                    .isEqualTo(404);
+        }
 
         @Test
         @DisplayName("OdsayServerException 발생 시 GlobalException 503을 던진다")

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -4,6 +4,7 @@ import com.danburn.common.exception.GlobalException;
 import com.danburn.mobility.dto.request.OdsayApiRequest;
 import com.danburn.mobility.dto.response.OdsayApiResponse;
 import com.danburn.mobility.dto.response.TransitRouteResponse;
+import com.danburn.mobility.exception.OdsayServerException;
 import com.danburn.mobility.infra.OdsayApiClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,11 +61,11 @@ class OdsayServiceTest {
         @DisplayName("client가 GlobalException을 던지면 그대로 전파된다")
         void client_throws_global_exception_propagates() {
             given(odsayApiClient.fetchOdsayRoute(REQUEST))
-                    .willThrow(new GlobalException(502, "ODsay API 응답이 올바르지 않습니다."));
+                    .willThrow(new GlobalException(503, "경로를 찾을 수 없습니다."));
 
             assertThatThrownBy(() -> odsayService.fetchOdsayRoute(REQUEST))
                     .isInstanceOf(GlobalException.class)
-                    .hasMessage("ODsay API 응답이 올바르지 않습니다.");
+                    .hasMessage("경로를 찾을 수 없습니다.");
 
             then(odsayResponseMapper).shouldHaveNoInteractions();
         }


### PR DESCRIPTION
dev → main promotion. #354(직전 promotion) 이후 dev에 쌓인 변경 일괄 승격.

## 포함 (내 작업)
- **#359** `_parse_pub_date` hour 단위 24h↑ 일 환산 — main 에 남아있던 recency 가드 우회 버그 수정
- **#358** anomaly 1시간 주기 재분석 — BUSY 지속 시 armed TTL(기본 60분) 만료 후 재발행

## 포함 (타 팀원 작업, dev 기머지)
- **#357 / #356** 의존성 추가 및 서킷브레이커 모니터링
- **#355 / #341** Odsay 서킷브레이커, Retry/fallback 예외 처리, 404 수정

## 비고
- 모든 항목 dev 에서 gemini 리뷰 + CI 통과 후 머지됨
- main 은 승인 필수(ruleset) — 머지는 리뷰 승인 후 진행