### PR TITLE
fix(ai): LLM 429 지수 백오프 base_delay 6→15초 (15→30→60)

### DIFF
--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -26,9 +26,9 @@ class Settings(BaseSettings):
     # ── LLM 429 재시도 (지수 백오프) ──
     # - 최초 호출 포함 총 시도 횟수. 소진 시 RetriableError 전파 → DLQ
     # - 대기 = max(base * 2**(n-1), retry_after), 상한 max_delay
-    # - RPM 슬롯(12초) 정렬: 6 → 12 → 24초 (인라인 총 ≤42초), 상한 60초=한 분 윈도우
+    # - RPM 슬롯(15초=60/RPM4) 정렬: 15 → 30 → 60초 (인라인 총 ≤105초), 상한 60초=한 분 윈도우
     llm_retry_max_attempts: int = 4
-    llm_retry_base_delay: float = 6.0
+    llm_retry_base_delay: float = 15.0
     llm_retry_max_delay: float = 60.0
 
     # ── RabbitMQ ──


### PR DESCRIPTION
## 변경
- `service-ai/app/config.py`: `llm_retry_base_delay` 6.0 → 15.0
- 주석 정합 수정 (15→30→60초, RPM=4 슬롯 정렬)

## 효과
| 재시도 | 변경 전 | 변경 후 |
|---|---|---|
| 1회 | 6초 | 15초 |
| 2회 | 12초 | 30초 |
| 3회 | 24초 | 60초 |

- `max_attempts=4` (최초 1 + 재시도 3) 유지, 상한 60초 유지
- RPM=4(60/4=15초 슬롯)에 정렬

## 참고
- 인라인 재시도 총 대기: 42초 → 105초 (429 빈발 시 처리량 영향 가능, ack 타임아웃 내라 안전)
- `tests/test_openai_client_retry.py` 4건 통과 (base_delay 동적 참조라 회귀 없음)