### PR TITLE
fix(mobility): ODsay 타임아웃 단축 (connect 2s / read 3s)

### DIFF
--- a/service-mobility/src/main/java/com/danburn/mobility/config/RestClientConfig.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/config/RestClientConfig.java
@@ -12,8 +12,8 @@ public class RestClientConfig {
   @Bean
   public RestClient odsayRestClient(){
     SimpleClientHttpRequestFactory simpleClientHttpRequestFactory = new SimpleClientHttpRequestFactory();
-    simpleClientHttpRequestFactory.setConnectTimeout(Duration.ofSeconds(5));
-    simpleClientHttpRequestFactory.setReadTimeout(Duration.ofSeconds(5));
+    simpleClientHttpRequestFactory.setConnectTimeout(Duration.ofSeconds(2));
+    simpleClientHttpRequestFactory.setReadTimeout(Duration.ofSeconds(3));
 
     return RestClient.builder()
       .requestFactory(simpleClientHttpRequestFactory)


### PR DESCRIPTION
## 변경
- ODsay RestClient 타임아웃: connect 5s→2s, read 5s→3s

## 이유
- 기존 5s/5s + 재시도(2회, 500ms 대기)면 최악 10.5초까지 사용자가 대기
- 3s + 0.5s + 3s = 최악 약 6.5초 안에 fail-fast하도록 조정
- 웹/앱 사용자 대기 한계를 넘겨 '멈췄다'고 느끼지 않도록 마지노선을 낮춤

## 테스트
- `:service-mobility:test` 통과 (기존 단위 테스트는 RestClient를 목킹해 타임아웃 값에 비의존)