### PR TITLE
test(ai): Redis 분산락 dedup 부하테스트 + 모니터링 세팅

### DIFF
--- a/docker-compose.loadtest.yml
+++ b/docker-compose.loadtest.yml
@@ -1,0 +1,79 @@
+# Redis 분산락 dedup 부하테스트용 오버레이
+# - WireMock: 외부 LLM(OpenAI 호환) 목킹 + 호출 수 카운트
+# - service-ai-1 / service-ai-2: 멀티팟(분산락 증명용) — 로컬 캐시로는 못 막고 공유 Redis만 막음
+# - BATCH_MAX_SIZE=1: 이벤트 1개 = LLM 호출 1회로 만들어 "WireMock 호출 수 = 고유 이벤트 수" 1:1 대응
+#
+# 실행:
+#   docker compose -f docker-compose.yml -f docker-compose.loadtest.yml up -d \
+#     redis rabbitmq observability wiremock service-ai-1 service-ai-2
+#
+# 단일팟 대조 실험이 필요하면 service-ai-1 만 up.
+services:
+  wiremock:
+    image: wiremock/wiremock:latest
+    command: ["--port", "8080", "--disable-banner"]
+    volumes:
+      - ./load-test/wiremock/mappings:/home/wiremock/mappings
+    ports:
+      - "8089:8080"
+    networks:
+      - backend-net
+
+  service-ai-1:
+    build:
+      context: ./service-ai
+      dockerfile: Dockerfile
+    environment:
+      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
+      - AI_PROVIDER=openai
+      - OPENAI_BASE_URL=http://wiremock:8080/v1
+      - OPENAI_API_KEY=test
+      - OPENAI_MODEL=gpt-oss-120b
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      - BATCH_MAX_SIZE=1
+      - TIKTOKEN_DISABLE=1
+      - SERVER_NAME=service-ai-1
+      - OTLP_TRACES_URL=http://observability:4318/v1/traces
+      - LOKI_URL=http://observability:3100/loki/api/v1/push
+    ports:
+      - "8085:8085"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      wiremock:
+        condition: service_started
+    networks:
+      - backend-net
+
+  service-ai-2:
+    build:
+      context: ./service-ai
+      dockerfile: Dockerfile
+    environment:
+      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
+      - AI_PROVIDER=openai
+      - OPENAI_BASE_URL=http://wiremock:8080/v1
+      - OPENAI_API_KEY=test
+      - OPENAI_MODEL=gpt-oss-120b
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
+      - BATCH_MAX_SIZE=1
+      - TIKTOKEN_DISABLE=1
+      - SERVER_NAME=service-ai-2
+      - OTLP_TRACES_URL=http://observability:4318/v1/traces
+      - LOKI_URL=http://observability:3100/loki/api/v1/push
+    ports:
+      - "8086:8085"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      wiremock:
+        condition: service_started
+    networks:
+      - backend-net
+
+networks:
+  backend-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,10 +198,13 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL:-https://api.cerebras.ai/v1}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-oss-120b}
+      - REDIS_URL=redis://:${REDIS_PASSWORD:-}@redis:6379/0
       - OTLP_TRACES_URL=http://observability:4318/v1/traces
       - LOKI_URL=http://observability:3100/loki/api/v1/push
     depends_on:
       rabbitmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks:
       - backend-net

--- a/grafana/dashboards/ai-dedup-dashboard.json
+++ b/grafana/dashboards/ai-dedup-dashboard.json
@@ -1,0 +1,91 @@
+{
+  "uid": "ai-dedup",
+  "title": "AI Redis 분산락 Dedup",
+  "tags": ["service-ai", "dedup", "redis-lock"],
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-15m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "선점 성공 (LLM 호출 대상)",
+      "description": "SETNX로 락을 잡아 실제 분석에 들어간 건수. WireMock 호출 수와 일치해야 함.",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({app=\"service-ai\"} |= \"배치 처리 시작\" [$__range]))",
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "중복 스킵 (락 실패 → LLM 미호출)",
+      "description": "락을 못 잡아 LLM 없이 ack된 중복 요청 수. 절감된 호출.",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "orange" } } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({app=\"service-ai\"} |= \"중복 요청\" [$__range]))",
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "piechart",
+      "title": "서버별 처리 분산 (멀티 인스턴스 증명)",
+      "description": "중복 이벤트가 2개 서버(service-ai 인스턴스)로 분산 유입됐음을 보여줌 → 로컬 캐시로는 못 막고 공유 Redis만 막았다는 근거.",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } } },
+      "options": { "legend": { "showLegend": true, "placement": "right", "values": ["value"] }, "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "pieType": "pie" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (server) (count_over_time({app=\"service-ai\"} |~ \"배치 처리 시작|중복 요청\" [$__range]))",
+          "queryType": "range",
+          "legendFormat": "{{server}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "중복 스킵 스파이크 (서버별)",
+      "description": "동시 폭주 시점에 스킵 카운트가 솟구쳤다 0으로 떨어지는 침 모양이면 동시성 방어 성공.",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } } } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum by (server) (count_over_time({app=\"service-ai\"} |= \"중복 요청\" [5s]))",
+          "queryType": "range",
+          "legendFormat": "skip {{server}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "sum(count_over_time({app=\"service-ai\"} |= \"배치 처리 시작\" [5s]))",
+          "queryType": "range",
+          "legendFormat": "선점 성공(LLM)"
+        }
+      ]
+    }
+  ]
+}

--- a/load-test/DEDUP-TEST.md
+++ b/load-test/DEDUP-TEST.md
@@ -1,0 +1,76 @@
+# Redis 분산락 Dedup 검증 (부하테스트)
+
+`service-ai`의 Redis 분산락이 **At-Least-Once 재전달로 인한 중복 이벤트를 앞단에서 걸러 LLM 호출을 딱 1번만** 나가게 하는지 검증한다.
+
+## 핵심 가설
+> 같은 `(area_code, population_time)` 이벤트가 아무리 많이 중복 유입돼도 **실제 LLM 호출은 1회**.
+
+- 판정 지표: **WireMock에 기록된 실제 LLM HTTP 호출 수** (외부 실측, 불가위조)
+- 합격: 유입 N건 → LLM 호출 **1건** (`1 − 1/N` 절감)
+
+## 왜 멀티서버인가
+분산락의 존재 이유는 **여러 인스턴스가 같은 이벤트를 동시에 소비**할 때 막기 위함이다.
+- 단일서버이면 자바 `synchronized`/인메모리 Set으로도 통과 → "분산락 성과" 증명 불가
+- **2개 서버**에 중복이 분산 유입돼도 LLM 1회면 → 로컬 자료구조로는 불가능, **공유 Redis만** 가능 = 증명
+
+## 구성
+- `docker-compose.loadtest.yml`: WireMock(LLM 목킹) + `service-ai-1` / `service-ai-2`
+- `BATCH_MAX_SIZE=1`: 이벤트 1개 = LLM 호출 1회로 만들어 **WireMock 호출 수 = 고유 이벤트 수** 1:1 대응
+  (배치가 여러 이벤트를 묶으면 dedup 없이도 호출 1회라 효과가 안 드러남)
+- 락 선점 시점: 배치 flush(LLM 호출 직전). 멀티서버이라 배치/로컬 캐시로는 못 막으므로 Redis가 주체임이 증명됨
+
+## 실행
+
+### 1. 스택 기동
+```bash
+docker compose -f docker-compose.yml -f docker-compose.loadtest.yml up -d \
+  redis rabbitmq observability wiremock service-ai-1 service-ai-2
+```
+
+### 2. Redis 초기화 (필수 — 이전 실행 멱등성 키 제거)
+```bash
+docker compose exec redis redis-cli FLUSHDB
+```
+> 안 하면 이전 마커가 남아 항상 LLM 0회로 보일 수 있음. (또는 매 실행 `-e POP_TIME` 을 다르게)
+
+### 3. k6 동시 버스트 실행
+```bash
+k6 run load-test/k6/dedup.js
+# 유입 수/키 조정:
+k6 run -e N=50 -e POP_TIME="2026-07-06 16:00" load-test/k6/dedup.js
+```
+k6 `teardown`이 WireMock Admin API로 실제 호출 수를 조회해 **PASS/FAIL**을 출력한다.
+
+### 4. 수동 교차 검증 (WireMock Admin)
+```bash
+curl -s -X POST http://localhost:8089/__admin/requests/count \
+  -H 'Content-Type: application/json' \
+  -d '{"method":"POST","urlPathPattern":".*/chat/completions"}'
+# → {"count": 1}  이면 통과
+```
+
+### 5. Grafana 확인
+- http://localhost:3000 → 대시보드 **"AI Redis 분산락 Dedup"**
+- 패널: `선점 성공(=1)` vs `중복 스킵(=N−1)`, `서버별 처리 분산`(2개 서버), 스킵 스파이크 시계열
+- 로그 교차검증(Explore → Loki):
+  - `{app="service-ai"} |= "배치 처리 시작"` → **1건** (락 획득)
+  - `{app="service-ai"} |= "중복 요청"` → **N−1건** (스킵)
+  - `{app="service-ai"} |= "중복 요청"` 를 `server` 별로 보면 두 서버에 분산
+
+## 합격 판정 체크리스트
+- [ ] WireMock `.*/chat/completions` 호출 수 = **1**
+- [ ] 두 서버(`service-ai-1`, `service-ai-2`) 로그를 합쳐 `배치 처리 시작` 1건 / `중복 요청` N−1건
+- [ ] Grafana 서버별 분산 파이에 **2개 서버** 모두 표시 (중복이 분산 유입됐다는 증거)
+
+## (선택) 단일서버 대조 실험
+"분산락이 진짜 필요한가"를 보여주려면:
+```bash
+# 단일서버: service-ai-1 만 기동 → 여기선 로컬로도 통과할 수 있음
+docker compose -f docker-compose.yml -f docker-compose.loadtest.yml up -d \
+  redis rabbitmq observability wiremock service-ai-1
+```
+멀티서버 결과(LLM=1)와 나란히 캡처하면 "멀티서버에서도 1회 = Redis 분산락 덕분"이 명확해진다.
+
+## 참고
+- WireMock 스텁: `load-test/wiremock/mappings/llm-chat-completions.json` — `{"results": []}` 반환(파싱 안전, 툴콜 없음 → 1회 왕복). 응답 내용은 검증 대상이 아니라 **호출 수만** 센다.
+- `/test/publish` 는 `area_code`, `population_time`, `area_name`, `congestion_level` 쿼리 파라미터를 받는다.

--- a/load-test/k6/dedup.js
+++ b/load-test/k6/dedup.js
@@ -1,0 +1,69 @@
+// Redis 분산락 dedup 동시성 검증
+// 같은 (area_code, population_time) 키를 N개 VU가 "동시에" 발행 →
+// RabbitMQ가 2개 팟으로 분산 소비 → SETNX 레이스 → LLM 호출은 딱 1회여야 함.
+//
+// 실행 (사전: redis FLUSHDB):
+//   k6 run load-test/k6/dedup.js
+//   k6 run -e N=50 -e POP_TIME="2026-07-06 16:00" load-test/k6/dedup.js
+//
+// 판정: teardown이 WireMock Admin API로 실제 LLM HTTP 호출 수를 조회해 PASS/FAIL 출력.
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+
+const PUBLISH_URL = __ENV.PUBLISH_URL || 'http://localhost:8085/test/publish';
+const WIREMOCK_ADMIN = __ENV.WIREMOCK_ADMIN || 'http://localhost:8089/__admin';
+const AREA_CODE = __ENV.AREA_CODE || 'POI-DEDUP';
+const POP_TIME = __ENV.POP_TIME || '2026-07-06 15:00';
+const N = Number(__ENV.N || 20);
+const WAIT_SEC = Number(__ENV.WAIT_SEC || 12);
+
+export const options = {
+  scenarios: {
+    // per-vu-iterations: N개 VU가 동시에 시작해 각 1회 발행 → 거의 같은 ms에 폭주
+    burst: { executor: 'per-vu-iterations', vus: N, iterations: 1, maxDuration: '30s' },
+  },
+};
+
+const published = new Counter('published_events');
+
+export function setup() {
+  // 이전 실행 잔여 요청 로그 제거 (WireMock 카운터 0으로)
+  http.del(`${WIREMOCK_ADMIN}/requests`);
+  return { area: AREA_CODE, time: POP_TIME };
+}
+
+export default function () {
+  const url = `${PUBLISH_URL}?area_code=${encodeURIComponent(AREA_CODE)}` +
+    `&population_time=${encodeURIComponent(POP_TIME)}`;
+  const res = http.post(url);
+  check(res, { 'publish 200': (r) => r.status === 200 });
+  published.add(1);
+}
+
+export function teardown() {
+  // 배치(BATCH_MAX_SIZE=1) 소비 + 처리 완료 대기
+  sleep(WAIT_SEC);
+  const body = JSON.stringify({ method: 'POST', urlPathPattern: '.*/chat/completions' });
+  const res = http.post(`${WIREMOCK_ADMIN}/requests/count`, body, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const count = res.json('count');
+  const savedPct = Math.round((1 - 1 / N) * 100);
+  console.log('\n===== Redis 분산락 dedup 검증 =====');
+  console.log(`유입(발행) 이벤트 : ${N}  (동일 키 ${AREA_CODE} / ${POP_TIME})`);
+  console.log(`실제 LLM 호출     : ${count}  (WireMock 실측)`);
+  if (count === 1) {
+    console.log(`✅ PASS — 분산락 동작: 호출 1회, ${savedPct}% 절감`);
+  } else {
+    console.log(`❌ FAIL — LLM ${count}회 호출 (락 미동작 / Redis 미주입 / 마커 잔여 의심)`);
+  }
+  console.log('===================================\n');
+}
+
+export function handleSummary(data) {
+  return {
+    'load-test/results/dedup-summary.json': JSON.stringify(data, null, 2),
+    stdout: `published=${data.metrics.published_events?.values?.count ?? 0}\n`,
+  };
+}

--- a/load-test/wiremock/mappings/llm-chat-completions.json
+++ b/load-test/wiremock/mappings/llm-chat-completions.json
@@ -1,0 +1,25 @@
+{
+  "priority": 5,
+  "request": {
+    "method": "POST",
+    "urlPathPattern": ".*/chat/completions"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "jsonBody": {
+      "id": "chatcmpl-mock",
+      "object": "chat.completion",
+      "created": 0,
+      "model": "gpt-oss-120b",
+      "choices": [
+        {
+          "index": 0,
+          "message": { "role": "assistant", "content": "{\"results\": []}" },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": { "prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110 }
+    }
+  }
+}

--- a/service-ai/app/observability.py
+++ b/service-ai/app/observability.py
@@ -1,7 +1,9 @@
 import atexit
 import logging
 import logging.handlers
+import os
 import queue
+import socket
 
 import logging_loki
 from opentelemetry import trace
@@ -61,9 +63,11 @@ def setup_observability(app) -> None:
             self.emitter.tags["level"] = record.levelname
             super().emit(record)
 
+    # 다중 인스턴스 구분용 라벨 — SERVER_NAME 미지정 시 hostname
+    server_name = os.getenv("SERVER_NAME") or socket.gethostname()
     loki_handler = _LevelLokiHandler(
         url=settings.loki_url,
-        tags={"app": "service-ai"},
+        tags={"app": "service-ai", "server": server_name},
         version="1",
     )
     loki_handler.setFormatter(formatter)

--- a/service-ai/main.py
+++ b/service-ai/main.py
@@ -102,22 +102,32 @@ def health():
 # ── 테스트 전용 API (프로덕션에서 제거) ──
 
 @app.post("/test/publish")
-async def test_publish(area_code: str = "POI001", congestion_level: str = "붐빔"):
-    """RabbitMQ에 테스트 메시지를 발행한다. Consumer → Batch → Stub AI 전체 플로우 검증용."""
+async def test_publish(
+    area_code: str = "POI001",
+    congestion_level: str = "붐빔",
+    population_time: str = "2026-04-03 14:00",
+    area_name: str = "테스트지역",
+):
+    """RabbitMQ에 테스트 메시지를 발행한다. Consumer → Batch → AI 전체 플로우 검증용.
+
+    - population_time: 멱등성 키 (area_code, population_time) 제어용 (부하테스트 중복/고유 키 구분)
+    - area_name: consumer 필수 필드 (누락 시 파싱 실패 → DLQ)
+    """
     connection = await aio_pika.connect_robust(settings.rabbitmq_url)
     async with connection:
         channel = await connection.channel()
         message = aio_pika.Message(
             body=json.dumps({
+                "areaName": area_name,
                 "areaCode": area_code,
                 "congestionLevel": congestion_level,
                 "maxPeopleCount": 12000,
-                "populationTime": "2026-04-03 14:00",
+                "populationTime": population_time,
             }).encode(),
             content_type="application/json",
         )
         await channel.default_exchange.publish(message, routing_key=settings.rabbitmq_queue)
-    return {"status": "published", "area_code": area_code, "congestion_level": congestion_level}
+    return {"status": "published", "area_code": area_code, "population_time": population_time}
 
 
 @app.post("/test/analyze")


### PR DESCRIPTION
## 요약
멀티 인스턴스 동시 버스트로 **Redis 분산락(요청 멱등성)을 E2E 검증**. WireMock으로 실제 LLM HTTP 호출 수를 실측해 `유입 N건 → LLM 1건(95% 절감)`을 증명한다.

## 검증 결과 (로컬 실행 완료)
- 같은 `(지역+시각)` 키 20건 동시 발행 → **WireMock LLM 호출 = 1** ✅
- 두 인스턴스(service-ai-1/2)에 분산 유입돼도 SETNX 원자성으로 1건만 통과 = 분산락 증명
- 큐/DLQ 0 완결

## 변경
- `docker-compose.loadtest.yml`: WireMock(LLM 목킹) + service-ai 2 인스턴스, `BATCH_MAX_SIZE=1`(카운트 1:1), `TIKTOKEN_DISABLE=1`
- `load-test/k6/dedup.js`: 동시 버스트 + WireMock 카운트 PASS/FAIL
- `load-test/wiremock/mappings/llm-chat-completions.json`: OpenAI 호환 목 응답
- `grafana/dashboards/ai-dedup-dashboard.json`: 선점/스킵/서버별 분산 (Loki)
- `load-test/DEDUP-TEST.md`: 실행 런북

## 버그픽스/보강 🐛
- **`docker-compose.yml`: service-ai 에 `REDIS_URL` 미주입** → 컨테이너가 localhost Redis 참조 → 항상 fail-open → **프로덕션 dedup 무력화** 상태였음. 주입 + redis 의존성 추가로 해결
- `main.py /test/publish`: `population_time`·`area_name` 파라미터 추가 (`areaName` 누락 시 DLQ)
- `observability.py`: 다중 인스턴스 구분 `server` Loki 라벨(`SERVER_NAME`)