### PR TITLE
fix(congestion): AiReport 멱등 insert를 INSERT IGNORE로 수정

### DIFF
--- a/service-congestion/src/main/java/com/danburn/congestion/repository/AiReportRepository.java
+++ b/service-congestion/src/main/java/com/danburn/congestion/repository/AiReportRepository.java
@@ -13,13 +13,13 @@ public interface AiReportRepository extends JpaRepository<AiReport, Long> {
     /** createdAt 이 cutoff(createdAfter) 이후인 최신 1건만 조회 — 오래된 리포트의 stale 노출 방지. */
     Optional<AiReport> findTopByAreaCodeAndCreatedAtAfterOrderByCreatedAtDesc(String areaCode, Instant createdAfter);
 
-    /** (area_code, population_time) UNIQUE 기준 atomic idempotent insert. 신규=1, 중복=0. */
+    /** (area_code, population_time) UNIQUE 기준 idempotent insert. 신규=1, 중복=0.
+     *  INSERT IGNORE 사용 — ON DUPLICATE KEY UPDATE 는 useAffectedRows=false(드라이버 기본)에서 중복 시 matched=1 을 반환해 중복 판별 불가. */
     @Transactional
     @Modifying
-    @Query(value = "INSERT INTO ai_report " +
+    @Query(value = "INSERT IGNORE INTO ai_report " +
             "(area_name, area_code, congestion_level, analysis_message, population_time, created_at, updated_at) " +
-            "VALUES (:areaName, :areaCode, :congestionLevel, :analysisMessage, :populationTime, NOW(), NOW()) " +
-            "ON DUPLICATE KEY UPDATE area_code = area_code",
+            "VALUES (:areaName, :areaCode, :congestionLevel, :analysisMessage, :populationTime, NOW(), NOW())",
             nativeQuery = true)
     int insertIfAbsent(@Param("areaName") String areaName,
                        @Param("areaCode") String areaCode,


### PR DESCRIPTION
## 문제
At-Least-Once 환경에서 `congestion.ai.report` 큐 중복 수신 시, 소비자의 중복 스킵 분기(`if (inserted == 0)`)가 **실제로 한 번도 동작하지 않음**.

원인: `INSERT ... ON DUPLICATE KEY UPDATE area_code = area_code` + `useAffectedRows=false`(mysql-connector-j 기본, `CLIENT_FOUND_ROWS`). 이 조합에서 중복 시 affected rows가 changed(0)가 아니라 matched(1)로 반환되어 `insertIfAbsent`가 항상 1을 리턴.

## 영향
- DB UNIQUE 제약으로 **데이터 정합성(1행)은 유지** (실질 장애 아님)
- 그러나 중복 메시지마다 `cacheToRedis()` 재실행 + `[AiReportConsumer] 저장 완료` 오탐 로그. 의도한 "중복 무시" 로그/스킵은 미발생.

## 해결
`INSERT IGNORE` 로 변경. 드라이버 설정과 무관하게 중복 시 0을 반환 → 중복 판별 정상화. 커넥션 전역 설정(`useAffectedRows`)을 건드리지 않아 다른 쿼리에 영향 없음.

## 검증
프로덕션 기본 datasource URL(useAffectedRows 미지정)로 로컬 기동 후 동일 메시지 5회 발행:
- `#1` → INFO `저장 완료`
- `#2~5` → WARN `중복 메시지 무시`
- `ai_report` 테이블 1행

수정 전에는 동일 조건에서 `저장 완료` x5, 중복 무시 0회였음.