### PR TITLE
fix(mobility): ODsay 서킷 브레이커 fallback 503→500

### DIFF
--- a/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
+++ b/service-mobility/src/main/java/com/danburn/mobility/service/OdsayService.java
@@ -32,6 +32,6 @@ public class OdsayService {
             throw e;
         }
         log.warn("ODsay 서킷 브레이커 작동 - fallback 실행: {}", t.getMessage());
-        throw new GlobalException(HttpStatus.SERVICE_UNAVAILABLE.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
+        throw new GlobalException(HttpStatus.INTERNAL_SERVER_ERROR.value(), "대중교통 경로 조회 서비스가 일시적으로 불가합니다.");
     }
 }

--- a/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
+++ b/service-mobility/src/test/java/com/danburn/mobility/service/OdsayServiceTest.java
@@ -102,27 +102,27 @@ class OdsayServiceTest {
         }
 
         @Test
-        @DisplayName("OdsayServerException 발생 시 GlobalException 503을 던진다")
-        void fallback_on_server_exception_throws_503() {
+        @DisplayName("OdsayServerException 발생 시 GlobalException 500을 던진다")
+        void fallback_on_server_exception_throws_500() {
             Throwable cause = new com.danburn.mobility.exception.OdsayServerException("ODsay API 응답이 없습니다.");
 
             assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage("대중교통 경로 조회 서비스가 일시적으로 불가합니다.")
                     .extracting(e -> ((GlobalException) e).getStatus())
-                    .isEqualTo(503);
+                    .isEqualTo(500);
         }
 
         @Test
-        @DisplayName("RuntimeException 발생 시 GlobalException 503을 던진다")
-        void fallback_on_runtime_exception_throws_503() {
+        @DisplayName("RuntimeException 발생 시 GlobalException 500을 던진다")
+        void fallback_on_runtime_exception_throws_500() {
             Throwable cause = new RuntimeException("네트워크 오류");
 
             assertThatThrownBy(() -> odsayService.fetchOdsayRouteFallback(REQUEST, cause))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage("대중교통 경로 조회 서비스가 일시적으로 불가합니다.")
                     .extracting(e -> ((GlobalException) e).getStatus())
-                    .isEqualTo(503);
+                    .isEqualTo(500);
         }
     }
 


### PR DESCRIPTION
## 변경 사항
ODsay 서킷 브레이커 fallback이 반환하던 `503 SERVICE_UNAVAILABLE`을 `500 INTERNAL_SERVER_ERROR`로 변경했습니다.

## 이유
503(서비스 일시 불가)은 과한 응답이라 판단하여 500으로 완화.

## 영향 범위
- `OdsayService.fetchOdsayRouteFallback` — 상태코드 503→500
- `OdsayServiceTest` — 기대 상태코드 및 DisplayName/메서드명 500으로 수정 (테스트 통과 확인)