### PR TITLE
feat(ai): Redis 분산락으로 중복 LLM 요청 방지 (요청 멱등성)

### DIFF
--- a/service-ai/app/config.py
+++ b/service-ai/app/config.py
@@ -52,6 +52,17 @@ class Settings(BaseSettings):
     batch_window_seconds: float = 5.0
     batch_max_size: int = 3
 
+    # ── Redis 멱등성 게이트 (중복 LLM 요청 방지) ──
+    # - LLM 호출 전 (area_code, population_time) 키를 SET NX EX 로 선점
+    #   · 선점 성공 → LLM 호출 통과 / 이미 존재 → 중복 재전달 → 스킵(ack)
+    # - 성공 시 마커 유지(TTL 동안 재전달 스킵) / 실패 시 해제(DLQ 재처리 재선점)
+    # - Redis 장애 시 fail-open: 게이트 통과 → 저장 중복은 DB UNIQUE 가 최종 보증
+    # - TTL: 인라인 재시도 예산(≤105초) + 재전달 지연 여유. DLQ 재처리 주기(600초)보다 짧아 재시도 미차단
+    redis_url: str = "redis://localhost:6379/0"
+    dedup_enabled: bool = True
+    dedup_key_prefix: str = "ai:dedup"
+    dedup_key_ttl_seconds: int = 300
+
     # ── Observability ──
     otlp_traces_url: str = "http://localhost:4318/v1/traces"
     loki_url: str = "http://localhost:3100/loki/api/v1/push"

--- a/service-ai/app/rabbitmq/batch.py
+++ b/service-ai/app/rabbitmq/batch.py
@@ -7,6 +7,7 @@ from app.ai.errors import NonRetriableError, RetriableError
 from app.ai.interface import AIAnalyzer
 from app.config import settings
 from app.models.schemas import CongestionEvent
+from app.rabbitmq.dedup import IdempotencyGate
 from app.rabbitmq.publisher import RabbitMQPublisher
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,8 @@ class BatchProcessor:
     - mode: "normal" 또는 "anomaly". analyzer 에 전달되어 시스템 프롬프트/tool_choice 분기.
     - max_size / window_seconds 인자 미지정 시 settings 기본값 사용.
       anomaly 큐는 max_size=1 로 즉시 처리.
+    - gate: 멱등성 게이트. LLM 호출 전 (area_code, population_time) 선점으로 중복 요청 차단.
+      None 이면 게이트 비활성(전건 fresh) — 기존 동작.
     """
 
     def __init__(
@@ -35,9 +38,11 @@ class BatchProcessor:
         max_size: int | None = None,
         window_seconds: float | None = None,
         name: str | None = None,
+        gate: IdempotencyGate | None = None,
     ) -> None:
         self._analyzer = analyzer
         self._publisher = publisher
+        self._gate = gate
         self._mode = mode
         self._max_size = max_size if max_size is not None else settings.batch_max_size
         self._window_seconds = (
@@ -125,35 +130,81 @@ class BatchProcessor:
                 )
                 return
 
+    async def _partition(
+        self, items: list[BatchItem]
+    ) -> tuple[list[BatchItem], list[BatchItem]]:
+        """멱등성 게이트로 (선점 성공=fresh, 이미 존재=중복) 분리.
+
+        - gate 미설정 시 전건 fresh (기존 동작)
+        - 같은 (area_code, population_time) 이 한 배치에 중복돼도 첫 건만 fresh
+        """
+        if self._gate is None:
+            return list(items), []
+        fresh: list[BatchItem] = []
+        duplicates: list[BatchItem] = []
+        for event, message in items:
+            if await self._gate.acquire(self._gate.key_for(event)):
+                fresh.append((event, message))
+            else:
+                duplicates.append((event, message))
+        return fresh, duplicates
+
+    async def _release_all(self, items: list[BatchItem]) -> None:
+        """선점 마커 해제 (실패로 DLQ 이동 시 → DLQ 재처리가 재선점 가능)."""
+        if self._gate is None:
+            return
+        for event, _ in items:
+            await self._gate.release(self._gate.key_for(event))
+
     async def _process(self, items: list[BatchItem]) -> None:
         if not items:
             return
-        events = [event for event, _ in items]
+
+        fresh, duplicates = await self._partition(items)
+
+        # 중복(이미 선점됨) → LLM 호출 없이 즉시 ack (토큰 절약)
+        if duplicates:
+            logger.info(
+                "[BatchProcessor:%s] 중복 요청 %d건 스킵 - LLM 호출 없음",
+                self._name,
+                len(duplicates),
+            )
+            await self._ack_all(duplicates)
+
+        if not fresh:
+            return
+
+        events = [event for event, _ in fresh]
         logger.info("[BatchProcessor:%s] 배치 처리 시작 - %d건", self._name, len(events))
 
         try:
             results = await self._analyzer.analyze(events, mode=self._mode)
         except NonRetriableError as e:
-            await self._dlq_all(items, f"NonRetriableError: {e}")
+            await self._release_all(fresh)
+            await self._dlq_all(fresh, f"NonRetriableError: {e}")
             return
         except RetriableError as e:
-            await self._dlq_all(items, f"RetriableError: {e}")
+            await self._release_all(fresh)
+            await self._dlq_all(fresh, f"RetriableError: {e}")
             return
         except Exception as e:
-            await self._dlq_all(items, f"AI 분석 실패: {type(e).__name__}: {e}")
+            await self._release_all(fresh)
+            await self._dlq_all(fresh, f"AI 분석 실패: {type(e).__name__}: {e}")
             return
 
         # 분석 성공 → publish 시도
         try:
             await self._publisher.publish_all(results)
         except Exception as e:
-            await self._dlq_all(items, f"Publisher 실패: {e}")
+            await self._release_all(fresh)
+            await self._dlq_all(fresh, f"Publisher 실패: {e}")
             return
 
-        await self._ack_all(items)
+        # 성공 → 마커 유지(TTL 동안 재전달 스킵) 후 ack
+        await self._ack_all(fresh)
         logger.info(
             "[BatchProcessor:%s] 배치 처리 완료 - 분석=%d건, 입력=%d건",
             self._name,
             len(results),
-            len(items),
+            len(fresh),
         )

--- a/service-ai/app/rabbitmq/dedup.py
+++ b/service-ai/app/rabbitmq/dedup.py
@@ -1,0 +1,65 @@
+"""Redis 분산락 기반 멱등성 게이트 (중복 LLM 요청 방지).
+
+- LLM 호출 전 (area_code, population_time) 키를 SET NX EX 로 선점
+  · acquire True  → 이 요청이 선점 → LLM 호출 통과
+  · acquire False → 이미 선점(중복 재전달) → LLM 호출 스킵
+- 성공 시 마커 유지(TTL 동안 재전달 스킵), 실패 시 release → DLQ 재처리가 재선점
+- Redis 장애 시 fail-open: acquire True 반환(기존처럼 LLM 호출). 저장 중복은 DB UNIQUE 가 최종 보증.
+- 키는 저장측 DB UNIQUE (area_code, population_time) 와 동일 → 요청·저장 멱등성 정렬
+
+한계: acquire 후 TTL 만료 전 하드 크래시 시 마커가 남아, TTL 내 재전달이 스킵될 수 있는 좁은 창 존재.
+완전 차단은 락+완료마커 2키 구조 필요 (별도 이슈). 저장 정확성은 DB UNIQUE 가 보증.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+from app.models.schemas import CongestionEvent
+
+logger = logging.getLogger(__name__)
+
+
+class IdempotencyGate:
+    """Redis SET NX EX 기반 요청 멱등성 게이트."""
+
+    def __init__(self, redis: Redis, *, key_prefix: str, ttl_seconds: int) -> None:
+        self._redis = redis
+        self._key_prefix = key_prefix
+        self._ttl = ttl_seconds
+
+    def key_for(self, event: CongestionEvent) -> str:
+        # DB UNIQUE (area_code, population_time) 와 동일한 멱등성 키
+        return f"{self._key_prefix}:{event.area_code}:{event.population_time}"
+
+    async def acquire(self, key: str) -> bool:
+        """SET key NX EX ttl. 선점 성공 True / 이미 존재 False.
+
+        Redis 장애 시 fail-open → True (LLM 호출 통과, 중복 저장은 DB UNIQUE 가 차단).
+        """
+        try:
+            acquired = await self._redis.set(key, "1", nx=True, ex=self._ttl)
+            return bool(acquired)
+        except RedisError as e:
+            logger.warning(
+                "[Dedup] acquire 실패, fail-open 통과 - key=%s, %s: %r",
+                key,
+                type(e).__name__,
+                e,
+            )
+            return True
+
+    async def release(self, key: str) -> None:
+        """마커 해제 → DLQ 재처리가 다시 선점 가능. 해제 실패는 무시(마커는 TTL 로 자동 만료)."""
+        try:
+            await self._redis.delete(key)
+        except RedisError as e:
+            logger.warning(
+                "[Dedup] release 실패 무시(TTL 만료 대기) - key=%s, %s: %r",
+                key,
+                type(e).__name__,
+                e,
+            )

--- a/service-ai/main.py
+++ b/service-ai/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 
 import aio_pika
 from fastapi import FastAPI
+from redis.asyncio import Redis
 
 from app.ai.factory import create_analyzer
 from app.ai.mcp.client import MCPClient
@@ -11,6 +12,7 @@ from app.config import settings
 from app.observability import setup_observability, shutdown_observability
 from app.rabbitmq.batch import BatchProcessor
 from app.rabbitmq.consumer import RabbitMQConsumer
+from app.rabbitmq.dedup import IdempotencyGate
 from app.rabbitmq.dlq_worker import DLQWorker
 from app.rabbitmq.publisher import RabbitMQPublisher
 
@@ -19,13 +21,30 @@ logger = logging.getLogger(__name__)
 mcp_client = MCPClient()
 analyzer = create_analyzer(mcp_client)
 publisher = RabbitMQPublisher()
-batch_processor = BatchProcessor(analyzer, publisher, name="normal")
+
+# 멱등성 게이트: 중복 LLM 요청 방지 (dedup_enabled=False 면 비활성 → 기존 동작)
+redis_client = (
+    Redis.from_url(settings.redis_url, decode_responses=True)
+    if settings.dedup_enabled
+    else None
+)
+dedup_gate = (
+    IdempotencyGate(
+        redis_client,
+        key_prefix=settings.dedup_key_prefix,
+        ttl_seconds=settings.dedup_key_ttl_seconds,
+    )
+    if redis_client is not None
+    else None
+)
+batch_processor = BatchProcessor(analyzer, publisher, name="normal", gate=dedup_gate)
 anomaly_batch_processor = BatchProcessor(
     analyzer,
     publisher,
     mode="anomaly",
     max_size=1,
     name="anomaly",
+    gate=dedup_gate,
 )
 consumer = RabbitMQConsumer(batch_processor, queue_name=settings.rabbitmq_queue)
 anomaly_consumer = RabbitMQConsumer(
@@ -40,6 +59,13 @@ async def lifespan(app: FastAPI):
     # startup
     setup_observability(app)
     await mcp_client.start()
+    if redis_client is not None:
+        try:
+            await redis_client.ping()
+            logger.info("[AI Service] Redis 멱등성 게이트 활성 (dedup)")
+        except Exception as e:
+            # fail-open: Redis 불가 시에도 기동 진행 (중복 저장은 DB UNIQUE 가 보증)
+            logger.warning("[AI Service] Redis 연결 실패, 멱등성 게이트 fail-open - %r", e)
     await publisher.connect()
     await batch_processor.start()
     await anomaly_batch_processor.start()
@@ -58,6 +84,8 @@ async def lifespan(app: FastAPI):
     await batch_processor.stop()
     await analyzer.close()
     await publisher.close()
+    if redis_client is not None:
+        await redis_client.aclose()
     await mcp_client.stop()
     logger.info("[AI Service] 종료 완료")
     shutdown_observability()

--- a/service-ai/requirements.txt
+++ b/service-ai/requirements.txt
@@ -4,6 +4,7 @@ pydantic==2.11.10
 pydantic-settings==2.7.1
 httpx==0.28.1
 aio-pika==9.5.4
+redis>=5.0.1
 tiktoken>=0.7.0
 mcp==1.27.0
 ddgs==9.14.2

--- a/service-ai/tests/test_dedup.py
+++ b/service-ai/tests/test_dedup.py
@@ -1,0 +1,208 @@
+"""app.rabbitmq.dedup — IdempotencyGate + BatchProcessor 중복 요청 방지 테스트."""
+
+from __future__ import annotations
+
+import pytest
+from redis.exceptions import RedisError
+
+from app.models.schemas import AnalysisResult, CongestionEvent
+from app.rabbitmq.batch import BatchProcessor
+from app.rabbitmq.dedup import IdempotencyGate
+
+
+class FakeRedis:
+    """redis.asyncio.Redis 최소 더미 (SET NX EX / DELETE)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def delete(self, key):
+        return 1 if self.store.pop(key, None) is not None else 0
+
+
+class FailingRedis:
+    """모든 명령에서 RedisError → fail-open 검증용."""
+
+    async def set(self, *a, **k):
+        raise RedisError("boom")
+
+    async def delete(self, *a, **k):
+        raise RedisError("boom")
+
+
+class FakeMessage:
+    def __init__(self, tag: int) -> None:
+        self.tag = tag
+        self.acked = False
+        self.nacked = False
+        self.nack_requeue: bool | None = None
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def nack(self, requeue: bool = True) -> None:
+        self.nacked = True
+        self.nack_requeue = requeue
+
+
+class FakePublisher:
+    def __init__(self) -> None:
+        self.published: list[AnalysisResult] = []
+
+    async def publish_all(self, results: list[AnalysisResult]) -> None:
+        self.published.extend(results)
+
+
+class FakeAnalyzer:
+    def __init__(self, behaviour: str = "ok") -> None:
+        self.behaviour = behaviour
+        self.calls = 0
+        self.seen_events: list[list[CongestionEvent]] = []
+
+    async def analyze(self, events, *, mode="normal"):
+        self.calls += 1
+        self.seen_events.append(list(events))
+        if self.behaviour == "boom":
+            raise RuntimeError("network boom")
+        return [
+            AnalysisResult(
+                area_name=e.area_name,
+                area_code=e.area_code,
+                congestion_level=e.congestion_level,
+                analysis_message="ok",
+                population_time=e.population_time,
+            )
+            for e in events
+        ]
+
+
+def _event(code: str, time: str = "2026-04-11 12:00") -> CongestionEvent:
+    return CongestionEvent(
+        area_name=f"area-{code}",
+        area_code=code,
+        congestion_level="BUSY",
+        max_people_count=100,
+        population_time=time,
+    )
+
+
+def _gate(redis) -> IdempotencyGate:
+    return IdempotencyGate(redis, key_prefix="ai:dedup", ttl_seconds=300)
+
+
+# ── IdempotencyGate 단위 ──
+
+@pytest.mark.asyncio
+async def test_acquire_first_true_second_false():
+    gate = _gate(FakeRedis())
+    key = gate.key_for(_event("A"))
+    assert await gate.acquire(key) is True   # 첫 선점 성공
+    assert await gate.acquire(key) is False  # 이미 존재 → 차단
+
+
+@pytest.mark.asyncio
+async def test_release_allows_reacquire():
+    redis = FakeRedis()
+    gate = _gate(redis)
+    key = gate.key_for(_event("A"))
+    await gate.acquire(key)
+    await gate.release(key)
+    assert await gate.acquire(key) is True   # 해제 후 재선점 가능
+
+
+@pytest.mark.asyncio
+async def test_key_matches_db_unique_area_time():
+    gate = _gate(FakeRedis())
+    # 같은 (area, time) → 동일 키 / time 다르면 다른 키
+    assert gate.key_for(_event("A", "T1")) == gate.key_for(_event("A", "T1"))
+    assert gate.key_for(_event("A", "T1")) != gate.key_for(_event("A", "T2"))
+    assert gate.key_for(_event("A", "T1")) != gate.key_for(_event("B", "T1"))
+
+
+@pytest.mark.asyncio
+async def test_redis_failure_fails_open():
+    gate = _gate(FailingRedis())
+    key = gate.key_for(_event("A"))
+    assert await gate.acquire(key) is True   # 장애 시 통과 (LLM 호출 진행)
+    await gate.release(key)                   # 예외 삼킴 (raise 없음)
+
+
+# ── BatchProcessor 통합 ──
+
+@pytest.mark.asyncio
+async def test_duplicate_redelivery_skips_llm():
+    """같은 이벤트 재전달 시 두 번째는 LLM 호출 없이 ack."""
+    redis = FakeRedis()
+    analyzer = FakeAnalyzer("ok")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher, gate=_gate(redis))  # type: ignore[arg-type]
+
+    msg1 = FakeMessage(1)
+    await bp._process([(_event("A"), msg1)])
+    assert msg1.acked is True
+    assert analyzer.calls == 1
+
+    # 동일 (area, time) 재전달
+    msg2 = FakeMessage(2)
+    await bp._process([(_event("A"), msg2)])
+    assert msg2.acked is True        # 중복도 ack (재큐 방지)
+    assert msg2.nacked is False
+    assert analyzer.calls == 1       # LLM 재호출 없음 → 토큰 절약
+    assert len(publisher.published) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_within_single_batch_deduped():
+    """한 배치 안에 같은 키가 둘이면 첫 건만 분석."""
+    analyzer = FakeAnalyzer("ok")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher, gate=_gate(FakeRedis()))  # type: ignore[arg-type]
+
+    msg1, msg2 = FakeMessage(1), FakeMessage(2)
+    await bp._process([(_event("A"), msg1), (_event("A"), msg2)])
+
+    assert msg1.acked and msg2.acked
+    assert analyzer.calls == 1
+    assert len(analyzer.seen_events[0]) == 1   # fresh 1건만 LLM 투입
+
+
+@pytest.mark.asyncio
+async def test_failure_releases_marker_for_reprocess():
+    """분석 실패로 DLQ 이동 시 마커 해제 → 재처리가 다시 분석 가능."""
+    redis = FakeRedis()
+    gate = _gate(redis)
+
+    boom = FakeAnalyzer("boom")
+    bp_fail = BatchProcessor(boom, FakePublisher(), gate=gate)  # type: ignore[arg-type]
+    msg1 = FakeMessage(1)
+    await bp_fail._process([(_event("A"), msg1)])
+    assert msg1.nacked is True and msg1.nack_requeue is False   # DLQ 라우팅
+    assert redis.store == {}                                    # 마커 해제됨
+
+    # DLQ 재처리(같은 이벤트 재유입) → 마커 없으므로 다시 분석
+    ok = FakeAnalyzer("ok")
+    bp_ok = BatchProcessor(ok, FakePublisher(), gate=gate)  # type: ignore[arg-type]
+    msg2 = FakeMessage(2)
+    await bp_ok._process([(_event("A"), msg2)])
+    assert msg2.acked is True
+    assert ok.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_no_gate_processes_all_as_fresh():
+    """gate=None 이면 기존 동작 (전건 분석)."""
+    analyzer = FakeAnalyzer("ok")
+    publisher = FakePublisher()
+    bp = BatchProcessor(analyzer, publisher)  # type: ignore[arg-type]
+
+    msg1, msg2 = FakeMessage(1), FakeMessage(2)
+    await bp._process([(_event("A"), msg1), (_event("A"), msg2)])
+
+    assert msg1.acked and msg2.acked
+    assert len(analyzer.seen_events[0]) == 2   # 게이트 없음 → 둘 다 fresh


### PR DESCRIPTION
## 요약
At-Least-Once 재전달 시 같은 AI 분석 이벤트가 중복 소비돼 LLM 이 재호출되는 **토큰 낭비**를 차단한다. LLM 호출 **전** Redis 분산락으로 멱등성 키(`area_code + population_time`)를 선점해 먼저 잡은 요청만 통과시키고 동일 요청은 원자적으로 차단. 기존 DB UNIQUE 는 최종 방어선으로 유지.

## 변경
- `app/rabbitmq/dedup.py` (신규): `IdempotencyGate` — `SET NX EX` 선점 / `DEL` 해제 / Redis 장애 fail-open
- `app/rabbitmq/batch.py`: `_process` 에서 fresh/중복 분리 → 중복은 ack 스킵, 실패 시 마커 해제(DLQ 재처리 재선점)
- `main.py`: Redis 클라이언트 + 게이트 와이어링, lifespan ping/aclose
- `app/config.py`: `redis_url`, `dedup_enabled`, `dedup_key_prefix`, `dedup_key_ttl_seconds=300`
- `requirements.txt`: `redis>=5.0.1`
- `tests/test_dedup.py` (신규): 게이트 단위 + 배치 통합 9케이스

## 설계
- 성공 시 마커 유지(TTL 동안 재전달 스킵) / 실패 시 해제
- Redis 장애 시 fail-open — 저장 중복은 DB UNIQUE 가 보증하므로 분석이 멈추지 않음
- 키를 DB UNIQUE `(area_code, population_time)` 와 동일하게 정렬 → 요청·저장 멱등성 일치

## 검증
- 전체 테스트 **145개 통과**
- 실 Redis 컨테이너 통합: 첫 선점 True → 중복 False → TTL → 해제 후 재선점 True

## 한계 (향후 과제)
- LLM 호출 중 하드 크래시 시 마커가 TTL까지 남는 좁은 재전달-스킵 창. 완전 차단은 락+완료마커 2키 구조 필요.

Closes #369